### PR TITLE
fix: accept v2.0.0 PlantCapabilities payloads in from_dict() (2.0.2)

### DIFF
--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -256,22 +256,27 @@ class PlantCapabilities:
             # persisted the enum value (Model("2")). Try the name lookup first
             # — it's what every payload emitted by 2.0.1's to_dict() uses — and
             # fall back to the value lookup so v2.0.0 payloads keep working.
+            # `str(v)` on the fallback handles unquoted ints from sloppy JSON
+            # tooling (`device_type: 2` instead of `"2"`).
             if isinstance(v, Model):
                 return v
             try:
                 return Model[v]
-            except KeyError:
-                return Model(v)
+            except KeyError, TypeError:
+                return Model(str(v))
 
+        # `.get(k) or []` (not `.get(k, [])`) so an explicit `null` in JSON for
+        # any of the optional list fields safely degrades to empty rather than
+        # raising TypeError on iteration.
         return cls(
             device_type=_device_type(normalised["device_type"]),
             inverter_address=_addr(normalised["inverter_address"]),
-            meter_addresses=[_addr(a) for a in normalised.get("meter_addresses", [])],
-            lv_battery_addresses=[_addr(a) for a in normalised.get("lv_battery_addresses", [])],
+            meter_addresses=[_addr(a) for a in (normalised.get("meter_addresses") or [])],
+            lv_battery_addresses=[_addr(a) for a in (normalised.get("lv_battery_addresses") or [])],
             # Coerce bcu_stacks entries — hand-edited JSON / differently-serialised
             # payloads can put strings here, which would TypeError downstream
             # (`0x70 + offset` in detect()). Fail loud at parse time instead.
-            bcu_stacks=[(int(offset), int(modules)) for offset, modules in normalised.get("bcu_stacks", [])],
+            bcu_stacks=[(int(offset), int(modules)) for offset, modules in (normalised.get("bcu_stacks") or [])],
         )
 
     def __repr__(self) -> str:

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -224,30 +224,51 @@ class PlantCapabilities:
     def from_dict(cls, data: dict[str, Any]) -> "PlantCapabilities":
         """Reconstruct from a to_dict() payload.
 
-        Schema version mismatch raises ValueError — callers can catch and re-run
-        detect() without prior. Pre-rename `*_slave(s)` key aliases are
-        normalised silently so state persisted under the older conventions
-        still loads cleanly.
+        Accepts two on-disk shapes:
+
+        - **v2.0.0 (legacy, no `schema_version`)**: `device_type` as the enum
+          value (e.g. `"2"`), addresses as raw integers, no `schema_version`
+          key. Persisted by the v2.0.0 `to_dict()`.
+        - **v2.0.1+ (versioned)**: `schema_version` present and equal to
+          `SCHEMA_VERSION`, `device_type` as enum name (e.g. `"HYBRID_GEN1"`),
+          addresses as `"0x..."` hex strings.
+
+        A `schema_version` that's present but doesn't match `SCHEMA_VERSION`
+        raises `ValueError` — callers can catch and re-run detect() without
+        prior. Pre-rename `*_slave(s)` key aliases are normalised silently so
+        state persisted under the older conventions still loads cleanly.
         """
         normalised: dict[str, Any] = dict(data)
         for old, new in _CAPABILITIES_LEGACY_ALIASES.items():
             if old in normalised and new not in normalised:
                 normalised[new] = normalised.pop(old)
         version = normalised.get("schema_version")
-        if version != cls.SCHEMA_VERSION:
+        if version is not None and version != cls.SCHEMA_VERSION:
             raise ValueError(f"unsupported PlantCapabilities schema_version {version!r}; expected {cls.SCHEMA_VERSION}")
 
         def _addr(v: Any) -> int:
-            # Accept either hex strings (the canonical to_dict() form) or raw ints
-            # for resilience against hand-edited or differently-serialised payloads.
+            # Accept either hex strings (the v2.0.1+ canonical form) or raw ints
+            # (the v2.0.0 legacy form, or hand-edited payloads).
             return int(v, 0) if isinstance(v, str) else int(v)
 
