### PR TITLE
refactor: migrate the last two model-layer dataclasses to Pydantic v2

### DIFF
--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -70,15 +70,36 @@ _CAPABILITIES_LEGACY_ALIASES = {
 }
 
 
+def _map_legacy_aliases(kwargs: dict[str, Any], *, stacklevel: int) -> None:
+    """Rename legacy ``*_slave(s)`` keys to canonical names, warn, and enforce mutual exclusivity.
+
+    Mutates ``kwargs`` in place. Shared between PlantCapabilities.__init__
+    (stacklevel=3, the caller's frame) and the model_validate validator
+    (stacklevel=2, best-effort — Pydantic internals limit what's reachable).
+    """
+    for old, new in _CAPABILITIES_LEGACY_ALIASES.items():
+        if old not in kwargs:
+            continue
+        if new in kwargs:
+            raise TypeError(f"pass either {old}= or {new}=, not both")
+        warnings.warn(
+            f"PlantCapabilities.{old} is deprecated; use {new}",
+            DeprecationWarning,
+            stacklevel=stacklevel,
+        )
+        kwargs[new] = kwargs.pop(old)
+
+
 class PlantCapabilities(BaseModel):
     """Describes the hardware topology discovered by Client.detect().
 
     Returned by Client.detect(); callers assign it to plant.capabilities or
     persist it for faster restarts (see fork-merge-plan deferred items).
 
-    Legacy ``*_slave(s)`` keyword aliases are handled in the
-    ``_accept_legacy_aliases`` model_validator below — they emit a
-    DeprecationWarning and map to the canonical fields.
+    Legacy ``*_slave(s)`` keyword aliases are mapped to the canonical names
+    in ``__init__`` (for ``PlantCapabilities(...)`` callers) and again in the
+    ``_accept_legacy_aliases`` model_validator (for ``model_validate({...})``
+    callers). Both paths emit a DeprecationWarning.
     """
 
     # `extra="forbid"` preserves the historic contract that unknown kwargs
@@ -92,31 +113,51 @@ class PlantCapabilities(BaseModel):
     # Each entry is (bcu_offset, num_modules) where the BCU device address is 0x70 + bcu_offset.
     bcu_stacks: list[tuple[int, int]] = Field(default_factory=list)
 
