### PR TITLE
feat: per-commit and per-push overrides for the changelog bot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ uv run ruff check --fix && uv run ruff format
 
 When the conventional-commit prefix doesn't reflect the user impact, add a `Changelog:` git trailer to the commit body:
 
-```
+```text
 refactor: rename slave_address → device_address
 
 Changelog: Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,3 +44,36 @@ uv run ruff check --fix && uv run ruff format
 
 - Conventional commits: `feat:`, `fix:`, `refactor:`, etc.
 - Don't push; prepare commits and let the user decide when to push/PR.
+
+## Changelog
+
+`CHANGELOG.md` is maintained automatically by `.github/workflows/changelog.yml` (driven by `scripts/release.py append-many`), which appends entries to `[Unreleased]` on every push to `main`. The conventional-commit prefix determines the section:
+
+| Prefix | Section |
+|---|---|
+| `feat:` | ✨ Added |
+| `fix:` / `revert:` | 🐛 Fixed |
+| `perf:` / `<type>!:` (breaking) | 🔄 Changed |
+| `security:` | 🔒 Security |
+| `refactor:` / `docs:` / `chore:` / `ci:` / `test:` / `style:` / `build:` / `wip:` | 🔧 Maintenance |
+
+**Default rule: don't touch `CHANGELOG.md` on a feature branch.** Let the bot handle it — touching `CHANGELOG.md` on a long-lived branch invites stale-`[Unreleased]`-section conflicts.
+
+### Per-commit overrides (`Changelog:` trailer)
+
+When the conventional-commit prefix doesn't reflect the user impact, add a `Changelog:` git trailer to the commit body:
+
+```
+refactor: rename slave_address → device_address
+
+Changelog: Changed
+```
+
+- `Changelog: <section>` redirects the entry to that section (case-insensitive; matches `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`, `Maintenance`).
+- `Changelog: skip` suppresses the entry entirely. Useful for fixup commits whose narrative is already captured by their parent.
+
+The last `Changelog:` trailer in the message wins, matching standard git-trailer semantics.
+
+### Branch-managed changelog (escape hatch)
+
+If a PR's narrative is too complex for per-commit overrides, the branch can edit `CHANGELOG.md` directly. **If any commit in a push touches `CHANGELOG.md`, the bot skips that push entirely** — the assumption is the branch has authored its own fine-tuned entries. Be aware of the stale-`[Unreleased]` merge-conflict risk on long-lived branches.

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -68,11 +68,13 @@ class Changelog:
         # Resolve the default at call time (not as a parameter default) so tests can
         # redirect the module-level CHANGELOG to a temp file via monkeypatch.
         self.path = path if path is not None else CHANGELOG
-        self.lines = self.path.read_text().splitlines(keepends=True)
+        # Always read/write as UTF-8; the section headers contain emoji which fall
+        # outside Windows' default cp1252 codec.
+        self.lines = self.path.read_text(encoding="utf-8").splitlines(keepends=True)
 
     def save(self) -> None:
         """Write the current line buffer back to disk."""
-        self.path.write_text("".join(self.lines))
+        self.path.write_text("".join(self.lines), encoding="utf-8")
 
     def unreleased_has_content(self) -> bool:
         """Return True if [Unreleased] contains any non-blank, non-header lines."""
@@ -249,7 +251,7 @@ def cmd_append(_args) -> None:
         return
     section, description = _parse_commit(message)
     cl = Changelog()