+        def _device_type(v: Any) -> Model:
+            # v2.0.1+ persists the enum name (Model["HYBRID_GEN1"]); v2.0.0
+            # persisted the enum value (Model("2")). Try the name lookup first
+            # — it's what every payload emitted by 2.0.1's to_dict() uses — and
+            # fall back to the value lookup so v2.0.0 payloads keep working.
+            if isinstance(v, Model):
+                return v
+            try:
+                return Model[v]
+            except KeyError:
+                return Model(v)
+
         return cls(
-            device_type=Model[normalised["device_type"]],
+            device_type=_device_type(normalised["device_type"]),
             inverter_address=_addr(normalised["inverter_address"]),
-            meter_addresses=[_addr(a) for a in normalised["meter_addresses"]],
-            lv_battery_addresses=[_addr(a) for a in normalised["lv_battery_addresses"]],
-            bcu_stacks=[(offset, modules) for offset, modules in normalised["bcu_stacks"]],
+            meter_addresses=[_addr(a) for a in normalised.get("meter_addresses", [])],
+            lv_battery_addresses=[_addr(a) for a in normalised.get("lv_battery_addresses", [])],
+            bcu_stacks=[(offset, modules) for offset, modules in normalised.get("bcu_stacks", [])],
         )
 
     def __repr__(self) -> str:

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -268,7 +268,10 @@ class PlantCapabilities:
             inverter_address=_addr(normalised["inverter_address"]),
             meter_addresses=[_addr(a) for a in normalised.get("meter_addresses", [])],
             lv_battery_addresses=[_addr(a) for a in normalised.get("lv_battery_addresses", [])],
-            bcu_stacks=[(offset, modules) for offset, modules in normalised.get("bcu_stacks", [])],
+            # Coerce bcu_stacks entries — hand-edited JSON / differently-serialised
+            # payloads can put strings here, which would TypeError downstream
+            # (`0x70 + offset` in detect()). Fail loud at parse time instead.
+            bcu_stacks=[(int(offset), int(modules)) for offset, modules in normalised.get("bcu_stacks", [])],
         )
 
     def __repr__(self) -> str:

--- a/tests/client/test_detect.py
+++ b/tests/client/test_detect.py
@@ -100,6 +100,29 @@ def test_plant_capabilities_from_dict_rejects_mismatched_schema_version():
         PlantCapabilities.from_dict({"schema_version": 99, "device_type": Model.HYBRID.name})
 
 
