### PR TITLE
fix(client): skip inverter-style HR/IR reads on EMS plant controllers

### DIFF
--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -351,7 +351,9 @@ class Client:
 
         # Step 4 — LV battery detection. Battery #1 shares the inverter's IR bank at 0x32;
         # additional batteries are at 0x33–0x37. All slots are validated via Battery.is_valid().
-        if not caps.is_hv:
+        # Skipped for HV systems (handled at step 2) and EMS plant controllers (don't expose
+        # IR at the inverter address — wire capture confirms; see #86).
+        if not caps.is_hv and not caps.is_ems:
             await self.send_request_and_await_response(
                 ReadInputRegistersRequest(base_register=60, register_count=60, device_address=0x32),
                 timeout=timeout,
@@ -394,12 +396,22 @@ class Client:
         """Read HR configuration blocks for the inverter."""
         caps = self.plant.capabilities
         inverter = caps.inverter_address if caps else 0x32
+        is_ems = bool(caps and caps.is_ems)
+        # HR(0,60) is the identity/firmware/serial bank that every device type — including EMS —
+        # answers; it's the same bank detect() reads to identify the device. The HR(60,60),
+        # HR(120,60) and IR(120,60) banks are inverter-specific; EMS plant controllers don't
+        # expose them and the reads time out every poll. The EMS's own window at HR(2040,36)
+        # is covered by the EMS-conditional append below. See #86 (wire capture confirmed via
+        # dewet22/givenergy-hass#52).
         reqs: list[TransparentRequest] = [
             ReadHoldingRegistersRequest(base_register=0, register_count=60, device_address=inverter),
-            ReadHoldingRegistersRequest(base_register=60, register_count=60, device_address=inverter),
-            ReadHoldingRegistersRequest(base_register=120, register_count=60, device_address=inverter),
-            ReadInputRegistersRequest(base_register=120, register_count=60, device_address=inverter),
         ]
+        if not is_ems:
+            reqs += [
+                ReadHoldingRegistersRequest(base_register=60, register_count=60, device_address=inverter),
+                ReadHoldingRegistersRequest(base_register=120, register_count=60, device_address=inverter),
+                ReadInputRegistersRequest(base_register=120, register_count=60, device_address=inverter),
+            ]
         if caps:
             if caps.is_three_phase:
                 reqs += [
@@ -420,10 +432,13 @@ class Client:
         if caps is None:
             return await self.refresh_plant(full_refresh=False)
         inverter = caps.inverter_address
-        reqs: list[TransparentRequest] = [
-            ReadInputRegistersRequest(base_register=0, register_count=60, device_address=inverter),
-            ReadInputRegistersRequest(base_register=180, register_count=60, device_address=inverter),
-        ]
+        reqs: list[TransparentRequest] = []
+        # EMS plant controllers don't expose IR(0,60) or IR(180,60) — see load_config() and #86.
+        if not caps.is_ems:
+            reqs += [
+                ReadInputRegistersRequest(base_register=0, register_count=60, device_address=inverter),
+                ReadInputRegistersRequest(base_register=180, register_count=60, device_address=inverter),
+            ]
         if caps.is_three_phase:
             for base in range(1000, 1414, 60):
                 reqs.append(

--- a/tests/client/test_detect.py
+++ b/tests/client/test_detect.py
@@ -329,6 +329,28 @@ async def test_detect_hv_skips_lv_battery_probing():
 
 
 @pytest.mark.asyncio
+async def test_detect_ems_skips_lv_battery_probing():
+    """EMS plant controllers skip the LV battery probe.
+
+    They don't expose IR at the inverter address — the unconditional read at
+    IR(60,60) on 0x32 would time out every detect(). See #86.
+    """
+    client = _make_client()
+    # DTC 0x5001 → Model.EMS (first-digit prefix "5")
+    _prime_cache(client, 0x32, {HR(0): 0x5001, HR(21): 0})
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock) as mock_send:
+        with patch.object(client, "_probe", new=AsyncMock(return_value=False)):
+            caps = await client.detect()
+
+    assert caps.is_ems is True
+    assert caps.lv_battery_addresses == []
+    # Only the initial HR(0,60) read on 0x11 should have been issued — no IR(60,60) on 0x32.
+    sent = [call.args[0] for call in mock_send.call_args_list]
+    assert all(req.device_address != 0x32 for req in sent), f"detect() should not read from 0x32 for EMS; got {sent}"
+
+
+@pytest.mark.asyncio
 async def test_detect_raises_when_hr0_missing():
     """If HR(0) is absent after reading device 0x11, detect raises CommunicationError."""
     client = _make_client()

--- a/tests/client/test_load_refresh.py
+++ b/tests/client/test_load_refresh.py
@@ -76,11 +76,15 @@ async def test_load_config_extended_slots():
 
 
 async def test_load_config_ems():
-    """EMS models add HR 2040–2075."""
+    """EMS plant controllers expose HR(0,60) (identity/firmware/serial) and HR(2040,36) only.
+
+    The inverter-style HR(60,60), HR(120,60) and IR(120,60) banks time out on EMS devices.
+    Regression: #86. Wire capture confirmed via dewet22/givenergy-hass#52.
+    """
     client = _client_with_caps(Model.EMS)
     with patch.object(client, "execute", new_callable=AsyncMock) as mock_exec:
         await client.load_config()
-    assert _reqs(mock_exec) == [_hr(0, 60), _hr(60, 60), _hr(120, 60), _ir(120, 60), _hr(2040, 36)]
+    assert _reqs(mock_exec) == [_hr(0, 60), _hr(2040, 36)]
 
 
 # ---------------------------------------------------------------------------
@@ -122,11 +126,17 @@ async def test_refresh_three_phase():
 
 
 async def test_refresh_ems():
-    """EMS adds IR 2040–2094 as one read of 55 registers."""
+    """EMS skips the inverter-style IR(0,60)/IR(180,60) reads — only IR 2040–2094 is requested.
+
+    Regression: #86. The IR(2040,55) append matches what the library models for EMS today;
+    the wire capture in dewet22/givenergy-hass#52 ran without populated capabilities so it
+    can't independently confirm whether the EMS responds to that bank — revisit if a
+    caps-populated capture shows otherwise.
+    """
     client = _client_with_caps(Model.EMS)
     with patch.object(client, "execute", new_callable=AsyncMock) as mock_exec:
         await client.refresh()
-    assert _reqs(mock_exec) == [_ir(0, 60), _ir(180, 60), _ir(2040, 55)]
+    assert _reqs(mock_exec) == [_ir(2040, 55)]
 
 
 async def test_refresh_gateway():


### PR DESCRIPTION
Fix for #86 — verified against wire capture.

## Summary

EMS plant controllers expose a different register surface than inverters: they answer `HR(0,60)` (identity/firmware/serial) and `HR(2040,36)` (plant configuration), but not the inverter-style `HR(60/120,60)`, `IR(0/120/180,60)` banks. The library was issuing those reads unconditionally in three places — every poll cycle hit the coordinator's failure threshold (downstream impact in [dewet22/givenergy-hass#52](https://github.com/dewet22/givenergy-hass/issues/52)).

Three call sites are gated on `caps.is_ems`:

- `Client.load_config()` — drops `HR(60,60)`, `HR(120,60)`, `IR(120,60)` for EMS; keeps `HR(0,60)` (identity bank — every device type answers) and `HR(2040,36)` (existing EMS-conditional append).
- `Client.refresh()` — drops `IR(0,60)`, `IR(180,60)` for EMS; keeps `IR(2040,55)` (existing EMS-conditional append; surface unconfirmed pending a caps-populated capture).
- `Client.detect()` Step 4 — skips the unconditional `IR(60,60)` read at `0x32` during LV battery detection for EMS. Previously raised `TimeoutError` after the full retry budget (~6 s) on every cold detect. Addresses [@gemini-code-assist's review point](https://github.com/dewet22/givenergy-modbus/pull/93#pullrequestreview).

## What kept and what dropped, on the wire

From a real-hardware capture (EMS + two inverters), responses at the inverter's device address (`0x32`):

| Bank | Response | Action |
|---|---|---|
| `HR(0,60)` | populated (identity/firmware/serial) | **kept** |
| `HR(60,60)`, `HR(120,60)` | no response | **skipped** |
| `HR(2040,36)` | populated (plant config) | **kept** |
| `IR(0,60)`, `IR(60,60)`, `IR(120,60)`, `IR(180,60)` | no response | **skipped** |

Captures attached on [issue #86](https://github.com/dewet22/givenergy-modbus/issues/86#issuecomment-4559519238) for the record.

## Out of scope (follow-up)

The same capture shows the EMS exposing per-inverter real-time data at sub-addresses (`0x01`, `0x03`) and battery-slot addresses (`0x07`, `0x08`). That's the topology refactor the library needs for an EMS config entry to surface useful entities, and wants its own issue once we have a description of the user's plant.

## Test plan

- `tests/client/test_load_refresh.py::test_load_config_ems` — asserts `[HR(0,60), HR(2040,36)]`
- `tests/client/test_load_refresh.py::test_refresh_ems` — asserts `[IR(2040,55)]`
- `tests/client/test_detect.py::test_detect_ems_skips_lv_battery_probing` — asserts no IR read at `0x32` for EMS
- Full `tox` (py314 + format + lint + build + docs) passes locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved EMS controller detection by skipping unnecessary LV battery probing and inverter-specific reads that EMS systems do not expose, reducing communication overhead and preventing failed requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dewet22/givenergy-modbus/pull/93?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->