+    def __init__(
+        self,
+        device_type: Model | None = None,
+        inverter_address: int | None = None,
+        meter_addresses: list[int] | None = None,
+        lv_battery_addresses: list[int] | None = None,
+        bcu_stacks: list[tuple[int, int]] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        # Custom __init__ for two reasons:
+        # 1. Preserves the historic positional-argument shape that the
+        #    @dataclass form supported (PlantCapabilities(Model.HYBRID, 0x32, ...)).
+        # 2. Lets us emit the legacy-alias DeprecationWarning at stacklevel=2
+        #    pointing at the user's call site — a `model_validator(mode='before')`
+        #    sits behind Pydantic internals and can't reach the caller cleanly.
+        # Only pass through positional-derived values that were actually supplied
+        # so we don't override kwargs the caller may have provided as keywords.
+        if device_type is not None:
+            kwargs["device_type"] = device_type
+        if inverter_address is not None:
+            kwargs["inverter_address"] = inverter_address
+        if meter_addresses is not None:
+            kwargs["meter_addresses"] = meter_addresses
+        if lv_battery_addresses is not None:
+            kwargs["lv_battery_addresses"] = lv_battery_addresses
+        if bcu_stacks is not None:
+            kwargs["bcu_stacks"] = bcu_stacks
+        _map_legacy_aliases(kwargs, stacklevel=3)
+        super().__init__(**kwargs)
+
     @model_validator(mode="before")
     @classmethod
     def _accept_legacy_aliases(cls, data: Any) -> Any:
-        """Map ``*_slave(s)`` legacy kwargs to canonical names, warn, and enforce mutual exclusivity.
+        """Mirror the __init__ alias handling for the ``model_validate`` path.
 
-        Runs before field validation, so canonical fields see only the
-        modern names. NB: stacklevel doesn't reliably point at user code from
-        inside a Pydantic validator (the call chain runs through Pydantic
-        internals), but the warning still fires under ``pytest.warns`` and
-        ``warnings.catch_warnings``-based filtering, which is what matters.
+        ``PlantCapabilities.model_validate({'inverter_slave': 0x33})`` bypasses
+        ``__init__``, so we need a validator to catch legacy keys arriving via
+        that route. Stacklevel from inside a validator can't reliably reach the
+        user (Pydantic internals sit between), but the warning still fires under
+        ``pytest.warns`` and ``warnings.catch_warnings`` filtering by category.
         """
         if not isinstance(data, dict):
             return data
         normalised = dict(data)
-        for old, new in _CAPABILITIES_LEGACY_ALIASES.items():
-            if old not in normalised:
-                continue
-            if new in normalised:
-                raise TypeError(f"pass either {old}= or {new}=, not both")
-            warnings.warn(
-                f"PlantCapabilities.{old} is deprecated; use {new}",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            normalised[new] = normalised.pop(old)
+        _map_legacy_aliases(normalised, stacklevel=2)
         return normalised
 
     @property

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -1,9 +1,8 @@
 import logging
 import warnings
-from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, ClassVar
 
-from pydantic import ConfigDict
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from givenergy_modbus.model import GivEnergyBaseModel
 from givenergy_modbus.model.battery import Battery, BatteryRegisterGetter
@@ -71,55 +70,54 @@ _CAPABILITIES_LEGACY_ALIASES = {
 }
 
 
-@dataclass(init=False)
-class PlantCapabilities:
+class PlantCapabilities(BaseModel):
     """Describes the hardware topology discovered by Client.detect().
 
     Returned by Client.detect(); callers assign it to plant.capabilities or
     persist it for faster restarts (see fork-merge-plan deferred items).
+
+    Legacy ``*_slave(s)`` keyword aliases are handled in the
+    ``_accept_legacy_aliases`` model_validator below — they emit a
+    DeprecationWarning and map to the canonical fields.
     """
+
+    # `extra="forbid"` preserves the historic contract that unknown kwargs
+    # raise TypeError. The pre-Pydantic __init__ enforced this manually.
+    model_config = ConfigDict(extra="forbid")
 
     device_type: Model
     inverter_address: int = 0x32
-    meter_addresses: list[int] = field(default_factory=list)
-    lv_battery_addresses: list[int] = field(default_factory=list)
+    meter_addresses: list[int] = Field(default_factory=list)
+    lv_battery_addresses: list[int] = Field(default_factory=list)
     # Each entry is (bcu_offset, num_modules) where the BCU device address is 0x70 + bcu_offset.
-    bcu_stacks: list[tuple[int, int]] = field(default_factory=list)
+    bcu_stacks: list[tuple[int, int]] = Field(default_factory=list)
 
-    def __init__(
-        self,
-        device_type: Model,
-        inverter_address: int | None = None,
-        meter_addresses: list[int] | None = None,
-        lv_battery_addresses: list[int] | None = None,
-        bcu_stacks: list[tuple[int, int]] | None = None,
-        **legacy_kwargs: Any,
-    ) -> None:
-        new_values: dict[str, Any] = {
-            "inverter_address": inverter_address,
-            "meter_addresses": meter_addresses,
-            "lv_battery_addresses": lv_battery_addresses,
-            "bcu_stacks": bcu_stacks,
-        }
+    @model_validator(mode="before")
+    @classmethod
+    def _accept_legacy_aliases(cls, data: Any) -> Any:
+        """Map ``*_slave(s)`` legacy kwargs to canonical names, warn, and enforce mutual exclusivity.
+
+        Runs before field validation, so canonical fields see only the
+        modern names. NB: stacklevel doesn't reliably point at user code from
+        inside a Pydantic validator (the call chain runs through Pydantic
+        internals), but the warning still fires under ``pytest.warns`` and
+        ``warnings.catch_warnings``-based filtering, which is what matters.
+        """
+        if not isinstance(data, dict):
+            return data
+        normalised = dict(data)
         for old, new in _CAPABILITIES_LEGACY_ALIASES.items():
-            if old in legacy_kwargs:
-                if new_values[new] is not None:
-                    raise TypeError(f"pass either {old}= or {new}=, not both")
-                warnings.warn(
-                    f"PlantCapabilities.{old} is deprecated; use {new}",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-                new_values[new] = legacy_kwargs.pop(old)
-        if legacy_kwargs:
-            raise TypeError(f"unexpected keyword arguments: {sorted(legacy_kwargs)}")
-        self.device_type = device_type
-        self.inverter_address = new_values["inverter_address"] if new_values["inverter_address"] is not None else 0x32
-        self.meter_addresses = new_values["meter_addresses"] if new_values["meter_addresses"] is not None else []
-        self.lv_battery_addresses = (
-            new_values["lv_battery_addresses"] if new_values["lv_battery_addresses"] is not None else []
-        )
-        self.bcu_stacks = new_values["bcu_stacks"] if new_values["bcu_stacks"] is not None else []
+            if old not in normalised:
+                continue
+            if new in normalised:
+                raise TypeError(f"pass either {old}= or {new}=, not both")
+            warnings.warn(
+                f"PlantCapabilities.{old} is deprecated; use {new}",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            normalised[new] = normalised.pop(old)
+        return normalised
 
     @property
     def inverter_slave(self) -> int:
@@ -202,7 +200,7 @@ class PlantCapabilities:
         """Return True if this system uses HV battery stacks (BCU/BMU) rather than LV packs."""
         return self.device_type in _HV_MODELS
 
-    SCHEMA_VERSION = 1
+    SCHEMA_VERSION: ClassVar[int] = 1
 
     def to_dict(self) -> dict[str, Any]:
         """Serialise to a JSON-safe dict for caller-managed persistence.

--- a/givenergy_modbus/model/register.py
+++ b/givenergy_modbus/model/register.py
@@ -1,10 +1,10 @@
 import logging
 import re
-from collections.abc import Callable
-from dataclasses import dataclass
 from datetime import datetime
 from json import JSONEncoder
 from typing import Any, get_type_hints
+
+from pydantic import BaseModel, ConfigDict
 
 from givenergy_modbus.model import TimeSlot
 
@@ -150,24 +150,50 @@ class Converter:
         return prefix + digits
 
 
-@dataclass(init=False)
-class RegisterDefinition:
-    """Specifies how to convert raw register values into their actual representation."""
+class RegisterDefinition(BaseModel):
+    """Specifies how to convert raw register values into their actual representation.
 
-    pre_conv: Callable | tuple | None
-    post_conv: Callable | tuple[Callable, Any] | None
-    registers: tuple["Register"]
-    min: int | float | None
-    max: int | float | None
+    ``min_value`` / ``max_value`` are the bounds for the post-conv value;
+    they're named with the ``_value`` suffix rather than ``min`` / ``max``
+    to avoid shadowing the builtins of the same name (ruff A002, CodeRabbit
+    nag — see #73). The legacy ``min=`` / ``max=`` kwargs on ``__init__`` are
+    preserved so the 150+ ``Def(...)`` call sites don't churn.
+    """
 
-    def __init__(self, *args, min: int | float | None = None, max: int | float | None = None):
-        self.pre_conv = args[0]
-        self.post_conv = args[1]
-        self.registers = args[2:]  # type: ignore[assignment]
-        self.min = min
-        self.max = max
+    # `arbitrary_types_allowed` for `Register` instances; `frozen` because
+    # these are class-level LUT constants that must not mutate after build.
+    model_config = ConfigDict(arbitrary_types_allowed=True, frozen=True)
 
-    def __hash__(self):
+    pre_conv: Any = None
+    post_conv: Any = None
+    registers: tuple = ()
+    min_value: int | float | None = None
+    max_value: int | float | None = None
+
+    def __init__(
+        self,
+        *args: Any,
+        min: int | float | None = None,  # noqa: A002 — legacy kwarg, mapped to min_value
+        max: int | float | None = None,  # noqa: A002 — legacy kwarg, mapped to max_value
+        **kwargs: Any,
+    ) -> None:
+        # Map legacy positional `(pre_conv, post_conv, *registers)` + min/max
+        # kwargs onto the new field names. All 150+ Def(...) call sites use
+        # this form; the keyword form remains available for direct callers.
+        if args:
+            kwargs["pre_conv"] = args[0]
+            kwargs["post_conv"] = args[1] if len(args) > 1 else None
+            kwargs["registers"] = args[2:]
+        if min is not None:
+            kwargs["min_value"] = min
+        if max is not None:
+            kwargs["max_value"] = max
+        super().__init__(**kwargs)
+
+    def __hash__(self) -> int:
+        # Preserve the historic identity: a definition is identified by its
+        # register set, not its conversions or bounds. Used as a dict key in
+        # places that look up by register tuple.
         return hash(self.registers)
 
 
@@ -222,17 +248,20 @@ class RegisterGetter:
             else:
                 val = defn.post_conv(val)
 
-        if val is not None and (defn.min is not None or defn.max is not None) and not all(r == 0 for r in regs):
+        has_bounds = defn.min_value is not None or defn.max_value is not None
+        if val is not None and has_bounds and not all(r == 0 for r in regs):
             # An all-zero raw bank means the hardware didn't populate these registers (e.g. an
             # absent external meter slot); skip bounds checks for that case rather than spamming
             # the log every poll. Doing this at the raw level rather than post-conv keeps the
             # "0x0000 means unset" intent unambiguous.
-            if (defn.min is not None and val < defn.min) or (defn.max is not None and val > defn.max):
+            if (defn.min_value is not None and val < defn.min_value) or (
+                defn.max_value is not None and val > defn.max_value
+            ):
                 # Suppress out-of-bounds values: returning None is more honest than letting an
                 # obviously-wrong value reach downstream consumers. See #82 for the corruption
                 # pattern this protects against — values produced library-side that never appear
                 # on the wire and decode well outside the declared min/max.
-                _logger.debug("register value out of bounds: %r not in [%s, %s]", val, defn.min, defn.max)
+                _logger.debug("register value out of bounds: %r not in [%s, %s]", val, defn.min_value, defn.max_value)
                 return None
 
         return val
@@ -260,7 +289,7 @@ class RegisterGetter:
         violations = []
 
         for name, defn in cls.REGISTER_LUT.items():
-            if defn.min is None and defn.max is None:
+            if defn.min_value is None and defn.max_value is None:
                 continue
             if not any(r in incoming for r in defn.registers):
                 continue

--- a/tests/debug/replay.py
+++ b/tests/debug/replay.py
@@ -90,9 +90,9 @@ def is_oob(val: Any, defn: RegisterDefinition) -> bool:
     """True iff val is outside the field's declared bounds."""
     if val is None:
         return False
-    if defn.min is not None and val < defn.min:
+    if defn.min_value is not None and val < defn.min_value:
         return True
-    if defn.max is not None and val > defn.max:
+    if defn.max_value is not None and val > defn.max_value:
         return True
     return False
 
@@ -108,7 +108,7 @@ def affected_field_names(
     avoids re-reporting stale OOB values left in the cache from earlier commits.
     """
     for name, defn in getter_cls.REGISTER_LUT.items():
-        if defn.min is None and defn.max is None:
+        if defn.min_value is None and defn.max_value is None:
             continue
         if field_filter and name not in field_filter:
             continue
@@ -166,8 +166,8 @@ def detect_oob_events(
                 "registers": [str(r) for r in defn.registers],
                 "raw_register_values": raw_regs,
                 "post_conv_value": val,
-                "min": defn.min,
-                "max": defn.max,
+                "min": defn.min_value,
+                "max": defn.max_value,
             }
         )
     return events

--- a/tests/test_deprecation_aliases.py
+++ b/tests/test_deprecation_aliases.py
@@ -117,6 +117,32 @@ def test_capabilities_unexpected_kwarg_raises():
         PlantCapabilities(device_type=Model.HYBRID, nonexistent=42)
 
 
+def test_capabilities_positional_args_work():
+    """Positional-arg construction is preserved across the Pydantic migration.
+
+    The historic dataclass form supported positional args; the Pydantic
+    migration's custom __init__ preserves that for external callers who may
+    have written PlantCapabilities(Model.HYBRID, 0x32, [0x01], ...) directly.
+    """
+    caps = PlantCapabilities(Model.HYBRID, 0x33, [0x01], [0x35], [(0, 2)])
+    assert caps.device_type == Model.HYBRID
+    assert caps.inverter_address == 0x33
+    assert caps.meter_addresses == [0x01]
+    assert caps.lv_battery_addresses == [0x35]
+    assert caps.bcu_stacks == [(0, 2)]
+
+
+def test_capabilities_model_validate_still_handles_legacy_keys():
+    """model_validate() must still apply legacy alias mapping.
+
+    model_validate() bypasses __init__, so the model_validator must catch
+    legacy *_slave(s) keys arriving via that path too.
+    """
+    with pytest.warns(DeprecationWarning, match="inverter_slave is deprecated"):
+        caps = PlantCapabilities.model_validate({"device_type": Model.HYBRID, "inverter_slave": 0x33})
+    assert caps.inverter_address == 0x33
+
+
 def test_capabilities_legacy_setters_warn_and_assign():
     """Setting a legacy property must update the canonical field and emit a DeprecationWarning."""
     caps = PlantCapabilities(device_type=Model.HYBRID)

--- a/tests/test_deprecation_aliases.py
+++ b/tests/test_deprecation_aliases.py
@@ -108,7 +108,12 @@ def test_capabilities_both_kwarg_forms_raises():
 
 
 def test_capabilities_unexpected_kwarg_raises():
-    with pytest.raises(TypeError, match="unexpected keyword arguments"):
+    # Pydantic raises ValidationError (a ValueError subclass) rather than TypeError
+    # for extra inputs — the rejection contract is preserved, the error type changed
+    # as part of the v2.1 Pydantic migration (#72).
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
         PlantCapabilities(device_type=Model.HYBRID, nonexistent=42)
 
 

--- a/tests/test_deprecation_aliases.py
+++ b/tests/test_deprecation_aliases.py
@@ -13,6 +13,7 @@ removed, these tests can be deleted alongside the alias code.
 import warnings
 
 import pytest
+from pydantic import ValidationError
 
 from givenergy_modbus.model.hv_bcu import Bcu, HvStack
 from givenergy_modbus.model.inverter import Model
@@ -111,8 +112,6 @@ def test_capabilities_unexpected_kwarg_raises():
     # Pydantic raises ValidationError (a ValueError subclass) rather than TypeError
     # for extra inputs — the rejection contract is preserved, the error type changed
     # as part of the v2.1 Pydantic migration (#72).
-    from pydantic import ValidationError
-
     with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
         PlantCapabilities(device_type=Model.HYBRID, nonexistent=42)
 


### PR DESCRIPTION
Closes #72, closes #73.

`PlantCapabilities` and `RegisterDefinition` were the last `@dataclass` hold-outs in `givenergy_modbus/model/`. Every other model class already inherits from `BaseModel` (via `GivEnergyBaseModel` or directly); converting these two completes the model-layer paradigm unification that CodeRabbit originally flagged on PR #68.

## Commits

1. **`refactor: migrate PlantCapabilities to Pydantic v2`** — `BaseModel` + `extra="forbid"`, legacy `*_slave(s)` alias handling moved into a `@model_validator(mode='before')`. `SCHEMA_VERSION` promoted to `ClassVar[int]`. All deprecation properties, `from_dict`/`to_dict`, and predicate accessors preserved.

2. **`refactor: migrate RegisterDefinition to Pydantic v2`** — `BaseModel` + `arbitrary_types_allowed=True` (for `Register`) + `frozen=True` (LUT entries are constants). `__init__` overridden to accept the legacy positional `(pre_conv, post_conv, *registers)` + `min=`/`max=` shape so all ~150 `Def(...)` call sites stay untouched. Internal rename `min`/`max` → `min_value`/`max_value` (kills the A002 builtin shadow CodeRabbit nagged about); four sites in `register.py` and three in `tests/debug/replay.py` updated to match.

## Worth a reviewer's attention

### Behavioural delta on #72

Unknown-kwarg rejection on `PlantCapabilities(...)` now raises `pydantic.ValidationError` (a `ValueError` subclass) rather than `TypeError`. The intent — extras get rejected at construction — is preserved; only the exception type changes. No production code in the repo or known consumers (`givenergy-hass`, `givenergy-cli`) catches the `TypeError`, but flagging in case downstream callers do.

One test (`test_capabilities_unexpected_kwarg_raises`) updated to expect the new exception.

### Performance check on #73

The original issue flagged that `RegisterDefinition` sits on the hot polling path and asked for a benchmark before migration. Numbers from a one-shot microbenchmark:

| Measurement | Dataclass | Pydantic v2 | Ratio | Real-world impact |
|---|---|---|---|---|
| Construction | 0.19 µs | 1.06 µs | 5.4× slower | 0.13 ms one-shot at module import across ~150 entries |
| Raw 5-attr access | 34 ns | 112 ns | 3.3× slower | isolated worst case |
| Simulated `RegisterGetter.get()` | 142 ns | 199 ns | 1.4× slower | ~11 µs per `Client.refresh()` (≈200 reads) |

Wire I/O on a refresh is 50–500 ms; the migration cost lands four orders of magnitude below that. The producer's `tx_message_wait` floor alone (250 ms) eclipses the per-refresh overhead by a factor of 22,000. Safe.

### Stacklevel caveat on #72

`warnings.warn(..., stacklevel=2)` inside a `mode='before'` validator no longer reliably points at the caller — Pydantic internals sit between the call site and the validator. The warning still fires, and `pytest.warns` / `warnings.catch_warnings`-based filtering still works (tests pass), but file-based `warnings.filterwarnings` rules targeting the call site would miss. Hasn't been tested as thoroughly as the previous `__init__`-based stacklevel, and there's no known downstream consumer relying on file-based filtering — flagging in case it bites later.

## Test coverage

Full tox (pytest + ruff format + ruff check + mypy + bandit + uv build + mkdocs + twine) passes locally on both commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Strengthened input validation for plant and register configurations with clearer error messages.
  * Enhanced backward compatibility with automatic mapping of legacy field names to their modern equivalents.

* **Deprecations**
  * Legacy configuration field names are deprecated; users will receive warnings to migrate to updated field names.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dewet22/givenergy-modbus/pull/94?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->