### PR TITLE
Update battery.py

### DIFF
--- a/givenergy_modbus/model/battery.py
+++ b/givenergy_modbus/model/battery.py
@@ -54,4 +54,5 @@ class Battery(GivEnergyBaseModel):
         return self.battery_serial_number not in (
             '',
             '\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00',
+            '          ',
         )


### PR DESCRIPTION
I have 2 batteries but the list of batteries returns 3, one with a serial of `'          '` (10 spaces)

First battery is correct with a serial number, second returns` '          ' ` (10 spaces) and third has a serial number.

This should hopefully discount that incorrect battery.