### PR TITLE
fix(model): guard p_pv() / e_pv_day() against None inputs

### DIFF
--- a/givenergy_modbus/model/inverter.py
+++ b/givenergy_modbus/model/inverter.py
@@ -626,12 +626,16 @@ class SinglePhaseInverter(_SinglePhaseInverterBase, _InverterCommands):  # type:
         """Construct a SinglePhaseInverter from a RegisterCache."""
         return cls.model_validate(SinglePhaseInverterRegisterGetter(register_cache).build())
 
-    def p_pv(self) -> int:
-        """Computes the total PV power."""
+    def p_pv(self) -> int | None:
+        """Computes the total PV power, or None if either input is unavailable."""
+        if self.p_pv1 is None or self.p_pv2 is None:  # type: ignore[attr-defined]
+            return None
         return self.p_pv1 + self.p_pv2  # type: ignore[attr-defined]
 
-    def e_pv_day(self) -> float:
-        """Computes the total PV energy for the day."""
+    def e_pv_day(self) -> float | None:
+        """Computes the total PV energy for the day, or None if either input is unavailable."""
+        if self.e_pv1_day is None or self.e_pv2_day is None:  # type: ignore[attr-defined]
+            return None
         return self.e_pv1_day + self.e_pv2_day  # type: ignore[attr-defined]
 
     @property

--- a/tests/model/test_inverter.py
+++ b/tests/model/test_inverter.py
@@ -999,6 +999,49 @@ def test_single_phase_inverter_p_pv_and_e_pv_day():
     assert inv.e_pv_day() == 2.0  # type: ignore[attr-defined]
 
 
+def _cache(**entries):
+    from givenergy_modbus.model.register import IR
+
+    addr_lut = {"e_pv1_day": IR(17), "p_pv1": IR(18), "e_pv2_day": IR(19), "p_pv2": IR(20)}
+    return RegisterCache({addr_lut[k]: v for k, v in entries.items()})
+
+
+@pytest.mark.parametrize(
+    "cache",
+    [
+        # p_pv2 missing
+        _cache(p_pv1=1000, e_pv1_day=12, e_pv2_day=8),
+        # p_pv1 missing
+        _cache(p_pv2=500, e_pv1_day=12, e_pv2_day=8),
+        # both missing
+        _cache(e_pv1_day=12, e_pv2_day=8),
+        # p_pv1 out of bounds → None after #82 bounds enforcement
+        _cache(p_pv1=60000, p_pv2=500, e_pv1_day=12, e_pv2_day=8),
+        # p_pv2 out of bounds → None
+        _cache(p_pv1=1000, p_pv2=60000, e_pv1_day=12, e_pv2_day=8),
+    ],
+)
+def test_p_pv_returns_none_when_either_input_unavailable(cache):
+    inv = SinglePhaseInverter.from_register_cache(cache)
+    assert inv.p_pv() is None  # type: ignore[attr-defined]
+
+
+@pytest.mark.parametrize(
+    "cache",
+    [
+        # e_pv2_day missing
+        _cache(e_pv1_day=12, p_pv1=1000, p_pv2=500),
+        # e_pv1_day missing
+        _cache(e_pv2_day=8, p_pv1=1000, p_pv2=500),
+        # both missing
+        _cache(p_pv1=1000, p_pv2=500),
+    ],
+)
+def test_e_pv_day_returns_none_when_either_input_unavailable(cache):
+    inv = SinglePhaseInverter.from_register_cache(cache)
+    assert inv.e_pv_day() is None  # type: ignore[attr-defined]
+
+
 def test_inverter_max_power():
     from givenergy_modbus.model.inverter import _DTC_RATED_POWER
     from givenergy_modbus.model.register import HR


### PR DESCRIPTION
Closes #85.

## Summary

- `SinglePhaseInverter.p_pv()` and `.e_pv_day()` raised `TypeError` when either input field was `None`. This became substantially more likely after #82's bounds-enforcement landed: `p_pv1` / `p_pv2` declare `max=50000`, so any corruption event substituting a higher value yields `None` rather than an OOB int.
- Both methods now early-return `None` when any input is missing, matching the existing pattern on `battery_capacity_kwh`, `_battery_max_power`, and `slot_map` in the same file.
- Return-type annotations widen to `int | None` / `float | None`. Downstream consumers (givenergy-hass) already handle field-level `None` via the "unavailable" sensor path — this just routes the computed fields through the same branch instead of raising.

## Scope check

Audited the rest of `SinglePhaseInverter` and `ThreePhaseInverter` for similar unguarded arithmetic; the other inter-field methods are already `None`-guarded. The fix is scoped to the two methods named in #85.

## Test plan

- [x] New regression tests in `tests/model/test_inverter.py` cover both methods returning `None` when either input is missing, and the happy-path int/float return otherwise
- [x] `tox` passes locally (py313 + py314 + lint + format + build)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * PV power and daily PV energy calculations now return "unavailable" when required component readings are missing or out-of-range, preventing incorrect values or errors.

* **Tests**
  * Added tests covering PV power and daily energy behaviors to ensure missing or out-of-range inputs are handled as unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dewet22/givenergy-modbus/pull/92?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->