+def test_plant_capabilities_from_dict_coerces_bcu_stacks_ints():
+    """A hand-edited payload with stringified bcu_stacks entries still loads cleanly.
+
+    The address fields already tolerate hex-string-or-int via the `_addr()` helper, but
+    `bcu_stacks` was passing entries through verbatim — strings here would only blow up
+    later in `detect()` at `0x70 + offset` with `TypeError`, far from the parse site.
+    Coercing to int at from_dict() time fails loud and immediately if the payload is
+    malformed, and silently accepts the legitimate hand-edit case.
+    """
+    caps = PlantCapabilities.from_dict(
+        {
+            "schema_version": 1,
+            "device_type": "ALL_IN_ONE",
+            "inverter_address": "0x32",
+            "meter_addresses": [],
+            "lv_battery_addresses": [],
+            "bcu_stacks": [["0", "3"], ["1", "2"]],
+        }
+    )
+    assert caps.bcu_stacks == [(0, 3), (1, 2)]
+    assert all(isinstance(o, int) and isinstance(n, int) for o, n in caps.bcu_stacks)
+
+
 def test_plant_capabilities_from_dict_tolerates_legacy_key_aliases():
     """Pre-rename `*_slave(s)` keys are normalised so persisted state still loads cleanly."""
     legacy = {

--- a/tests/client/test_detect.py
+++ b/tests/client/test_detect.py
@@ -100,6 +100,46 @@ def test_plant_capabilities_from_dict_rejects_mismatched_schema_version():
         PlantCapabilities.from_dict({"schema_version": 99, "device_type": Model.HYBRID.name})
 
 
+def test_plant_capabilities_from_dict_accepts_int_device_type():
+    """A device_type that comes through as an unquoted int (sloppy JSON tooling) is coerced.
+
+    `Model[v]` requires a string key, so an int input falls through to the
+    value-lookup `Model(str(v))` rather than crashing with `ValueError: 2 is not
+    a valid Model`. Same fallback that lets v2.0.0 string-value payloads parse.
+    """
+    caps = PlantCapabilities.from_dict(
+        {
+            "device_type": 2,  # int, not str — what unquoted JSON / sloppy YAML yields
+            "inverter_address": 0x32,
+            "meter_addresses": [],
+            "lv_battery_addresses": [],
+            "bcu_stacks": [],
+        }
+    )
+    assert caps.device_type == Model.HYBRID
+
+
+def test_plant_capabilities_from_dict_treats_null_list_fields_as_empty():
+    """An explicit `null` for any of the optional list fields safely degrades to empty.
+
+    Without the `or []` guard, `null` in JSON would surface as a `NoneType is not
+    iterable` TypeError far from the parse site.
+    """
+    caps = PlantCapabilities.from_dict(
+        {
+            "schema_version": 1,
+            "device_type": "HYBRID",
+            "inverter_address": "0x32",
+            "meter_addresses": None,
+            "lv_battery_addresses": None,
+            "bcu_stacks": None,
+        }
+    )
+    assert caps.meter_addresses == []
+    assert caps.lv_battery_addresses == []
+    assert caps.bcu_stacks == []
+
+
 def test_plant_capabilities_from_dict_coerces_bcu_stacks_ints():
     """A hand-edited payload with stringified bcu_stacks entries still loads cleanly.
 

--- a/tests/client/test_detect.py
+++ b/tests/client/test_detect.py
@@ -63,14 +63,39 @@ def test_plant_capabilities_round_trip_with_bcus():
     assert restored.bcu_stacks == [(0, 3), (1, 2)]
 
 
-def test_plant_capabilities_from_dict_rejects_missing_schema_version():
-    """from_dict() requires a matching schema_version — callers fall back to a cold detect on mismatch."""
-    with pytest.raises(ValueError, match="schema_version None"):
-        PlantCapabilities.from_dict({"device_type": Model.HYBRID.name})
+def test_plant_capabilities_from_dict_accepts_v2_0_0_legacy_shape():
+    """Regression: a v2.0.0-shaped payload must still parse after the v2.0.1 schema change.
+
+    v2.0.0's to_dict() emitted no schema_version, used Model.value, and stored
+    addresses as raw ints. v2.0.1 added schema_version=1, switched device_type
+    to Model.name, and switched addresses to hex strings. Without a legacy
+    parse path, a v2.0.0 → v2.0.1+ upgrade would crash with `ValueError:
+    unsupported PlantCapabilities schema_version None`.
+
+    The fixture below matches exactly what v2.0.0's `PlantCapabilities.to_dict()`
+    would have produced for this configuration — captured by reading the v2.0.0
+    tag's plant.py.
+    """
+    v2_0_0_payload = {
+        "device_type": "2",  # Model.HYBRID.value, not .name
+        "inverter_address": 0x32,  # integer, not hex string
+        "meter_addresses": [0x01, 0x02],
+        "lv_battery_addresses": [0x33, 0x34],
+        "bcu_stacks": [],
+    }
+    caps = PlantCapabilities.from_dict(v2_0_0_payload)
+    assert caps.device_type == Model.HYBRID
+    assert caps.inverter_address == 0x32
+    assert caps.meter_addresses == [0x01, 0x02]
+    assert caps.lv_battery_addresses == [0x33, 0x34]
+    assert caps.bcu_stacks == []
 
 
 def test_plant_capabilities_from_dict_rejects_mismatched_schema_version():
-    """An unknown schema_version triggers ValueError, not a silent best-effort parse."""
+    """A versioned payload with an unknown schema_version triggers ValueError.
+
+    Distinct from missing-schema_version, which is now treated as v2.0.0 legacy.
+    """
     with pytest.raises(ValueError, match="schema_version 99"):
         PlantCapabilities.from_dict({"schema_version": 99, "device_type": Model.HYBRID.name})
 

--- a/tests/client/test_detect.py
+++ b/tests/client/test_detect.py
@@ -100,6 +100,21 @@ def test_plant_capabilities_from_dict_rejects_mismatched_schema_version():
         PlantCapabilities.from_dict({"schema_version": 99, "device_type": Model.HYBRID.name})
 
 
+def test_plant_capabilities_from_dict_accepts_model_instance_device_type():
+    """A `Model` instance passed directly is returned as-is, no string round-trip required."""
+    caps = PlantCapabilities.from_dict(
+        {
+            "schema_version": 1,
+            "device_type": Model.HYBRID_GEN1,  # Model instance, not a string
+            "inverter_address": "0x32",
+            "meter_addresses": [],
+            "lv_battery_addresses": [],
+            "bcu_stacks": [],
+        }
+    )
+    assert caps.device_type is Model.HYBRID_GEN1
+
+
 def test_plant_capabilities_from_dict_accepts_int_device_type():
     """A device_type that comes through as an unquoted int (sloppy JSON tooling) is coerced.
 


### PR DESCRIPTION
## Why

v2.0.0 shipped `PlantCapabilities.to_dict()` / `from_dict()` already, but v2.0.1 silently changed the on-disk shape:

- added `schema_version: 1` as a required field
- switched `device_type` from enum value (`"2"`) to enum name (`"HYBRID_GEN1"`)
- switched address fields from raw int to hex string (`50` → `"0x32"`)

Any caller that persisted `PlantCapabilities` under v2.0.0 and upgraded to 2.0.1 would crash on `from_dict()` with:

```
ValueError: unsupported PlantCapabilities schema_version None; expected 1
```

…before reaching the documented `PlantTopologyMismatch` recovery path. This was caught by openai/codex on the retroactive review PR #87 — they verified v2.0.0's source rather than trusting the git log (which I'd relied on, incorrectly).

Reproduced:

```python
from givenergy_modbus.model.plant import PlantCapabilities
PlantCapabilities.from_dict({
    "device_type": "2",
    "inverter_address": 0x32,
    "meter_addresses": [0x01],
    "lv_battery_addresses": [0x33],
    "bcu_stacks": [],
})
# ValueError: unsupported PlantCapabilities schema_version None; expected 1
```

## What

`from_dict()` now treats missing `schema_version` as the v2.0.0 legacy shape (accepted) rather than a versioned payload that fails the strict check. Two compatibility shims:

- `_device_type()` tries `Model[name]` lookup first (the v2.0.1+ convention), falls back to `Model(value)` lookup (the v2.0.0 convention) on `KeyError`.
- The existing `_addr()` helper already handles either int or hex string.

Strict-version-check is preserved for payloads with a `schema_version` that isn't `SCHEMA_VERSION` — that's the documented "future schema, fall back to a cold detect" path.

## Tests

- `test_plant_capabilities_from_dict_accepts_v2_0_0_legacy_shape` — uses the exact v2.0.0 `to_dict()` shape (verified against `git show v2.0.0:givenergy_modbus/model/plant.py`)
- `test_plant_capabilities_from_dict_rejects_mismatched_schema_version` — strict check on unknown versioned payloads still fires
- Existing round-trip and to_dict format tests unchanged and passing

## Release plan

- Targeting **2.0.2 patch release** once this merges
- 2.0.1 will be yanked from PyPI separately

## References

- Caught on #87 (retroactive review of 2.0.0 → 2.0.1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backward compatibility to accept legacy payload shapes and normalize older field aliases.
  * More tolerant parsing of device types and address formats (e.g., numeric or hex), treats missing address lists as empty, and coerces stack entries to integer pairs.

* **Tests**
  * Added and updated tests covering legacy payload handling, relaxed parsing, and stack-entry coercion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dewet22/givenergy-modbus/pull/89?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->