### PR TITLE
fix(client): drop empty meter slots in detect() via Meter.is_valid()

### DIFF
--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -11,6 +11,7 @@ from givenergy_modbus.exceptions import CommunicationError, ExceptionBase, Plant
 from givenergy_modbus.framer import ClientFramer, Framer
 from givenergy_modbus.model.battery import Battery
 from givenergy_modbus.model.inverter import resolve_model
+from givenergy_modbus.model.meter import Meter
 from givenergy_modbus.model.plant import Plant, PlantCapabilities
 from givenergy_modbus.model.register import HR, IR
 from givenergy_modbus.model.register_cache import RegisterCache
@@ -336,14 +337,27 @@ class Client:
             )
 
         # Step 3 — meter probing. Hinted: only previously-seen addresses. Cold: full 0x01–0x08 sweep.
+        # In both modes, a probe response is necessary but not sufficient — some EMS firmwares
+        # ACK every slot in 0x01..0x08 with all-zero registers regardless of whether a meter is
+        # actually wired. Validate via Meter.is_valid() to filter those ghosts, matching the
+        # convention used for Battery and BCU validation. Per-slot (not break-on-fail) because
+        # meters can be non-contiguous (e.g. ports 1 and 3 populated, port 2 empty). See #95.
         meter_candidates = prior.meter_addresses if prior is not None else range(0x01, 0x09)
         for meter_addr in meter_candidates:
-            if await self._probe(
+            if not await self._probe(
                 ReadInputRegistersRequest(base_register=60, register_count=30, device_address=meter_addr),
                 timeout=probe_timeout,
                 retries=probe_retries,
             ):
-                caps.meter_addresses.append(meter_addr)
+                continue
+            meter_cache = self.plant.register_caches.get(meter_addr)
+            if meter_cache is None or not Meter.from_register_cache(meter_cache).is_valid():
+                _logger.debug(
+                    "detect: meter probe responded at 0x%02x but is_valid()=False — skipping",
+                    meter_addr,
+                )
+                continue
+            caps.meter_addresses.append(meter_addr)
         _logger.info(
             "detect: meter_addresses=[%s]",
             ", ".join(f"0x{a:02x}" for a in caps.meter_addresses),

--- a/tests/client/test_detect.py
+++ b/tests/client/test_detect.py
@@ -236,6 +236,15 @@ def _prime_battery_serial(client: Client, device_address: int) -> None:
     )
 
 
+def _prime_meter_voltage(client: Client, device_address: int, raw_v_phase_1: int = 2386) -> None:
+    """Prime a device cache so Meter.is_valid() returns True.
+
+    is_valid() checks v_phase_1 = IR(60), expecting a non-zero deci-volt reading.
+    Default 2386 = 238.6 V (typical UK domestic mains, taken from the wire capture in #86).
+    """
+    _prime_cache(client, device_address, {IR(60): raw_v_phase_1})
+
+
 @pytest.mark.asyncio
 async def test_detect_no_peripherals_returns_empty_lists():
     client = _make_client()
@@ -276,6 +285,9 @@ async def test_detect_finds_lv_batteries():
 async def test_detect_finds_meters():
     client = _make_client()
     _prime_cache(client, 0x32, {HR(0): 0x2001, HR(21): 0})
+    # Prime IR(60) on the responding meters so Meter.is_valid() passes.
+    _prime_meter_voltage(client, 0x01)
+    _prime_meter_voltage(client, 0x03)
 
     meter_addresses = {0x01, 0x03}
 
@@ -287,6 +299,138 @@ async def test_detect_finds_meters():
             caps = await client.detect()
 
     assert caps.meter_addresses == [0x01, 0x03]
+
+
+@pytest.mark.asyncio
+async def test_detect_cold_filters_empty_meter_slots():
+    """EMS firmwares can ACK every slot in 0x01..0x08 even when no meter is wired.
+
+    Real meters report a non-zero v_phase_1; empty slots ACK but report zeros. The
+    filter should drop the empty slots so they don't end up as ghost Meter objects
+    in plant.meters. Regression: #95 item 1 (wire evidence in #86).
+    """
+    client = _make_client()
+    _prime_cache(client, 0x32, {HR(0): 0x2001, HR(21): 0})
+    # Real meters at 0x01 and 0x03 (mirrors Nick's grid + load CTs).
+    _prime_meter_voltage(client, 0x01)
+    _prime_meter_voltage(client, 0x03)
+    # Empty-but-ACK'd slots at 0x07 and 0x08 — primed with zeros explicitly.
+    _prime_cache(client, 0x07, {IR(60): 0})
+    _prime_cache(client, 0x08, {IR(60): 0})
+
+    # All four addresses respond to the probe; only the valid pair survives the filter.
+    responding = {0x01, 0x03, 0x07, 0x08}
+
+    async def _probe_side_effect(request, *, timeout, retries):
+        return request.device_address in responding
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
+        with patch.object(client, "_probe", side_effect=_probe_side_effect):
+            caps = await client.detect()
+
+    assert caps.meter_addresses == [0x01, 0x03]
+
+
+@pytest.mark.asyncio
+async def test_detect_cold_handles_non_contiguous_meters():
+    """The meter filter is per-slot, not break-on-fail.
+
+    Meters can be non-contiguous (Nick's installation has 0x01 and 0x03 populated
+    with 0x02 absent). A real meter following an empty slot must still be discovered.
+    """
+    client = _make_client()
+    _prime_cache(client, 0x32, {HR(0): 0x2001, HR(21): 0})
+    # Real meters at 0x01 and 0x05 — non-contiguous.
+    _prime_meter_voltage(client, 0x01)
+    _prime_meter_voltage(client, 0x05)
+    # Empty-but-ACK'd at 0x06–0x08.
+    for addr in (0x06, 0x07, 0x08):
+        _prime_cache(client, addr, {IR(60): 0})
+
+    # 0x02–0x04 don't respond at all; 0x01, 0x05, 0x06, 0x07, 0x08 all ACK.
+    responding = {0x01, 0x05, 0x06, 0x07, 0x08}
+
+    async def _probe_side_effect(request, *, timeout, retries):
+        return request.device_address in responding
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
+        with patch.object(client, "_probe", side_effect=_probe_side_effect):
+            caps = await client.detect()
+
+    assert caps.meter_addresses == [0x01, 0x05]
+
+
+@pytest.mark.asyncio
+async def test_detect_hinted_drops_ghost_meter_with_mismatch():
+    """Prior caps carrying a ghost address get cleaned up on next hinted detect.
+
+    Migration path for any user whose persisted prior was captured before #95
+    landed — the empty slot drops out of caps and PlantTopologyMismatch is raised,
+    which the consumer (givenergy-hass#62) auto-accepts and re-persists.
+    """
+    client = _make_client()
+    _prime_cache(client, 0x32, {HR(0): 0x2001, HR(21): 0})
+    _prime_battery_serial(client, 0x32)
+    _prime_meter_voltage(client, 0x01)
+    _prime_meter_voltage(client, 0x03)
+    # 0x07 is the ghost: cached, probes ACK, but v_phase_1 = 0.
+    _prime_cache(client, 0x07, {IR(60): 0})
+
+    prior = PlantCapabilities(
+        device_type=Model.HYBRID_GEN1,
+        meter_addresses=[0x01, 0x03, 0x07],
+        lv_battery_addresses=[0x32],
+    )
+
+    # All hinted meter addresses respond to the probe.
+    async def _probe_side_effect(request, *, timeout, retries):
+        return request.device_address in {0x01, 0x03, 0x07}
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
+        with patch.object(client, "_probe", side_effect=_probe_side_effect):
+            with pytest.raises(PlantTopologyMismatch) as exc_info:
+                await client.detect(prior=prior)
+
+    assert exc_info.value.prior is prior
+    assert exc_info.value.actual.meter_addresses == [0x01, 0x03]
+    assert client.plant.capabilities is None
+
+
+@pytest.mark.asyncio
+async def test_detect_hinted_drops_meter_with_transient_zero_voltage():
+    """A previously-valid meter reading v_phase_1=0 at the instant of hinted detect is dropped.
+
+    This is the trade-off documented in the design discussion for #95: a real meter
+    that has lost AC reference (e.g. warm restart during a grid outage) will fail
+    is_valid() at detect time. We deliberately surface this as PlantTopologyMismatch
+    rather than carrying the meter through with a transient zero — symmetry with the
+    Battery path, and the consumer (givenergy-hass#62) handles the auto-accept and
+    advisory Repairs note. Documented as a test so the choice is visible to future
+    readers rather than buried in commit history.
+    """
+    client = _make_client()
+    _prime_cache(client, 0x32, {HR(0): 0x2001, HR(21): 0})
+    _prime_battery_serial(client, 0x32)
+    # 0x01 probes ACK but v_phase_1 == 0 — the transient-zero case.
+    _prime_cache(client, 0x01, {IR(60): 0})
+
+    prior = PlantCapabilities(
+        device_type=Model.HYBRID_GEN1,
+        meter_addresses=[0x01],
+        lv_battery_addresses=[0x32],
+    )
+
+    async def _probe_side_effect(request, *, timeout, retries):
+        return request.device_address == 0x01
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
+        with patch.object(client, "_probe", side_effect=_probe_side_effect):
+            with pytest.raises(PlantTopologyMismatch) as exc_info:
+                await client.detect(prior=prior)
+
+    assert exc_info.value.prior is prior
+    assert exc_info.value.actual.meter_addresses == []
+    assert client.plant.capabilities is None
 
 
 @pytest.mark.asyncio
@@ -352,6 +496,7 @@ async def test_detect_hinted_confirms_known_layout():
     _prime_cache(client, 0x32, {HR(0): 0x2001, HR(21): 0})
     _prime_battery_serial(client, 0x32)
     _prime_battery_serial(client, 0x33)
+    _prime_meter_voltage(client, 0x01)
 
     prior = PlantCapabilities(
         device_type=Model.HYBRID_GEN1,
@@ -399,6 +544,7 @@ async def test_detect_hinted_raises_when_hinted_address_missing():
     client = _make_client()
     _prime_cache(client, 0x32, {HR(0): 0x2001, HR(21): 0})
     _prime_battery_serial(client, 0x32)
+    _prime_meter_voltage(client, 0x01)
 
     prior = PlantCapabilities(
         device_type=Model.HYBRID_GEN1,


### PR DESCRIPTION
Closes #95 item 1.

## Summary

EMS plant controllers can ACK every address in `0x01..0x08` with all-zero registers, even when no meter is wired there. `Client.detect()`'s meter-probing loop currently appends any address that responds to the probe, so those empty slots end up as ghost `Meter` objects in `plant.meters` — polled every refresh, surfacing as empty entities downstream.

Wire evidence in #86: at `0x07` and `0x08` the EMS ACKs the `IR(60,30)` probe with all-zero readings; real meters at `0x01` and `0x03` return non-zero voltage / current / power.

After a successful probe, also check `Meter.from_register_cache(cache).is_valid()` before committing the address — matching the validation convention already used for Battery (Step 4) and BCU (Step 2).

## Behaviour after this change

| Case | Outcome |
|---|---|
| Cold detect, EMS ACKs all 8 slots but only 0x01/0x03 carry real readings | `caps.meter_addresses == [0x01, 0x03]` |
| Cold detect, non-contiguous real meters (e.g. 0x01 and 0x05 with 0x06–0x08 empty) | Per-slot filter, not break-on-fail — both kept |
| Hinted detect, prior carries ghost (`[0x01, 0x03, 0x07]` from before this fix) | Ghost drops, `PlantTopologyMismatch` raised carrying `actual.meter_addresses == [0x01, 0x03]`. Migration path: `dewet22/givenergy-hass#62` auto-accepts and re-persists the clean set. |
| Hinted detect, known meter is transiently reading `v_phase_1 == 0` (e.g. warm restart during a grid outage) | Same shape: drops out, `PlantTopologyMismatch` raised, consumer auto-accepts. Trade-off documented as a test (`test_detect_hinted_drops_meter_with_transient_zero_voltage`) so the choice is visible. |

The trade-off in the last row is the same shape Battery validation has today and is the consequence of treating `is_valid()` as a library invariant rather than a consumer-policy choice. The consumer (hass#62) already owns the "is this churn acceptable?" decision via auto-accept and an advisory Repairs note.

## Tests

Four new cases:

- `test_detect_cold_filters_empty_meter_slots` — headline regression for #95
- `test_detect_cold_handles_non_contiguous_meters` — per-slot filter rather than break-on-fail
- `test_detect_hinted_drops_ghost_meter_with_mismatch` — migration path for persisted prior with ghosts
- `test_detect_hinted_drops_meter_with_transient_zero_voltage` — explicit documentation of the trade-off

Three existing tests (`test_detect_finds_meters`, `test_detect_hinted_confirms_known_layout`, `test_detect_hinted_raises_when_hinted_address_missing`) updated to prime `IR(60)` on responding meter addresses via a new `_prime_meter_voltage()` helper alongside the existing `_prime_battery_serial()`.

## Test plan

- [x] `uv run --group test pytest tests/client/test_detect.py -v` — 26 passed
- [x] `uv run --group test tox` — py314, format, lint, build all green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device detection to validate meters and filter out unresponsive or ghost meter slots for more accurate discovery
  * Enhanced detection to correctly identify non-contiguous meter addresses with gaps between responding devices
  * Fixed handling of transient meter conditions during the detection process

* **Tests**
  * Added comprehensive test coverage for meter detection across cold and hinted discovery modes
  * Includes validation of ghost meter filtering, cached invalid meter removal, and edge cases

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dewet22/givenergy-modbus/pull/96?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->