### PR TITLE
ci: notify downstream consumers on release via repository_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,25 @@ jobs:
           password: ${{ secrets.PYPI_API_TOKEN }}
           skip-existing: true
 
+      - name: Notify downstream consumers
+        env:
+          # Fine-grained PAT with `Contents: write` on dewet22/givenergy-cli
+          # and dewet22/givenergy-hass. If unset, the step skips with a warning
+          # so the release flow doesn't break before the secret is configured.
+          GH_TOKEN: ${{ secrets.DOWNSTREAM_DISPATCH_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::warning::DOWNSTREAM_DISPATCH_TOKEN not set; skipping downstream notification"
+            exit 0
+          fi
+          for repo in dewet22/givenergy-cli dewet22/givenergy-hass; do
+            echo "Dispatching givenergy-modbus-release event to ${repo}"
+            jq -nc --arg v "$VERSION" \
+              '{event_type: "givenergy-modbus-release", client_payload: {version: $v}}' \
+              | gh api -X POST "repos/${repo}/dispatches" --input -
+          done
+
       - name: Install docs dependencies
         run: uv sync --group docs
 


### PR DESCRIPTION
## Summary

Closes the loop on the auto-bump flow set up in [givenergy-cli#1](https://github.com/dewet22/givenergy-cli/pull/1) and [givenergy-hass#33](https://github.com/dewet22/givenergy-hass/pull/33).

After a successful PyPI publish, fires a \`repository_dispatch\` event of type \`givenergy-modbus-release\` to each downstream repo carrying the new version in \`client_payload\`. The downstream listener workflows bump their pins and open PRs.

## Setup required before this is functional

Need a fine-grained PAT with **\`Contents: write\`** scope on \`dewet22/givenergy-cli\` and \`dewet22/givenergy-hass\`, stored as a repo secret named \`DOWNSTREAM_DISPATCH_TOKEN\` on \`dewet22/givenergy-modbus\`.

The default \`GITHUB_TOKEN\` can't dispatch to other repos (its scope is the current repo only).

The step skips gracefully with a warning if the secret isn't set, so this PR can safely land before the PAT is configured — the release flow still works, downstreams just won't be notified instantly (dependabot in each downstream is the safety net).

## Test plan

- [ ] Merge the two downstream PRs first
- [ ] Create the \`DOWNSTREAM_DISPATCH_TOKEN\` secret
- [ ] Cut the next release (1.2.1 or similar) and verify both downstreams open bump PRs within seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)