### PR TITLE
fix(framer): harden against malformed-frame DoS cases (#88)

### DIFF
--- a/givenergy_modbus/framer.py
+++ b/givenergy_modbus/framer.py
@@ -1,5 +1,4 @@
 import logging
-import struct
 from abc import ABC
 from collections.abc import AsyncIterator, Callable
 
@@ -107,18 +106,31 @@ class Framer(ABC):
                 # split across reads (the first len(marker)-1 bytes), so a
                 # faulty/malicious peer streaming non-marker data can't grow
                 # this buffer without bound. See #88.
+                #
+                # The while-loop's `>= 18` guard means the buffer is always
+                # larger than `keep` (= 3) at this point, so there's always
+                # something to discard. The log level is tiered so a peer
+                # drip-feeding a few bytes at a time doesn't flood operator
+                # logs with warnings — a sustained substantial discard still
+                # surfaces as a warning so operators have visibility.
                 keep = len(HEADER_START_MARKER) - 1
-                if len(self._buffer) > keep:
+                discarded = len(self._buffer) - keep
+                if discarded > 100:
                     _logger.warning(
                         "No frame header in %db accumulated buffer, "
                         "discarding %db of leading garbage and retaining trailing %db",
                         len(self._buffer),
-                        len(self._buffer) - keep,
+                        discarded,
                         keep,
                     )
-                    self._buffer = self._buffer[-keep:]
                 else:
-                    _logger.info("No frame header found, await more data")
+                    _logger.debug(
+                        "No frame header in %db buffer, discarding %db, retaining trailing %db",
+                        len(self._buffer),
+                        discarded,
+                        keep,
+                    )
+                self._buffer = self._buffer[-keep:]
                 break
             elif frame_start_offset > 0:
                 # The next candidate frame header is not at the start of the buffer: skip forward to that position
@@ -167,13 +179,15 @@ class Framer(ABC):
                 yield self.pdu_class.decode_bytes(frame)
             except (InvalidPduState, InvalidFrame) as e:
                 yield e
-            except struct.error as e:
-                # A frame whose MBAP header looks plausible but whose transparent
-                # payload is too short / misaligned bubbles `struct.error` up from
-                # the codec. Wrap as InvalidFrame so the consumer task keeps
-                # running rather than terminating on a single malformed frame
-                # from the network. See #88.
-                yield InvalidFrame(f"frame failed low-level decode: {e}", frame)
+            except Exception as e:
+                # Defence-in-depth against malformed-frame DoS: any unexpected
+                # exception from low-level decoding (e.g. `struct.error` from a
+                # too-short payload, `ValueError` / `IndexError` from misaligned
+                # offsets) is wrapped as `InvalidFrame` so the consumer task
+                # keeps running rather than terminating on a single bad frame
+                # from the network. Broad catch is deliberate here — this is
+                # the trust boundary for untrusted network input. See #88.
+                yield InvalidFrame(f"frame failed low-level decode: {type(e).__name__}: {e}", frame)
 
 
 class ClientFramer(Framer):

--- a/givenergy_modbus/framer.py
+++ b/givenergy_modbus/framer.py
@@ -1,4 +1,5 @@
 import logging
+import struct
 from abc import ABC
 from collections.abc import AsyncIterator, Callable
 
@@ -101,7 +102,23 @@ class Framer(ABC):
             # ensure the head of the buffer starts with a valid MBAP header
             frame_start_offset = self._buffer.find(HEADER_START_MARKER)
             if frame_start_offset < 0:
-                _logger.info("No frame header found, await more data")
+                # No marker found anywhere in the accumulated buffer. Trim to
+                # the tail bytes that could still be the start of a marker
+                # split across reads (the first len(marker)-1 bytes), so a
+                # faulty/malicious peer streaming non-marker data can't grow
+                # this buffer without bound. See #88.
+                keep = len(HEADER_START_MARKER) - 1
+                if len(self._buffer) > keep:
+                    _logger.warning(
+                        "No frame header in %db accumulated buffer, "
+                        "discarding %db of leading garbage and retaining trailing %db",
+                        len(self._buffer),
+                        len(self._buffer) - keep,
+                        keep,
+                    )
+                    self._buffer = self._buffer[-keep:]
+                else:
+                    _logger.info("No frame header found, await more data")
                 break
             elif frame_start_offset > 0:
                 # The next candidate frame header is not at the start of the buffer: skip forward to that position
@@ -150,6 +167,13 @@ class Framer(ABC):
                 yield self.pdu_class.decode_bytes(frame)
             except (InvalidPduState, InvalidFrame) as e:
                 yield e
+            except struct.error as e:
+                # A frame whose MBAP header looks plausible but whose transparent
+                # payload is too short / misaligned bubbles `struct.error` up from
+                # the codec. Wrap as InvalidFrame so the consumer task keeps
+                # running rather than terminating on a single malformed frame
+                # from the network. See #88.
+                yield InvalidFrame(f"frame failed low-level decode: {e}", frame)
 
 
 class ClientFramer(Framer):

--- a/tests/test_framer.py
+++ b/tests/test_framer.py
@@ -409,7 +409,8 @@ async def test_headerless_garbage_bounds_buffer_growth(caplog):
     indefinitely. The reproducer from #88 streamed 100 × 300 bytes and ended
     up retaining 30,000 bytes. After the fix, the buffer is trimmed to the
     last `len(HEADER_START_MARKER) - 1` bytes (which could still be the head
-    of a marker split across reads).
+    of a marker split across reads). A 300-byte chunk crosses the 100-byte
+    log-tiering threshold, so the discard is reported at WARNING.
     """
     framer = ClientFramer()
     with caplog.at_level(logging.WARNING, logger="givenergy_modbus.framer"):
@@ -419,6 +420,27 @@ async def test_headerless_garbage_bounds_buffer_growth(caplog):
 
     assert len(framer._buffer) <= len(HEADER_START_MARKER) - 1
     assert any("discarding" in r.message for r in caplog.records)
+
+
+async def test_small_no_marker_discard_logs_at_debug(caplog):
+    """A small discard (≤ 100 bytes) below the threshold logs at DEBUG, not WARNING.
+
+    Distinguishes drip-feed garbage (where each iteration only discards a few
+    bytes) from a peer streaming substantial non-marker payloads. The former
+    would flood operator logs at warning level for no actionable reason.
+    """
+    framer = ClientFramer()
+    with caplog.at_level(logging.DEBUG, logger="givenergy_modbus.framer"):
+        async for _ in framer.decode(b"x" * 50):  # 50 bytes, no marker
+            pass
+
+    # The buffer was bigger than 18 (so the loop ran) but the discarded count
+    # (50 - 3 = 47) is below the 100-byte warning threshold.
+    assert len(framer._buffer) <= len(HEADER_START_MARKER) - 1
+    debug_msgs = [r for r in caplog.records if r.levelno == logging.DEBUG and "discarding" in r.message]
+    warning_msgs = [r for r in caplog.records if r.levelno == logging.WARNING and "discarding" in r.message]
+    assert debug_msgs, "expected at least one DEBUG-level discard log"
+    assert not warning_msgs, "small discards should not surface as WARNING"
 
 
 async def test_marker_split_across_reads_is_preserved(caplog):

--- a/tests/test_framer.py
+++ b/tests/test_framer.py
@@ -5,8 +5,8 @@ from typing import Any
 
 import pytest
 
-from givenergy_modbus.exceptions import ExceptionBase
-from givenergy_modbus.framer import ClientFramer, Framer, ServerFramer
+from givenergy_modbus.exceptions import ExceptionBase, InvalidFrame
+from givenergy_modbus.framer import HEADER_START_MARKER, ClientFramer, Framer, ServerFramer
 from givenergy_modbus.pdu import (
     BasePDU,
     HeartbeatRequest,
@@ -164,7 +164,10 @@ async def test_process_short_buffer():
     assert response.error is False
     assert response.transparent_function_code == 3
     assert response.raw_frame.hex() == (buffer + buffer[:19]).hex()
-    assert framer._buffer == buffer[19:]
+    # After #88: the residual contains no marker, so the framer bounds the
+    # retained buffer to the trailing (len(marker) - 1) bytes — the most that
+    # could be the head of a marker split across reads.
+    assert framer._buffer == buffer[-(len(HEADER_START_MARKER) - 1) :]
 
 
 @pytest.mark.parametrize("buffer", [VALID_RESPONSE_FRAME], ids=["VALID_RESPONSE_FRAME"])
@@ -372,3 +375,78 @@ async def test_inverter_boot(caplog):
         "1/HeartbeatResponse(data_adapter_serial_number=WF2125G316 data_adapter_type=1)",
         "2:22/ReadMeterProductRegistersRequest(device_address=0x04 base_register=60)",
     ]
+
+
+# ---------------------------------------------------------------------------
+# #88 — framer hardening against malformed-frame DoS
+# ---------------------------------------------------------------------------
+
+
+async def test_malformed_short_frame_yields_invalidframe_not_struct_error():
+    """A plausibly-headered but too-short transparent payload must not kill the consumer.
+
+    The reproducer is taken from #88: an MBAP header that claims a transparent
+    payload of two bytes (so `frame_len` = 6 + 2 = 8), followed by enough
+    trailing garbage to push the buffer past the 18-byte minimum frame size.
+    Before the fix, the codec raised `struct.error` straight out of
+    `Framer.decode()`; now it's wrapped as `InvalidFrame` and yielded.
+    """
+    frame_bytes = bytes.fromhex("5959000100020102") + b"x" * 10
+    framer = ClientFramer()
+    yielded: list[Any] = []
+    async for msg in framer.decode(frame_bytes):
+        yielded.append(msg)
+
+    assert len(yielded) == 1
+    assert isinstance(yielded[0], InvalidFrame)
+    assert "low-level decode" in str(yielded[0])
+
+
+async def test_headerless_garbage_bounds_buffer_growth(caplog):
+    """Sustained no-marker traffic must not grow the framer buffer without bound.
+
+    Before the fix, every chunk without a marker accumulated in `_buffer`
+    indefinitely. The reproducer from #88 streamed 100 × 300 bytes and ended
+    up retaining 30,000 bytes. After the fix, the buffer is trimmed to the
+    last `len(HEADER_START_MARKER) - 1` bytes (which could still be the head
+    of a marker split across reads).
+    """
+    framer = ClientFramer()
+    with caplog.at_level(logging.WARNING, logger="givenergy_modbus.framer"):
+        for _ in range(100):
+            async for _ in framer.decode(b"x" * 300):
+                pass
+
+    assert len(framer._buffer) <= len(HEADER_START_MARKER) - 1
+    assert any("discarding" in r.message for r in caplog.records)
+
+
+async def test_marker_split_across_reads_is_preserved(caplog):
+    """Counter-example: a marker that straddles two reads must still be detected.
+
+    The bounding behaviour from `test_headerless_garbage_bounds_buffer_growth`
+    must not silently lose a marker arriving in pieces — the framer keeps the
+    last `len(marker) - 1` bytes precisely so a partially-received marker
+    completes on the next chunk.
+    """
+    framer = ClientFramer()
+    # First chunk: 20 bytes of garbage + first 3 bytes of the marker. After
+    # processing, no full marker is in the buffer, so the framer discards the
+    # 20 garbage bytes and keeps only the trailing partial marker.
+    first_chunk = b"x" * 20 + HEADER_START_MARKER[:3]
+    async for _ in framer.decode(first_chunk):
+        pass
+    assert framer._buffer == HEADER_START_MARKER[:3]
+
+    # Second chunk: the missing last byte of the marker + 20 more bytes of
+    # garbage. Once concatenated, the marker straddles the read boundary but
+    # is now intact in the buffer. The framer DOES find it (and proceeds to
+    # parse the MBAP header, which is junk, triggering the "Unexpected header
+    # values" path — that warning is what proves the marker was detected).
+    second_chunk = HEADER_START_MARKER[3:] + b"x" * 20
+    with caplog.at_level(logging.WARNING, logger="givenergy_modbus.framer"):
+        async for _ in framer.decode(second_chunk):
+            pass
+    assert any("Unexpected header values" in r.message for r in caplog.records)
+    # After processing, the marker has been consumed (the framer skipped past it).
+    assert HEADER_START_MARKER not in framer._buffer


### PR DESCRIPTION
Closes #88.

## Why

Security review found two DoS-resilience issues in the framer/decoder, both reachable from bytes received over the modbus TCP connection.

### 1. Malformed short frames crash the consumer task

\`Framer.decode()\` only caught \`InvalidPduState\` and \`InvalidFrame\` around \`decode_bytes()\`. A plausibly-headered but too-short transparent payload bubbles \`struct.error\` up from the codec, escaping the async generator and terminating \`Client._task_network_consumer()\`.

Reproducer (from #88):

\`\`\`python
async for msg in ClientFramer().decode(bytes.fromhex(\"5959000100020102\") + b\"x\" * 10):
    print(msg)
# Before: uncaught struct.error
# After:  yields InvalidFrame(\"frame failed low-level decode: ...\")
\`\`\`

### 2. Headerless garbage grows the framer buffer without bound

When \`HEADER_START_MARKER\` isn't found, the framer used to log and break while retaining the entire accumulated buffer. Sustained no-marker traffic grew \`_buffer\` indefinitely.

Reproducer (from #88):

\`\`\`python
f = ClientFramer()
for _ in range(100):
    async for _ in f.decode(b\"x\" * 300):
        pass
print(len(f._buffer))
# Before: 30000
# After:  3 (bounded to len(HEADER_START_MARKER) - 1)
\`\`\`

## What

- Wrap \`struct.error\` from the codec as \`InvalidFrame\` so the consumer keeps running.
- On no-marker-found, trim \`_buffer\` to the trailing \`len(marker) - 1\` bytes (the most that could still be the head of a marker split across reads). Falls back to the existing \"await more data\" info log when the buffer is already small.

## Tests

- \`test_malformed_short_frame_yields_invalidframe_not_struct_error\` — finding 1's exact reproducer
- \`test_headerless_garbage_bounds_buffer_growth\` — finding 2's exact reproducer
- \`test_marker_split_across_reads_is_preserved\` — counter-example proving the bounded-buffer change doesn't lose legitimately-split markers
- Existing \`test_process_short_buffer\` assertion updated to match the new bounded-residual behaviour (comment cross-refs #88)

Full tox green: pytest (542) + format + lint + build + docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Frame decoding now recovers from malformed frames instead of crashing, improving runtime stability.  
- Input buffering is capped to avoid unbounded memory growth when receiving corrupted or continuous garbage data.  
- Low-level decode errors are reported as standardized invalid-frame events, and logging has been adjusted to distinguish small vs. large discard conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dewet22/givenergy-modbus/pull/90?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->