-    attribution = _commit_attribution(cl.path.read_text())
+    attribution = _commit_attribution(cl.path.read_text(encoding="utf-8"))
     cl.append_to_unreleased(section, f"- {description}{attribution}")
     cl.save()
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -45,10 +45,12 @@ _CHANGELOG_TRAILER_RE = re.compile(r"^changelog\s*:\s*(.+?)\s*$", re.IGNORECASE 
 
 
 def _resolve_section_alias(name: str) -> str | None:
-    """Match a section name (e.g. 'Changed') to its emoji-prefixed form."""
+    """Match a section name (e.g. 'Changed' or '✨ Added') to its emoji-prefixed form."""
     name = name.strip().lower()
     for section in _SECTION_ORDER:
-        # Strip leading emoji + space, e.g. "✨ Added" → "Added"
+        # Accept both the full form ("✨ Added") and the textual suffix ("Added").
+        if section.lower() == name:
+            return section
         textual = section.split(" ", 1)[-1].lower()
         if textual == name:
             return section
@@ -247,7 +249,7 @@ def _commit_attribution(changelog_text: str) -> str:
 def cmd_append(_args) -> None:
     """Append a conventional commit (from $COMMIT_MSG) to [Unreleased]."""
     message = os.environ.get("COMMIT_MSG", "").strip()
-    if not message:
+    if not message or _is_skippable_commit(message):
         return
     section, description = _parse_commit(message)
     cl = Changelog()
@@ -282,14 +284,16 @@ def _is_skippable_commit(message: str) -> bool:
 
 
 def _push_touched_changelog(commits: list[dict]) -> bool:
-    """Return True if any commit in the push added/modified CHANGELOG.md.
+    """Return True if any commit in the push added/modified/removed CHANGELOG.md.
 
     Used as an opt-out: if a branch maintained its own changelog entries (e.g. for
     a complex PR where per-commit auto-bucketing isn't expressive enough), the bot
     should not also append entries on top — that would double-record the change.
+    `removed` is included so that a push deleting the file doesn't cause the
+    subsequent read_text() to raise FileNotFoundError.
     """
     for c in commits:
-        for key in ("added", "modified"):
+        for key in ("added", "modified", "removed"):
             files = c.get(key) or []
             if "CHANGELOG.md" in files:
                 return True

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -38,13 +38,37 @@ _COMMIT_TYPE_TO_SECTION: dict[str, str] = {
     "wip": "🔧 Maintenance",
 }
 
+# Trailer key that overrides automatic section bucketing on a per-commit basis.
+# Recognised values are either `skip` (suppress the entry) or any of the textual
+# section names in _SECTION_ORDER (case-insensitive, emoji optional).
+_CHANGELOG_TRAILER_RE = re.compile(r"^changelog\s*:\s*(.+?)\s*$", re.IGNORECASE | re.MULTILINE)
+
+
+def _resolve_section_alias(name: str) -> str | None:
+    """Match a section name (e.g. 'Changed') to its emoji-prefixed form."""
+    name = name.strip().lower()
+    for section in _SECTION_ORDER:
+        # Strip leading emoji + space, e.g. "✨ Added" → "Added"
+        textual = section.split(" ", 1)[-1].lower()
+        if textual == name:
+            return section
+    return None
+
+
+def _find_changelog_trailer(message: str) -> str | None:
+    """Return the value of the last `Changelog:` trailer in the message, or None."""
+    matches = _CHANGELOG_TRAILER_RE.findall(message)
+    return matches[-1].strip() if matches else None
+
 
 class Changelog:
     """Line-by-line reader/editor for Keep a Changelog files."""
 
-    def __init__(self, path: Path = CHANGELOG) -> None:
-        self.path = path
-        self.lines = path.read_text().splitlines(keepends=True)
+    def __init__(self, path: Path | None = None) -> None:
+        # Resolve the default at call time (not as a parameter default) so tests can
+        # redirect the module-level CHANGELOG to a temp file via monkeypatch.
+        self.path = path if path is not None else CHANGELOG
+        self.lines = self.path.read_text().splitlines(keepends=True)
 
     def save(self) -> None:
         """Write the current line buffer back to disk."""
@@ -143,15 +167,28 @@ class Changelog:
 
 
 def _parse_commit(message: str) -> tuple[str, str]:
-    """Return (changelog_section, description) for a conventional commit message."""
+    """Return (changelog_section, description) for a conventional commit message.
+
+    A `Changelog: <Section>` trailer (case-insensitive) overrides the section that
+    the conventional-commit prefix would normally map to. Useful when the prefix
+    doesn't reflect the change's user impact (e.g. a `refactor:` that renames public
+    API → `Changelog: Changed`). Unrecognised values are ignored. `Changelog: skip`
+    is handled separately by `_is_skippable_commit`.
+    """
     subject = message.splitlines()[0].strip()
     m = re.match(r"^(\w+)(?:\([^)]*\))?(!)?\s*:\s*(.+)", subject)
     if not m:
-        return "🔄 Changed", subject
-    commit_type, breaking, description = m.group(1).lower(), m.group(2), m.group(3).strip()
-    if breaking:
-        return "🔄 Changed", f"⚠️ Breaking: {description}"
-    return _COMMIT_TYPE_TO_SECTION.get(commit_type, "🔄 Changed"), description
+        section, description = "🔄 Changed", subject
+    else:
+        commit_type, breaking, description = m.group(1).lower(), m.group(2), m.group(3).strip()
+        section = "🔄 Changed" if breaking else _COMMIT_TYPE_TO_SECTION.get(commit_type, "🔄 Changed")
+        if breaking:
+            description = f"⚠️ Breaking: {description}"
+
+    trailer = _find_changelog_trailer(message)
+    if trailer and trailer.lower() != "skip":
+        section = _resolve_section_alias(trailer) or section
+    return section, description
 
 
 def cmd_check(_args) -> None:
@@ -226,6 +263,8 @@ def _is_skippable_commit(message: str) -> bool:
     - The bot's own changelog-update commits — would otherwise recurse.
     - Any chore: commit whose subject mentions "changelog" — these are housekeeping
       edits to CHANGELOG.md itself and don't belong as entries within it.
+    - Commits with a `Changelog: skip` trailer — author opt-out for follow-up
+      commits whose narrative is already captured by their parent commit.
     """
     subject = message.splitlines()[0].strip()
     if subject.startswith(("Merge pull request", "Merge branch")):
@@ -234,19 +273,41 @@ def _is_skippable_commit(message: str) -> bool:
         return True
     if subject.startswith("chore:") and "changelog" in subject.lower():
         return True
+    trailer = _find_changelog_trailer(message)
+    if trailer and trailer.lower() == "skip":
+        return True
+    return False
+
+
+def _push_touched_changelog(commits: list[dict]) -> bool:
+    """Return True if any commit in the push added/modified CHANGELOG.md.
+
+    Used as an opt-out: if a branch maintained its own changelog entries (e.g. for
+    a complex PR where per-commit auto-bucketing isn't expressive enough), the bot
+    should not also append entries on top — that would double-record the change.
+    """
+    for c in commits:
+        for key in ("added", "modified"):
+            files = c.get(key) or []
+            if "CHANGELOG.md" in files:
+                return True
     return False
 
 
 def cmd_append_many(_args) -> None:
     """Append every commit from a JSON push-event `commits` array (read from stdin).
 
-    Each commit object must have `id`, `message`, and optionally `author.username`.
-    Commits where _is_skippable_commit returns True are dropped silently.
+    Each commit object must have `id`, `message`, and optionally `author.username`,
+    `added`, `modified`. Commits where _is_skippable_commit returns True are dropped
+    silently. If any commit in the push touched CHANGELOG.md, the entire append step
+    is skipped — see `_push_touched_changelog` for the rationale.
     """
     raw = sys.stdin.read().strip()
     if not raw:
         return
     commits = json.loads(raw)
+    if _push_touched_changelog(commits):
+        return
     cl = Changelog()
     for c in commits:
         message = (c.get("message") or "").strip()

--- a/tests/scripts/test_release.py
+++ b/tests/scripts/test_release.py
@@ -183,7 +183,7 @@ _MINIMAL_CHANGELOG = """\
 def tmp_changelog(tmp_path, monkeypatch):
     """Point the Changelog class at a temporary file populated with a minimal skeleton."""
     cl_path = tmp_path / "CHANGELOG.md"
-    cl_path.write_text(_MINIMAL_CHANGELOG)
+    cl_path.write_text(_MINIMAL_CHANGELOG, encoding="utf-8")
     monkeypatch.setattr(release, "CHANGELOG", cl_path)
     return cl_path
 
@@ -199,7 +199,7 @@ def test_append_many_writes_entries(tmp_changelog, monkeypatch):
         {"id": "def5678", "message": "fix: bar", "author": {"username": "alice"}, "modified": ["src/bar.py"]},
     ]
     _drive_append_many(commits, monkeypatch)
-    text = tmp_changelog.read_text()
+    text = tmp_changelog.read_text(encoding="utf-8")
     assert "✨ Added" in text
     assert "add widget" in text
     assert "🐛 Fixed" in text
@@ -213,7 +213,7 @@ def test_append_many_skips_when_changelog_touched_in_push(tmp_changelog, monkeyp
     ]
     _drive_append_many(commits, monkeypatch)
     # File is untouched — no entries appended for either commit.
-    assert tmp_changelog.read_text() == _MINIMAL_CHANGELOG
+    assert tmp_changelog.read_text(encoding="utf-8") == _MINIMAL_CHANGELOG
 
 
 def test_append_many_honours_changelog_section_trailer(tmp_changelog, monkeypatch):
@@ -225,7 +225,7 @@ def test_append_many_honours_changelog_section_trailer(tmp_changelog, monkeypatc
         },
     ]
     _drive_append_many(commits, monkeypatch)
-    text = tmp_changelog.read_text()
+    text = tmp_changelog.read_text(encoding="utf-8")
     assert "🔄 Changed" in text
     # Should NOT land in Maintenance, the default for refactor:
     assert "🔧 Maintenance" not in text
@@ -241,7 +241,7 @@ def test_append_many_honours_changelog_skip_trailer(tmp_changelog, monkeypatch):
         },
     ]
     _drive_append_many(commits, monkeypatch)
-    text = tmp_changelog.read_text()
+    text = tmp_changelog.read_text(encoding="utf-8")
     assert "add widget" in text
     assert "fixup review feedback" not in text
 
@@ -249,4 +249,4 @@ def test_append_many_honours_changelog_skip_trailer(tmp_changelog, monkeypatch):
 def test_append_many_with_empty_stdin_is_noop(tmp_changelog, monkeypatch):
     monkeypatch.setattr("sys.stdin", io.StringIO(""))
     release.cmd_append_many(None)
-    assert tmp_changelog.read_text() == _MINIMAL_CHANGELOG
+    assert tmp_changelog.read_text(encoding="utf-8") == _MINIMAL_CHANGELOG

--- a/tests/scripts/test_release.py
+++ b/tests/scripts/test_release.py
@@ -94,6 +94,11 @@ def test_last_trailer_wins_when_multiple_present():
     assert release._parse_commit(msg)[0] == "🔄 Changed"
 
 
+def test_trailer_accepts_emoji_prefixed_section_name():
+    msg = "refactor: rename API\n\nChangelog: ✨ Added"
+    assert release._parse_commit(msg)[0] == "✨ Added"
+
+
 def test_trailer_inside_body_text_still_matches():
     # The trailer detector uses MULTILINE rather than strict end-of-message position,
     # so a `Changelog:` line anywhere in the body counts.
@@ -164,6 +169,12 @@ def test_push_with_one_commit_touching_changelog_marks_whole_push():
         {"modified": ["bar.py"]},
     ]
     assert release._push_touched_changelog(commits) is True
+
+
+def test_push_removed_changelog_is_also_detected():
+    # If a branch deletes CHANGELOG.md, skip too — otherwise the bot's next
+    # read_text() would raise FileNotFoundError.
+    assert release._push_touched_changelog([{"removed": ["CHANGELOG.md"]}]) is True
 
 
 # ---------------------------------------------------------------------------
@@ -249,4 +260,29 @@ def test_append_many_honours_changelog_skip_trailer(tmp_changelog, monkeypatch):
 def test_append_many_with_empty_stdin_is_noop(tmp_changelog, monkeypatch):
     monkeypatch.setattr("sys.stdin", io.StringIO(""))
     release.cmd_append_many(None)
+    assert tmp_changelog.read_text(encoding="utf-8") == _MINIMAL_CHANGELOG
+
+
+# ---------------------------------------------------------------------------
+# cmd_append (single-commit path) — must apply the same skip rules
+# ---------------------------------------------------------------------------
+
+
+def test_append_writes_entry_for_normal_commit(tmp_changelog, monkeypatch):
+    monkeypatch.setenv("COMMIT_MSG", "feat: add widget")
+    release.cmd_append(None)
+    text = tmp_changelog.read_text(encoding="utf-8")
+    assert "✨ Added" in text
+    assert "add widget" in text
+
+
+def test_append_honours_changelog_skip_trailer(tmp_changelog, monkeypatch):
+    monkeypatch.setenv("COMMIT_MSG", "fix: tiny follow-up\n\nChangelog: skip")
+    release.cmd_append(None)
+    assert tmp_changelog.read_text(encoding="utf-8") == _MINIMAL_CHANGELOG
+
+
+def test_append_skips_merge_commits(tmp_changelog, monkeypatch):
+    monkeypatch.setenv("COMMIT_MSG", "Merge pull request #99 from foo/bar")
+    release.cmd_append(None)
     assert tmp_changelog.read_text(encoding="utf-8") == _MINIMAL_CHANGELOG

--- a/tests/scripts/test_release.py
+++ b/tests/scripts/test_release.py
@@ -1,0 +1,252 @@
+"""Tests for the changelog-bot helper in scripts/release.py.
+
+Covers the auto-bucketing of conventional commits and the three opt-in
+overrides:
+
+- `Changelog: <section>` trailer to redirect a commit's entry
+- `Changelog: skip` trailer to suppress an entry
+- Branch-managed CHANGELOG.md: any push that touches the file skips the bot
+"""
+
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+# scripts/ isn't a package, so make release.py importable by name.
+_SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import release  # noqa: E402, I001
+
+
+# ---------------------------------------------------------------------------
+# _parse_commit — automatic bucketing
+# ---------------------------------------------------------------------------
+
+
+def test_feat_lands_in_added():
+    assert release._parse_commit("feat: add foo")[0] == "✨ Added"
+
+
+def test_fix_lands_in_fixed():
+    assert release._parse_commit("fix: correct bar")[0] == "🐛 Fixed"
+
+
+def test_refactor_lands_in_maintenance_by_default():
+    assert release._parse_commit("refactor: extract helper")[0] == "🔧 Maintenance"
+
+
+def test_breaking_change_lands_in_changed_with_prefix():
+    section, description = release._parse_commit("feat!: redesign API")
+    assert section == "🔄 Changed"
+    assert description.startswith("⚠️ Breaking: ")
+
+
+def test_unknown_type_falls_back_to_changed():
+    assert release._parse_commit("flarble: something odd")[0] == "🔄 Changed"
+
+
+def test_non_conventional_subject_falls_back_to_changed():
+    section, description = release._parse_commit("just a plain sentence")
+    assert section == "🔄 Changed"
+    assert description == "just a plain sentence"
+
+
+def test_scoped_type_still_parses():
+    assert release._parse_commit("feat(api): add endpoint")[0] == "✨ Added"
+
+
+# ---------------------------------------------------------------------------
+# Changelog: <section> trailer override
+# ---------------------------------------------------------------------------
+
+
+def test_trailer_overrides_section():
+    msg = "refactor: rename slave→device\n\nLonger body\n\nChangelog: Changed"
+    assert release._parse_commit(msg)[0] == "🔄 Changed"
+
+
+def test_trailer_is_case_insensitive():
+    msg = "refactor: rename slave→device\n\nchangelog: changed"
+    assert release._parse_commit(msg)[0] == "🔄 Changed"
+
+
+def test_trailer_with_unknown_section_is_ignored():
+    msg = "feat: add foo\n\nChangelog: Whatever"
+    # Falls back to the conventional-commit default, not silently picking something else.
+    assert release._parse_commit(msg)[0] == "✨ Added"
+
+
+def test_trailer_skip_does_not_override_section_in_parse():
+    # _parse_commit shouldn't crash on skip; skipping is _is_skippable_commit's job.
+    msg = "fix: process noise\n\nChangelog: skip"
+    section, _ = release._parse_commit(msg)
+    assert section == "🐛 Fixed"
+
+
+def test_last_trailer_wins_when_multiple_present():
+    # Standard git-trailer semantics: the final occurrence is authoritative.
+    msg = "refactor: foo\n\nChangelog: Maintenance\nChangelog: Changed"
+    assert release._parse_commit(msg)[0] == "🔄 Changed"
+
+
+def test_trailer_inside_body_text_still_matches():
+    # The trailer detector uses MULTILINE rather than strict end-of-message position,
+    # so a `Changelog:` line anywhere in the body counts.
+    msg = "refactor: foo\n\nSome context here.\nChangelog: Added\n\nMore narrative."
+    assert release._parse_commit(msg)[0] == "✨ Added"
+
+
+# ---------------------------------------------------------------------------
+# _is_skippable_commit
+# ---------------------------------------------------------------------------
+
+
+def test_merge_pr_commits_are_skipped():
+    assert release._is_skippable_commit("Merge pull request #61 from foo/bar") is True
+
+
+def test_merge_branch_commits_are_skipped():
+    assert release._is_skippable_commit("Merge branch 'main' into feature") is True
+
+
+def test_bot_changelog_commit_is_skipped():
+    assert release._is_skippable_commit("chore: update [Unreleased] changelog") is True
+
+
+def test_other_chore_changelog_commits_are_skipped():
+    assert release._is_skippable_commit("chore: tidy changelog formatting") is True
+
+
+def test_normal_commit_is_not_skipped():
+    assert release._is_skippable_commit("feat: add new thing") is False
+
+
+def test_changelog_skip_trailer_skips_commit():
+    msg = "fix: fold in review feedback\n\nChangelog: skip"
+    assert release._is_skippable_commit(msg) is True
+
+
+def test_changelog_skip_trailer_is_case_insensitive():
+    msg = "fix: fold in review feedback\n\nchangelog: SKIP"
+    assert release._is_skippable_commit(msg) is True
+
+
+# ---------------------------------------------------------------------------
+# _push_touched_changelog
+# ---------------------------------------------------------------------------
+
+
+def test_push_touched_changelog_modified():
+    assert release._push_touched_changelog([{"modified": ["CHANGELOG.md", "foo.py"]}]) is True
+
+
+def test_push_touched_changelog_added():
+    assert release._push_touched_changelog([{"added": ["CHANGELOG.md"]}]) is True
+
+
+def test_push_did_not_touch_changelog():
+    assert release._push_touched_changelog([{"modified": ["foo.py", "bar.py"]}]) is False
+
+
+def test_push_with_no_file_info_does_not_touch():
+    assert release._push_touched_changelog([{}, {"message": "x"}]) is False
+
+
+def test_push_with_one_commit_touching_changelog_marks_whole_push():
+    commits = [
+        {"modified": ["foo.py"]},
+        {"modified": ["CHANGELOG.md"]},
+        {"modified": ["bar.py"]},
+    ]
+    assert release._push_touched_changelog(commits) is True
+
+
+# ---------------------------------------------------------------------------
+# cmd_append_many — integration via tmp CHANGELOG.md
+# ---------------------------------------------------------------------------
+
+_MINIMAL_CHANGELOG = """\
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0] - 2026-01-01
+"""
+
+
+@pytest.fixture
+def tmp_changelog(tmp_path, monkeypatch):
+    """Point the Changelog class at a temporary file populated with a minimal skeleton."""
+    cl_path = tmp_path / "CHANGELOG.md"
+    cl_path.write_text(_MINIMAL_CHANGELOG)
+    monkeypatch.setattr(release, "CHANGELOG", cl_path)
+    return cl_path
+
+
+def _drive_append_many(commits: list[dict], monkeypatch) -> None:
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps(commits)))
+    release.cmd_append_many(None)
+
+
+def test_append_many_writes_entries(tmp_changelog, monkeypatch):
+    commits = [
+        {"id": "abc1234", "message": "feat: add widget", "author": {"username": "alice"}, "modified": ["src/foo.py"]},
+        {"id": "def5678", "message": "fix: bar", "author": {"username": "alice"}, "modified": ["src/bar.py"]},
+    ]
+    _drive_append_many(commits, monkeypatch)
+    text = tmp_changelog.read_text()
+    assert "✨ Added" in text
+    assert "add widget" in text
+    assert "🐛 Fixed" in text
+    assert "bar" in text
+
+
+def test_append_many_skips_when_changelog_touched_in_push(tmp_changelog, monkeypatch):
+    commits = [
+        {"id": "abc1234", "message": "feat: add widget", "modified": ["src/foo.py"]},
+        {"id": "def5678", "message": "docs: hand-write changelog entry", "modified": ["CHANGELOG.md"]},
+    ]
+    _drive_append_many(commits, monkeypatch)
+    # File is untouched — no entries appended for either commit.
+    assert tmp_changelog.read_text() == _MINIMAL_CHANGELOG
+
+
+def test_append_many_honours_changelog_section_trailer(tmp_changelog, monkeypatch):
+    commits = [
+        {
+            "id": "abc1234",
+            "message": "refactor: rename API\n\nChangelog: Changed",
+            "modified": ["src/foo.py"],
+        },
+    ]
+    _drive_append_many(commits, monkeypatch)
+    text = tmp_changelog.read_text()
+    assert "🔄 Changed" in text
+    # Should NOT land in Maintenance, the default for refactor:
+    assert "🔧 Maintenance" not in text
+
+
+def test_append_many_honours_changelog_skip_trailer(tmp_changelog, monkeypatch):
+    commits = [
+        {"id": "abc1234", "message": "feat: add widget", "modified": ["src/foo.py"]},
+        {
+            "id": "def5678",
+            "message": "fix: fixup review feedback\n\nChangelog: skip",
+            "modified": ["src/foo.py"],
+        },
+    ]
+    _drive_append_many(commits, monkeypatch)
+    text = tmp_changelog.read_text()
+    assert "add widget" in text
+    assert "fixup review feedback" not in text
+
+
+def test_append_many_with_empty_stdin_is_noop(tmp_changelog, monkeypatch):
+    monkeypatch.setattr("sys.stdin", io.StringIO(""))
+    release.cmd_append_many(None)
+    assert tmp_changelog.read_text() == _MINIMAL_CHANGELOG


### PR DESCRIPTION
## Summary

The changelog bot in [`scripts/release.py`](scripts/release.py) buckets commits by their conventional-commit prefix alone, which doesn't always reflect user impact. PR [#61](https://github.com/dewet22/givenergy-modbus/pull/61) surfaced this: the `refactor:` rename of public API landed under 🔧 Maintenance instead of 🔄 Changed, and the follow-up `fix:` review-feedback commit became a standalone Fixed entry duplicating the rename's narrative. Cleaning up by hand on `main` was fine for once, but the underlying mechanism was rigid.

This PR adds three opt-in escape hatches without changing default behaviour:

1. **`Changelog: <Section>` git trailer** — redirects a commit's entry to a different section. Case-insensitive; matches `Added`, `Changed`, `Deprecated`, `Removed`, `Fixed`, `Security`, `Maintenance`. Last trailer wins (standard git convention). Unknown values are ignored.
2. **`Changelog: skip` git trailer** — suppresses the entry entirely. For fixup commits whose narrative is already captured by their parent.
3. **Branch-managed `CHANGELOG.md`** — if any commit in a push to `main` adds or modifies `CHANGELOG.md`, the bot skips the entire append step. Lets a branch take ownership of its own entries when per-commit overrides aren't expressive enough.

Also fixes a latent bug in `Changelog.__init__`: `path=CHANGELOG` was a default-argument expression evaluated at definition time, so monkeypatching the module-level `CHANGELOG` couldn't reach the constructor. Now resolved at call time — which makes the integration tests possible.

This commit's own message dogfoods the new trailer: it ends with `Changelog: Added`, so when this PR merges the bot should route the entry into ✨ Added (which is also `feat:`'s default — chosen to keep the dogfooding cosmetic, not behavioural).

## Test plan

- [x] 30 new tests in [`tests/scripts/test_release.py`](tests/scripts/test_release.py) cover automatic bucketing, both trailer forms, the push-level escape hatch, and end-to-end via `cmd_append_many` against a tmp CHANGELOG
- [x] Full tox green locally (py313, py314, format, lint with ruff + mypy + bandit, build)
- [x] 445 tests pass overall (was 415)
- [ ] On merge: verify the bot routes this commit into ✨ Added per the `Changelog: Added` trailer
- [ ] Follow-up exercise: use `Changelog: skip` on a real fixup commit and confirm it's suppressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-commit "Changelog:" trailers to override or skip changelog section placement (case-insensitive, last-trailer-wins); breaking changes are labeled in entries. Append-many aborts when any commit in a push touches the changelog (including removed files).

* **Documentation**
  * Added changelog maintenance guidance: automatic section mapping, trailer usage, escape-hatch behavior, and precedence rules.

* **Tests**
  * Comprehensive tests for parsing, trailer handling, skip logic, push-detection (add/modify/remove), and append/append-many behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dewet22/givenergy-modbus/pull/63)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->