### PR TITLE
feat: Client.detect(prior=) for fast restarts; serialisable PlantCapabilities

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -262,6 +262,7 @@ empty-slot scan on next start.
 
 ```python
 import json
+from pathlib import Path
 
 caps = await client.detect()
 Path("~/.givenergy-caps.json").expanduser().write_text(json.dumps(caps.to_dict()))
@@ -270,6 +271,9 @@ Path("~/.givenergy-caps.json").expanduser().write_text(json.dumps(caps.to_dict()
 On next start, hand the previously-captured caps back via `prior=`:
 
 ```python
+import json
+from pathlib import Path
+
 from givenergy_modbus.exceptions import PlantTopologyMismatch
 from givenergy_modbus.model.plant import PlantCapabilities
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -251,3 +251,55 @@ with open("capture.txt", "w") as f:
 ```
 
 Only one capture may run on a Client at a time — starting a second raises `RuntimeError`.
+
+## Persisting detection state across restarts
+
+`Client.detect()` is the slow part of a cold start — it probes for BCUs, meters and
+battery devices across address ranges where most slots are empty, each probe waiting
+for its own timeout. The returned `PlantCapabilities` describes the topology that
+was actually found, and can be persisted by the calling application to skip the
+empty-slot scan on next start.
+
+```python
+import json
+
+caps = await client.detect()
+Path("~/.givenergy-caps.json").expanduser().write_text(json.dumps(caps.to_dict()))
+```
+
+On next start, hand the previously-captured caps back via `prior=`:
+
+```python
+from givenergy_modbus.exceptions import PlantTopologyMismatch
+from givenergy_modbus.model.plant import PlantCapabilities
+
+stored = json.loads(Path("~/.givenergy-caps.json").expanduser().read_text())
+prior = PlantCapabilities.from_dict(stored)
+
+try:
+    caps = await client.detect(prior=prior)
+except PlantTopologyMismatch as exc:
+    # Hardware changed since `prior` was captured. Either fall back to a cold
+    # detect, prompt the user, or accept the new layout explicitly.
+    caps = await client.detect()  # cold rescan
+```
+
+Hinted mode is **strict**: each address listed in `prior` is still probed, but the
+empty-slot sweep is skipped. If anything in `prior` fails to confirm — or the
+inverter's device_type has changed — `detect()` raises `PlantTopologyMismatch`
+(carrying both `prior` and `actual`) and leaves `client.plant.capabilities` as
+`None`. The application chooses the recovery policy. Library does no file I/O
+itself; storage location and lifecycle are entirely the caller's responsibility.
+
+The serialised form is stable and includes a `schema_version` field:
+
+```json
+{
+  "schema_version": 1,
+  "device_type": "HYBRID",
+  "inverter_address": "0x32",
+  "meter_addresses": ["0x01"],
+  "lv_battery_addresses": ["0x32", "0x33"],
+  "bcu_stacks": []
+}
+```

--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 from typing import Literal
 
 from givenergy_modbus.client import commands
-from givenergy_modbus.exceptions import CommunicationError, ExceptionBase
+from givenergy_modbus.exceptions import CommunicationError, ExceptionBase, PlantTopologyMismatch
 from givenergy_modbus.framer import ClientFramer, Framer
 from givenergy_modbus.model.battery import Battery
 from givenergy_modbus.model.inverter import resolve_model
@@ -213,12 +213,53 @@ class Client:
         except TimeoutError:
             return False
 
+    async def _detect_bcu_stacks(
+        self,
+        caps: PlantCapabilities,
+        prior: PlantCapabilities | None,
+        probe_timeout: float,
+        probe_retries: int,
+    ) -> None:
+        """Populate caps.bcu_stacks. Hinted mode trusts prior layout; cold mode reads BMS at 0xA0."""
+        if prior is not None:
+            # Hinted: confirm each previously-seen BCU is still answering. Skips the
+            # BMS read at 0xA0 entirely since prior tells us the layout.
+            for offset, num_modules in prior.bcu_stacks:
+                if await self._probe(
+                    ReadInputRegistersRequest(base_register=60, register_count=5, device_address=0x70 + offset),
+                    timeout=probe_timeout,
+                    retries=probe_retries,
+                ):
+                    caps.bcu_stacks.append((offset, num_modules))
+            return
+
+        # Cold path: ask the BMS how many BCUs exist, then probe each.
+        # 0xA0 is the BMS device address; IR(61) holds the number of BCUs present.
+        if not await self._probe(
+            ReadInputRegistersRequest(base_register=60, register_count=5, device_address=0xA0),
+            timeout=probe_timeout,
+            retries=probe_retries,
+        ):
+            return
+        bms_cache: RegisterCache = self.plant.register_caches.get(0xA0, RegisterCache())
+        num_bcus = bms_cache.get(IR(61)) or 0
+        for i in range(num_bcus):
+            if await self._probe(
+                ReadInputRegistersRequest(base_register=60, register_count=60, device_address=0x70 + i),
+                timeout=probe_timeout,
+                retries=probe_retries,
+            ):
+                bcu_cache: RegisterCache = self.plant.register_caches.get(0x70 + i, RegisterCache())
+                num_modules = bcu_cache.get(IR(64)) or 0
+                caps.bcu_stacks.append((i, num_modules))
+
     async def detect(
         self,
         timeout: float = 2.0,
         retries: int = 3,
         probe_timeout: float = 0.5,
         probe_retries: int = 1,
+        prior: PlantCapabilities | None = None,
     ) -> PlantCapabilities:
         """Discover device type and peripheral topology.
 
@@ -230,10 +271,29 @@ class Client:
         the plant are the same. Subsequent calls to Client.refresh() and
         Client.load_config() will use it automatically.
 
+        When `prior` is supplied, the probe sweep restricts itself to the
+        addresses listed in it — empty addresses from a cold sweep are skipped.
+        If reality doesn't match prior (device_type changed, or any hinted
+        address fails to confirm), raises PlantTopologyMismatch and leaves
+        `self.plant.capabilities` as None. The exception carries `prior` and
+        `actual` so callers can decide whether to retry, fall back to a cold
+        detect(), or surface the change to the user.
+
         Uses a two-tier timeout: `timeout`/`retries` for the known inverter device
         (where a response is expected), and `probe_timeout`/`probe_retries` for
         speculative probes where absence is the common case.
         """
+        if prior is not None:
+            _logger.info(
+                "detect: hinted mode — assuming device_type=Model.%s, inverter=0x%02x, "
+                "meters=[%s], lv_batteries=[%s], bcus=[%s]",
+                prior.device_type.name,
+                prior.inverter_address,
+                ", ".join(f"0x{a:02x}" for a in prior.meter_addresses),
+                ", ".join(f"0x{a:02x}" for a in prior.lv_battery_addresses),
+                ", ".join(f"0x{0x70 + offset:02x} (x{n})" for offset, n in prior.bcu_stacks),
+            )
+
         # Step 1 — read the inverter's configuration block to get DTC and ARM firmware.
         # 0x11 is the address used during initial discovery; plant.update() rewrites it to 0x32.
         await self.send_request_and_await_response(
@@ -249,38 +309,38 @@ class Client:
             )
         arm_fw = cache.get(HR(21)) or 0
         caps = PlantCapabilities(device_type=resolve_model(raw_dtc, arm_fw))
-        _logger.info("detect: device_type=%s", caps.device_type)
+        _logger.info("detect: device_type=Model.%s", caps.device_type.name)
+
+        if prior is not None and prior.device_type != caps.device_type:
+            self.plant.capabilities = None
+            raise PlantTopologyMismatch(
+                f"detect: device_type changed since prior capture "
+                f"(prior={prior.device_type}, actual={caps.device_type}) — discarding hint",
+                prior=prior,
+                actual=caps,
+            )
 
         # Step 2 — BCU probing for HV systems.
         if caps.is_hv:
-            # 0xA0 is the BMS device address; IR(61) holds the number of BCUs present.
-            if await self._probe(
-                ReadInputRegistersRequest(base_register=60, register_count=5, device_address=0xA0),
-                timeout=probe_timeout,
-                retries=probe_retries,
-            ):
-                bms_cache: RegisterCache = self.plant.register_caches.get(0xA0, RegisterCache())
-                num_bcus = bms_cache.get(IR(61)) or 0
-                for i in range(num_bcus):
-                    if await self._probe(
-                        ReadInputRegistersRequest(base_register=60, register_count=60, device_address=0x70 + i),
-                        timeout=probe_timeout,
-                        retries=probe_retries,
-                    ):
-                        bcu_cache: RegisterCache = self.plant.register_caches.get(0x70 + i, RegisterCache())
-                        num_modules = bcu_cache.get(IR(64)) or 0
-                        caps.bcu_stacks.append((i, num_modules))
-            _logger.info("detect: bcu_stacks=%s", caps.bcu_stacks)
+            await self._detect_bcu_stacks(caps, prior, probe_timeout, probe_retries)
+            _logger.info(
+                "detect: bcu_stacks=[%s]",
+                ", ".join(f"0x{0x70 + o:02x} (x{n})" for o, n in caps.bcu_stacks),
+            )
 
-        # Step 3 — meter probing (devices 0x01–0x08).
-        for meter_addr in range(0x01, 0x09):
+        # Step 3 — meter probing. Hinted: only previously-seen addresses. Cold: full 0x01–0x08 sweep.
+        meter_candidates = prior.meter_addresses if prior is not None else range(0x01, 0x09)
+        for meter_addr in meter_candidates:
             if await self._probe(
                 ReadInputRegistersRequest(base_register=60, register_count=30, device_address=meter_addr),
                 timeout=probe_timeout,
                 retries=probe_retries,
             ):
                 caps.meter_addresses.append(meter_addr)
-        _logger.info("detect: meter_addresses=%s", caps.meter_addresses)
+        _logger.info(
+            "detect: meter_addresses=[%s]",
+            ", ".join(f"0x{a:02x}" for a in caps.meter_addresses),
+        )
 
         # Step 4 — LV battery detection. Battery #1 shares the inverter's IR bank at 0x32;
         # additional batteries are at 0x33–0x37. All slots are validated via Battery.is_valid().
@@ -290,7 +350,8 @@ class Client:
                 timeout=timeout,
                 retries=retries,
             )
-            for batt_addr in range(0x32, 0x38):
+            batt_candidates = prior.lv_battery_addresses if prior is not None else range(0x32, 0x38)
+            for batt_addr in batt_candidates:
                 if batt_addr > 0x32:
                     if not await self._probe(
                         ReadInputRegistersRequest(base_register=60, register_count=60, device_address=batt_addr),
@@ -306,7 +367,18 @@ class Client:
                 except (KeyError, ValueError):  # fmt: skip  # TODO: drop parens when 3.13 support ends (PEP 758)
                     break
                 caps.lv_battery_addresses.append(batt_addr)
-            _logger.info("detect: lv_battery_addresses=%s", caps.lv_battery_addresses)
+            _logger.info(
+                "detect: lv_battery_addresses=[%s]",
+                ", ".join(f"0x{a:02x}" for a in caps.lv_battery_addresses),
+            )
+
+        if prior is not None and prior != caps:
+            self.plant.capabilities = None
+            raise PlantTopologyMismatch(
+                f"detect: plant topology does not match prior — prior={prior!r}, actual={caps!r}",
+                prior=prior,
+                actual=caps,
+            )
 
         self.plant.capabilities = caps
         return caps

--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -222,15 +222,22 @@ class Client:
     ) -> None:
         """Populate caps.bcu_stacks. Hinted mode trusts prior layout; cold mode reads BMS at 0xA0."""
         if prior is not None:
-            # Hinted: confirm each previously-seen BCU is still answering. Skips the
-            # BMS read at 0xA0 entirely since prior tells us the layout.
-            for offset, num_modules in prior.bcu_stacks:
+            # Hinted: probe each previously-seen BCU and record what the BCU actually
+            # reports for its module count (rather than trusting `prior`). The probe
+            # populates IR(60–64) into the register cache; IR(64) is the BCU's own
+            # module count. Letting actual values flow into `caps` here means a
+            # change in stack composition is surfaced by the subsequent comparison
+            # against `prior` rather than silently accepted. BMS read at 0xA0 is
+            # skipped entirely — prior already tells us which BCUs to look at.
+            for offset, _stored_modules in prior.bcu_stacks:
                 if await self._probe(
                     ReadInputRegistersRequest(base_register=60, register_count=5, device_address=0x70 + offset),
                     timeout=probe_timeout,
                     retries=probe_retries,
                 ):
-                    caps.bcu_stacks.append((offset, num_modules))
+                    bcu_cache = self.plant.register_caches.get(0x70 + offset, RegisterCache())
+                    actual_modules = bcu_cache.get(IR(64)) or 0
+                    caps.bcu_stacks.append((offset, actual_modules))
             return
 
         # Cold path: ask the BMS how many BCUs exist, then probe each.
@@ -249,7 +256,7 @@ class Client:
                 timeout=probe_timeout,
                 retries=probe_retries,
             ):
-                bcu_cache: RegisterCache = self.plant.register_caches.get(0x70 + i, RegisterCache())
+                bcu_cache = self.plant.register_caches.get(0x70 + i, RegisterCache())
                 num_modules = bcu_cache.get(IR(64)) or 0
                 caps.bcu_stacks.append((i, num_modules))
 

--- a/givenergy_modbus/exceptions.py
+++ b/givenergy_modbus/exceptions.py
@@ -28,3 +28,26 @@ class InvalidFrame(ExceptionBase):
 
 class CommunicationError(ExceptionBase):
     """Exception to indicate a communication error."""
+
+
+class PlantTopologyMismatch(CommunicationError):
+    """Raised when detect(prior=...) finds the plant doesn't match the supplied prior.
+
+    Carries both `prior` (what the caller asserted) and `actual` (a PlantCapabilities
+    reflecting what confirmed on this run). On raise, the Client's plant.capabilities
+    is left as None — callers that wish to accept the new topology must explicitly
+    assign `client.plant.capabilities = exc.actual`.
+
+    Caller policy decides whether to retry (e.g. with longer timeouts), fall back to
+    detect() without prior, or surface the change to the user.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        prior,
+        actual,
+    ) -> None:
+        super().__init__(message=message)
+        self.prior = prior
+        self.actual = actual

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -236,11 +236,17 @@ class PlantCapabilities:
         version = normalised.get("schema_version")
         if version != cls.SCHEMA_VERSION:
             raise ValueError(f"unsupported PlantCapabilities schema_version {version!r}; expected {cls.SCHEMA_VERSION}")
+
+        def _addr(v: Any) -> int:
+            # Accept either hex strings (the canonical to_dict() form) or raw ints
+            # for resilience against hand-edited or differently-serialised payloads.
+            return int(v, 0) if isinstance(v, str) else int(v)
+
         return cls(
             device_type=Model[normalised["device_type"]],
-            inverter_address=int(normalised["inverter_address"], 0),
-            meter_addresses=[int(a, 0) for a in normalised["meter_addresses"]],
-            lv_battery_addresses=[int(a, 0) for a in normalised["lv_battery_addresses"]],
+            inverter_address=_addr(normalised["inverter_address"]),
+            meter_addresses=[_addr(a) for a in normalised["meter_addresses"]],
+            lv_battery_addresses=[_addr(a) for a in normalised["lv_battery_addresses"]],
             bcu_stacks=[(offset, modules) for offset, modules in normalised["bcu_stacks"]],
         )
 

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -202,6 +202,61 @@ class PlantCapabilities:
         """Return True if this system uses HV battery stacks (BCU/BMU) rather than LV packs."""
         return self.device_type in _HV_MODELS
 
+    SCHEMA_VERSION = 1
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialise to a JSON-safe dict for caller-managed persistence.
+
+        Round-trips through from_dict(). Addresses render as `0x..` strings to
+        match the form used in logs, exceptions, and code. The schema_version
+        field gives future-us an escape hatch for format changes.
+        """
+        return {
+            "schema_version": self.SCHEMA_VERSION,
+            "device_type": self.device_type.name,
+            "inverter_address": f"0x{self.inverter_address:02x}",
+            "meter_addresses": [f"0x{a:02x}" for a in self.meter_addresses],
+            "lv_battery_addresses": [f"0x{a:02x}" for a in self.lv_battery_addresses],
+            "bcu_stacks": [[offset, modules] for offset, modules in self.bcu_stacks],
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "PlantCapabilities":
+        """Reconstruct from a to_dict() payload.
+
+        Schema version mismatch raises ValueError — callers can catch and re-run
+        detect() without prior. Pre-rename `*_slave(s)` key aliases are
+        normalised silently so state persisted under the older conventions
+        still loads cleanly.
+        """
+        normalised: dict[str, Any] = dict(data)
+        for old, new in _CAPABILITIES_LEGACY_ALIASES.items():
+            if old in normalised and new not in normalised:
+                normalised[new] = normalised.pop(old)
+        version = normalised.get("schema_version")
+        if version != cls.SCHEMA_VERSION:
+            raise ValueError(f"unsupported PlantCapabilities schema_version {version!r}; expected {cls.SCHEMA_VERSION}")
+        return cls(
+            device_type=Model[normalised["device_type"]],
+            inverter_address=int(normalised["inverter_address"], 0),
+            meter_addresses=[int(a, 0) for a in normalised["meter_addresses"]],
+            lv_battery_addresses=[int(a, 0) for a in normalised["lv_battery_addresses"]],
+            bcu_stacks=[(offset, modules) for offset, modules in normalised["bcu_stacks"]],
+        )
+
+    def __repr__(self) -> str:
+        meters = ", ".join(f"0x{a:02x}" for a in self.meter_addresses)
+        batts = ", ".join(f"0x{a:02x}" for a in self.lv_battery_addresses)
+        bcus = ", ".join(f"({o}, {n})" for o, n in self.bcu_stacks)
+        return (
+            f"PlantCapabilities("
+            f"device_type=Model.{self.device_type.name}, "
+            f"inverter_address=0x{self.inverter_address:02x}, "
+            f"meter_addresses=[{meters}], "
+            f"lv_battery_addresses=[{batts}], "
+            f"bcu_stacks=[{bcus}])"
+        )
+
     @property
     def is_three_phase(self) -> bool:
         """Return True if this system uses three-phase registers (HR/IR 1000-range)."""
@@ -221,39 +276,6 @@ class PlantCapabilities:
     def is_gateway(self) -> bool:
         """Return True if this system is a Gateway (IR 1600-range)."""
         return self.device_type == Model.GATEWAY
-
-    def to_dict(self) -> dict:
-        """Serialise to a JSON-safe dict for persistence."""
-        return {
-            "device_type": self.device_type.value,
-            "inverter_address": self.inverter_address,
-            "meter_addresses": self.meter_addresses,
-            "lv_battery_addresses": self.lv_battery_addresses,
-            "bcu_stacks": [list(s) for s in self.bcu_stacks],
-        }
-
-    @classmethod
-    def from_dict(cls, data: dict) -> "PlantCapabilities":
-        """Deserialise from a previously persisted dict.
-
-        Accepts both the current key names and the pre-deprecation `*_slave(s)` keys
-        so that state persisted by older versions still loads cleanly.
-        """
-        # Tolerate legacy keys without warning — persisted state shouldn't churn the caller.
-        normalised: dict[str, Any] = dict(data)
-        for old, new in _CAPABILITIES_LEGACY_ALIASES.items():
-            if old in normalised and new not in normalised:
-                normalised[new] = normalised.pop(old)
-        # Only forward keys that are present; let __init__ supply its defaults for any
-        # missing fields. This protects against partial snapshots persisted by older
-        # versions that didn't know about every field we now track.
-        kwargs: dict[str, Any] = {}
-        for key in ("inverter_address", "meter_addresses", "lv_battery_addresses"):
-            if key in normalised:
-                kwargs[key] = normalised[key]
-        if "bcu_stacks" in normalised:
-            kwargs["bcu_stacks"] = [tuple(s) for s in normalised["bcu_stacks"]]
-        return cls(device_type=Model(normalised["device_type"]), **kwargs)
 
 
 class Plant(GivEnergyBaseModel):

--- a/tests/client/test_detect.py
+++ b/tests/client/test_detect.py
@@ -319,10 +319,13 @@ async def test_detect_hinted_raises_when_hinted_address_missing():
 
 @pytest.mark.asyncio
 async def test_detect_hinted_hv_skips_bms_read():
-    """Hinted HV mode uses prior.bcu_stacks directly and skips the 0xA0 BMS probe."""
+    """Hinted HV mode probes the BCUs (skipping BMS at 0xA0) and reads actual module counts."""
     client = _make_client()
     _prime_cache(client, 0x32, {HR(0): 0x8000, HR(21): 0})
     # Crucially: no cache primed at 0xA0 — if hinted mode tries to read it, it'll fail downstream.
+    # Prime each BCU's IR(64) so the actual-module read returns the expected count.
+    _prime_cache(client, 0x70, {IR(64): 3})
+    _prime_cache(client, 0x71, {IR(64): 2})
 
     prior = PlantCapabilities(
         device_type=Model.ALL_IN_ONE,
@@ -341,3 +344,29 @@ async def test_detect_hinted_hv_skips_bms_read():
             caps = await client.detect(prior=prior)
 
     assert caps.bcu_stacks == [(0, 3), (1, 2)]
+
+
+@pytest.mark.asyncio
+async def test_detect_hinted_raises_on_bcu_module_count_drift():
+    """If a BCU now reports a different module count than prior, the final topology check raises."""
+    client = _make_client()
+    _prime_cache(client, 0x32, {HR(0): 0x8000, HR(21): 0})
+    # Stack 0 originally had 3 modules; it now reports 2 (a module was removed).
+    _prime_cache(client, 0x70, {IR(64): 2})
+    _prime_cache(client, 0x71, {IR(64): 2})
+
+    prior = PlantCapabilities(
+        device_type=Model.ALL_IN_ONE,
+        bcu_stacks=[(0, 3), (1, 2)],
+    )
+
+    async def _probe_side_effect(request, *, timeout, retries):
+        return request.device_address in {0x70, 0x71}
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
+        with patch.object(client, "_probe", side_effect=_probe_side_effect):
+            with pytest.raises(PlantTopologyMismatch) as exc_info:
+                await client.detect(prior=prior)
+
+    assert exc_info.value.prior.bcu_stacks == [(0, 3), (1, 2)]
+    assert exc_info.value.actual.bcu_stacks == [(0, 2), (1, 2)]

--- a/tests/client/test_detect.py
+++ b/tests/client/test_detect.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from givenergy_modbus.client.client import Client
-from givenergy_modbus.exceptions import CommunicationError
+from givenergy_modbus.exceptions import CommunicationError, PlantTopologyMismatch
 from givenergy_modbus.model.inverter import Model
 from givenergy_modbus.model.plant import PlantCapabilities
 from givenergy_modbus.model.register import HR, IR
@@ -63,16 +63,32 @@ def test_plant_capabilities_round_trip_with_bcus():
     assert restored.bcu_stacks == [(0, 3), (1, 2)]
 
 
-def test_plant_capabilities_from_dict_tolerates_missing_fields():
-    """Older persisted snapshots may omit fields the current __init__ supports."""
-    # Minimal dict — only device_type is non-defaultable. Everything else should
-    # fall through to __init__'s defaults rather than raising KeyError.
-    minimal = {"device_type": Model.HYBRID.value}
-    caps = PlantCapabilities.from_dict(minimal)
-    assert caps.device_type == Model.HYBRID
+def test_plant_capabilities_from_dict_rejects_missing_schema_version():
+    """from_dict() requires a matching schema_version — callers fall back to a cold detect on mismatch."""
+    with pytest.raises(ValueError, match="schema_version None"):
+        PlantCapabilities.from_dict({"device_type": Model.HYBRID.name})
+
+
+def test_plant_capabilities_from_dict_rejects_mismatched_schema_version():
+    """An unknown schema_version triggers ValueError, not a silent best-effort parse."""
+    with pytest.raises(ValueError, match="schema_version 99"):
+        PlantCapabilities.from_dict({"schema_version": 99, "device_type": Model.HYBRID.name})
+
+
+def test_plant_capabilities_from_dict_tolerates_legacy_key_aliases():
+    """Pre-rename `*_slave(s)` keys are normalised so persisted state still loads cleanly."""
+    legacy = {
+        "schema_version": 1,
+        "device_type": Model.HYBRID.name,
+        "inverter_slave": "0x32",
+        "meter_slaves": ["0x01"],
+        "lv_battery_slaves": ["0x32", "0x33"],
+        "bcu_slaves": [],
+    }
+    caps = PlantCapabilities.from_dict(legacy)
     assert caps.inverter_address == 0x32
-    assert caps.meter_addresses == []
-    assert caps.lv_battery_addresses == []
+    assert caps.meter_addresses == [0x01]
+    assert caps.lv_battery_addresses == [0x32, 0x33]
     assert caps.bcu_stacks == []
 
 
@@ -219,3 +235,109 @@ async def test_detect_raises_when_hr0_missing():
         with patch.object(client, "_probe", new=AsyncMock(return_value=False)):
             with pytest.raises(CommunicationError, match="HR\\(0\\)"):
                 await client.detect()
+
+
+# ---------------------------------------------------------------------------
+# Client.detect(prior=...) — hinted mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_detect_hinted_confirms_known_layout():
+    """When prior matches reality, hinted detect returns equivalent caps and skips empty-slot probes."""
+    client = _make_client()
+    _prime_cache(client, 0x32, {HR(0): 0x2001, HR(21): 0})
+    _prime_battery_serial(client, 0x32)
+    _prime_battery_serial(client, 0x33)
+
+    prior = PlantCapabilities(
+        device_type=Model.HYBRID_GEN1,
+        meter_addresses=[0x01],
+        lv_battery_addresses=[0x32, 0x33],
+    )
+
+    confirmed = {0x01, 0x33}
+
+    async def _probe_side_effect(request, *, timeout, retries):
+        return request.device_address in confirmed
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
+        with patch.object(client, "_probe", side_effect=_probe_side_effect) as mock_probe:
+            caps = await client.detect(prior=prior)
+
+    assert caps == prior
+    # Only the hinted meter (0x01) and battery (0x33) get probed — not the full 0x01–0x08 / 0x32–0x37 sweep.
+    probed = [call.args[0].device_address for call in mock_probe.call_args_list]
+    assert probed == [0x01, 0x33]
+
+
+@pytest.mark.asyncio
+async def test_detect_hinted_raises_on_device_type_change():
+    """If the inverter reports a different device_type than prior, raise and clear plant.capabilities."""
+    client = _make_client()
+    # Hardware now reports HYBRID_GEN1 (DTC 0x2001, arm_fw=0)
+    _prime_cache(client, 0x32, {HR(0): 0x2001, HR(21): 0})
+    # Caller's prior says ALL_IN_ONE_HYBRID — a different family entirely.
+    prior = PlantCapabilities(device_type=Model.ALL_IN_ONE_HYBRID)
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
+        with patch.object(client, "_probe", new=AsyncMock(return_value=False)):
+            with pytest.raises(PlantTopologyMismatch) as exc_info:
+                await client.detect(prior=prior)
+
+    assert exc_info.value.prior is prior
+    assert exc_info.value.actual.device_type == Model.HYBRID_GEN1
+    assert client.plant.capabilities is None
+
+
+@pytest.mark.asyncio
+async def test_detect_hinted_raises_when_hinted_address_missing():
+    """If a hinted meter doesn't confirm, raise PlantTopologyMismatch carrying both views."""
+    client = _make_client()
+    _prime_cache(client, 0x32, {HR(0): 0x2001, HR(21): 0})
+    _prime_battery_serial(client, 0x32)
+
+    prior = PlantCapabilities(
+        device_type=Model.HYBRID_GEN1,
+        meter_addresses=[0x01, 0x02],
+        lv_battery_addresses=[0x32],
+    )
+
+    # 0x01 confirms, 0x02 doesn't.
+    async def _probe_side_effect(request, *, timeout, retries):
+        return request.device_address == 0x01
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
+        with patch.object(client, "_probe", side_effect=_probe_side_effect):
+            with pytest.raises(PlantTopologyMismatch) as exc_info:
+                await client.detect(prior=prior)
+
+    assert exc_info.value.prior is prior
+    assert exc_info.value.actual.meter_addresses == [0x01]
+    assert client.plant.capabilities is None
+
+
+@pytest.mark.asyncio
+async def test_detect_hinted_hv_skips_bms_read():
+    """Hinted HV mode uses prior.bcu_stacks directly and skips the 0xA0 BMS probe."""
+    client = _make_client()
+    _prime_cache(client, 0x32, {HR(0): 0x8000, HR(21): 0})
+    # Crucially: no cache primed at 0xA0 — if hinted mode tries to read it, it'll fail downstream.
+
+    prior = PlantCapabilities(
+        device_type=Model.ALL_IN_ONE,
+        bcu_stacks=[(0, 3), (1, 2)],
+    )
+
+    # Only the BCUs themselves confirm; BMS at 0xA0 isn't queried.
+    confirmed_bcus = {0x70, 0x71}
+
+    async def _probe_side_effect(request, *, timeout, retries):
+        assert request.device_address != 0xA0, "hinted mode must not probe the BMS"
+        return request.device_address in confirmed_bcus
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
+        with patch.object(client, "_probe", side_effect=_probe_side_effect):
+            caps = await client.detect(prior=prior)
+
+    assert caps.bcu_stacks == [(0, 3), (1, 2)]

--- a/tests/test_deprecation_aliases.py
+++ b/tests/test_deprecation_aliases.py
@@ -132,23 +132,8 @@ def test_capabilities_legacy_setters_warn_and_assign():
     assert caps.bcu_stacks == [(0, 4)]
 
 
-def test_capabilities_from_dict_accepts_legacy_keys():
-    """Persisted state from older versions uses *_slave(s) keys; from_dict must still load it."""
-    legacy = {
-        "device_type": Model.HYBRID.value,
-        "inverter_slave": 0x32,
-        "meter_slaves": [0x01],
-        "lv_battery_slaves": [0x33],
-        "bcu_slaves": [[0, 2]],
-    }
-    caps = PlantCapabilities.from_dict(legacy)
-    assert caps.inverter_address == 0x32
-    assert caps.meter_addresses == [0x01]
-    assert caps.lv_battery_addresses == [0x33]
-    assert caps.bcu_stacks == [(0, 2)]
-
-
-def test_capabilities_to_dict_uses_new_keys():
+def test_capabilities_to_dict_format():
+    """Serialised form uses hex address strings, Model.name, and includes schema_version."""
     caps = PlantCapabilities(
         device_type=Model.HYBRID,
         inverter_address=0x32,
@@ -156,13 +141,35 @@ def test_capabilities_to_dict_uses_new_keys():
         lv_battery_addresses=[0x33],
         bcu_stacks=[(0, 2)],
     )
-    assert set(caps.to_dict().keys()) == {
-        "device_type",
-        "inverter_address",
-        "meter_addresses",
-        "lv_battery_addresses",
-        "bcu_stacks",
+    assert caps.to_dict() == {
+        "schema_version": 1,
+        "device_type": "HYBRID",
+        "inverter_address": "0x32",
+        "meter_addresses": ["0x01"],
+        "lv_battery_addresses": ["0x33"],
+        "bcu_stacks": [[0, 2]],
     }
+
+
+def test_capabilities_from_dict_rejects_unknown_schema_version():
+    with pytest.raises(ValueError, match="unsupported PlantCapabilities schema_version"):
+        PlantCapabilities.from_dict({"schema_version": 999, "device_type": "HYBRID"})
+
+
+def test_capabilities_from_dict_ignores_unknown_keys():
+    """Forward-compat: unknown keys are silently ignored."""
+    caps = PlantCapabilities.from_dict(
+        {
+            "schema_version": 1,
+            "device_type": "HYBRID",
+            "inverter_address": "0x32",
+            "meter_addresses": [],
+            "lv_battery_addresses": [],
+            "bcu_stacks": [],
+            "future_field": "ignored",
+        }
+    )
+    assert caps.device_type == Model.HYBRID
 
 
 def test_hv_stack_slave_address_kwarg_warns():


### PR DESCRIPTION
Re-raises [#56](https://github.com/dewet22/givenergy-modbus/issues/56) (now reopened) and brings the original \`e8f0631\` work onto current \`main\` for review.

## Context

The original commit landed on a local \`v2.1\` branch on 2026-05-15 and was inadvertently marked as shipped when #56 was closed. Checking the released code, what actually shipped in the 2.0 line was a *different* \`PlantCapabilities\` serialisation design — raw-int addresses, no \`schema_version\`, legacy-key-tolerant — and the \`Client.detect(prior=...)\` + \`PlantTopologyMismatch\` half was never integrated. See [the #56 comment](https://github.com/dewet22/givenergy-modbus/issues/56#issuecomment-4522696689) for the full correction.

This PR rebases the original commit onto current \`main\` (57 commits of drift) and resolves the two conflicts it surfaces. Pushing it as a discussion vehicle rather than a merge-immediately PR.

## What it adds

- \`Client.detect(prior=PlantCapabilities)\` — restricts probing to the addresses listed in \`prior\`, skipping the empty-slot sweep on a known plant. Strict semantics: any address that fails to confirm, or a \`device_type\` change since \`prior\` was captured, raises \`PlantTopologyMismatch\` (carrying both \`prior\` and \`actual\`) and zeroes \`plant.capabilities\`.
- \`PlantCapabilities\` serialisation reworked to use hex address strings, \`Model.name\` (not the opaque DTC prefix), and a \`schema_version\` field.
- New \`PlantTopologyMismatch\` exception.
- \`PlantCapabilities.__repr__\` so logs and exception messages render addresses consistently with the rest of the codebase.
- Docs update under "Persisting detection state across restarts".

The library does no file I/O itself — storage location and lifecycle are entirely the caller's responsibility, matching the existing pattern.

## Conflict resolutions

Two real collisions surfaced during the rebase:

### \`givenergy_modbus/model/plant.py\` — design collision

Two competing \`to_dict\`/\`from_dict\` implementations:

| | This branch (\`e8f0631\`) | \`main\` |
|---|---|---|
| Addresses | hex strings \`"0x32"\` | raw ints \`50\` |
| \`device_type\` | \`.name\` (enum name) | \`.value\` (raw) |
| \`schema_version\` | strict, \`ValueError\` on mismatch | absent |
| Legacy key handling | absent | \`_CAPABILITIES_LEGACY_ALIASES\` rename |
| Missing-fields tolerance | rejects | tolerant |

**Resolution: hybrid.** Took this branch's outer shape (strict \`schema_version\`, hex strings, \`.name\`) and folded \`main\`'s \`_CAPABILITIES_LEGACY_ALIASES\` key-rename into \`from_dict()\` for safety against any future renames. Dropped \`main\`'s missing-fields tolerance — the strict design accepts \"fall back to cold detect on mismatch\" as the contract, which matches the discussion on #56.

Test \`test_plant_capabilities_from_dict_tolerates_missing_fields\` (which asserted \`main\`'s tolerant behaviour) replaced with three tests asserting the new strict contract: missing \`schema_version\` rejects, mismatched \`schema_version\` rejects, legacy \`*_slave\` keys still load.

### \`docs/usage.md\` — independent sections, not actually competing

\`main\` added "Capturing frames for bug reports" (the v2.0 \`capture_frames\` feature). This branch added "Persisting detection state across restarts" (this PR's feature). Both belong; resolved by keeping both sections in order.

## Open design questions

1. **Hybrid vs strict-only.** I included \`_CAPABILITIES_LEGACY_ALIASES\` handling in \`from_dict\` as a safety net, even though no released version persisted state under the old key names. Happy to strip it back to pure-strict if you'd rather the design stay minimal.
2. **Tolerant fallback on mismatch.** Today the contract is "ValueError → caller catches and re-runs cold detect". Could alternatively raise \`PlantTopologyMismatch\` so callers have one exception type to catch for both schema-drift and topology-drift cases. Currently \`PlantTopologyMismatch\` is only raised from inside \`detect()\`, not \`from_dict\`. Worth deciding.
3. **\`detect(prior=)\` ergonomics.** Caller has to thread the prior themselves; could add a higher-level \`Client.warm_detect(stored: dict | None)\` helper that wraps the load/parse/detect/fallback flow. Out of scope for this PR but flagging.

## Test plan

- [x] \`uv run --group test pytest\` — 530 passed, 2 skipped (the pre-existing skips outside this PR's scope)
- [x] \`uv run --group test tox\` — py314 / format / lint / build all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional "hinted" detection mode to resume probing from a previously saved topology (limits probing to hinted addresses).
  * New exception surfaced when a supplied prior topology does not match the actual plant.

* **Documentation**
  * Usage guide for persisting/resuming detection, documenting a stable, versioned JSON payload and that storage is caller-managed (library does no file I/O).

* **Behavior / Compatibility**
  * Persisted format is now versioned and strictly validated; missing or unknown schema versions are rejected.

* **Tests**
  * Expanded tests covering hinted detection behaviors and serialization/version validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dewet22/givenergy-modbus/pull/81?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->