### PR TITLE
Backport #93 + #96 — EMS polling fix and empty-meter filter

### DIFF
--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -12,6 +12,7 @@ from givenergy_modbus.exceptions import CommunicationError, ExceptionBase, Plant
 from givenergy_modbus.framer import ClientFramer, Framer
 from givenergy_modbus.model.battery import Battery
 from givenergy_modbus.model.inverter import resolve_model
+from givenergy_modbus.model.meter import Meter
 from givenergy_modbus.model.plant import Plant, PlantCapabilities
 from givenergy_modbus.model.register import HR, IR
 from givenergy_modbus.model.register_cache import RegisterCache
@@ -353,14 +354,27 @@ class Client:
             )
 
         # Step 3 — meter probing. Hinted: only previously-seen addresses. Cold: full 0x01–0x08 sweep.
+        # In both modes, a probe response is necessary but not sufficient — some EMS firmwares
+        # ACK every slot in 0x01..0x08 with all-zero registers regardless of whether a meter is
+        # actually wired. Validate via Meter.is_valid() to filter those ghosts, matching the
+        # convention used for Battery and BCU validation. Per-slot (not break-on-fail) because
+        # meters can be non-contiguous (e.g. ports 1 and 3 populated, port 2 empty). See #95.
         meter_candidates = prior.meter_addresses if prior is not None else range(0x01, 0x09)
         for meter_addr in meter_candidates:
-            if await self._probe(
+            if not await self._probe(
                 ReadInputRegistersRequest(base_register=60, register_count=30, device_address=meter_addr),
                 timeout=probe_timeout,
                 retries=probe_retries,
             ):
-                caps.meter_addresses.append(meter_addr)
+                continue
+            meter_cache = self.plant.register_caches.get(meter_addr)
+            if meter_cache is None or not Meter.from_register_cache(meter_cache).is_valid():
+                _logger.debug(
+                    "detect: meter probe responded at 0x%02x but is_valid()=False — skipping",
+                    meter_addr,
+                )
+                continue
+            caps.meter_addresses.append(meter_addr)
         _logger.info(
             "detect: meter_addresses=[%s]",
             ", ".join(f"0x{a:02x}" for a in caps.meter_addresses),

--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -368,7 +368,9 @@ class Client:
 
         # Step 4 — LV battery detection. Battery #1 shares the inverter's IR bank at 0x32;
         # additional batteries are at 0x33–0x37. All slots are validated via Battery.is_valid().
-        if not caps.is_hv:
+        # Skipped for HV systems (handled at step 2) and EMS plant controllers (don't expose
+        # IR at the inverter address — wire capture confirms; see #86).
+        if not caps.is_hv and not caps.is_ems:
             await self.send_request_and_await_response(
                 ReadInputRegistersRequest(base_register=60, register_count=60, device_address=0x32),
                 timeout=timeout,
@@ -411,12 +413,22 @@ class Client:
         """Read HR configuration blocks for the inverter."""
         caps = self.plant.capabilities
         inverter = caps.inverter_address if caps else 0x32
+        is_ems = bool(caps and caps.is_ems)
+        # HR(0,60) is the identity/firmware/serial bank that every device type — including EMS —
+        # answers; it's the same bank detect() reads to identify the device. The HR(60,60),
+        # HR(120,60) and IR(120,60) banks are inverter-specific; EMS plant controllers don't
+        # expose them and the reads time out every poll. The EMS's own window at HR(2040,36)
+        # is covered by the EMS-conditional append below. See #86 (wire capture confirmed via
+        # dewet22/givenergy-hass#52).
         reqs: list[TransparentRequest] = [
             ReadHoldingRegistersRequest(base_register=0, register_count=60, device_address=inverter),
-            ReadHoldingRegistersRequest(base_register=60, register_count=60, device_address=inverter),
-            ReadHoldingRegistersRequest(base_register=120, register_count=60, device_address=inverter),
-            ReadInputRegistersRequest(base_register=120, register_count=60, device_address=inverter),
         ]
+        if not is_ems:
+            reqs += [
+                ReadHoldingRegistersRequest(base_register=60, register_count=60, device_address=inverter),
+                ReadHoldingRegistersRequest(base_register=120, register_count=60, device_address=inverter),
+                ReadInputRegistersRequest(base_register=120, register_count=60, device_address=inverter),
+            ]
         if caps:
             if caps.is_three_phase:
                 reqs += [
@@ -437,10 +449,13 @@ class Client:
         if caps is None:
             return await self.refresh_plant(full_refresh=False)
         inverter = caps.inverter_address
-        reqs: list[TransparentRequest] = [
-            ReadInputRegistersRequest(base_register=0, register_count=60, device_address=inverter),
-            ReadInputRegistersRequest(base_register=180, register_count=60, device_address=inverter),
-        ]
+        reqs: list[TransparentRequest] = []
+        # EMS plant controllers don't expose IR(0,60) or IR(180,60) — see load_config() and #86.
+        if not caps.is_ems:
+            reqs += [
+                ReadInputRegistersRequest(base_register=0, register_count=60, device_address=inverter),
+                ReadInputRegistersRequest(base_register=180, register_count=60, device_address=inverter),
+            ]
         if caps.is_three_phase:
             for base in range(1000, 1414, 60):
                 reqs.append(

--- a/tests/client/test_detect.py
+++ b/tests/client/test_detect.py
@@ -329,6 +329,28 @@ async def test_detect_hv_skips_lv_battery_probing():
 
 
 @pytest.mark.asyncio
+async def test_detect_ems_skips_lv_battery_probing():
+    """EMS plant controllers skip the LV battery probe.
+
+    They don't expose IR at the inverter address — the unconditional read at
+    IR(60,60) on 0x32 would time out every detect(). See #86.
+    """
+    client = _make_client()
+    # DTC 0x5001 → Model.EMS (first-digit prefix "5")
+    _prime_cache(client, 0x32, {HR(0): 0x5001, HR(21): 0})
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock) as mock_send:
+        with patch.object(client, "_probe", new=AsyncMock(return_value=False)):
+            caps = await client.detect()
+
+    assert caps.is_ems is True
+    assert caps.lv_battery_addresses == []
+    # Only the initial HR(0,60) read on 0x11 should have been issued — no IR(60,60) on 0x32.
+    sent = [call.args[0] for call in mock_send.call_args_list]
+    assert all(req.device_address != 0x32 for req in sent), f"detect() should not read from 0x32 for EMS; got {sent}"
+
+
+@pytest.mark.asyncio
 async def test_detect_raises_when_hr0_missing():
     """If HR(0) is absent after reading device 0x11, detect raises CommunicationError."""
     client = _make_client()

--- a/tests/client/test_detect.py
+++ b/tests/client/test_detect.py
@@ -236,6 +236,15 @@ def _prime_battery_serial(client: Client, device_address: int) -> None:
     )
 
 
+def _prime_meter_voltage(client: Client, device_address: int, raw_v_phase_1: int = 2386) -> None:
+    """Prime a device cache so Meter.is_valid() returns True.
+
+    is_valid() checks v_phase_1 = IR(60), expecting a non-zero deci-volt reading.
+    Default 2386 = 238.6 V (typical UK domestic mains, taken from the wire capture in #86).
+    """
+    _prime_cache(client, device_address, {IR(60): raw_v_phase_1})
+
+
 @pytest.mark.asyncio
 async def test_detect_no_peripherals_returns_empty_lists():
     client = _make_client()
@@ -276,6 +285,9 @@ async def test_detect_finds_lv_batteries():
 async def test_detect_finds_meters():
     client = _make_client()
     _prime_cache(client, 0x32, {HR(0): 0x2001, HR(21): 0})
+    # Prime IR(60) on the responding meters so Meter.is_valid() passes.
+    _prime_meter_voltage(client, 0x01)
+    _prime_meter_voltage(client, 0x03)
 
     meter_addresses = {0x01, 0x03}
 
@@ -287,6 +299,138 @@ async def test_detect_finds_meters():
             caps = await client.detect()
 
     assert caps.meter_addresses == [0x01, 0x03]
+
+
+@pytest.mark.asyncio
+async def test_detect_cold_filters_empty_meter_slots():
+    """EMS firmwares can ACK every slot in 0x01..0x08 even when no meter is wired.
+
+    Real meters report a non-zero v_phase_1; empty slots ACK but report zeros. The
+    filter should drop the empty slots so they don't end up as ghost Meter objects
+    in plant.meters. Regression: #95 item 1 (wire evidence in #86).
+    """
+    client = _make_client()
+    _prime_cache(client, 0x32, {HR(0): 0x2001, HR(21): 0})
+    # Real meters at 0x01 and 0x03 (mirrors Nick's grid + load CTs).
+    _prime_meter_voltage(client, 0x01)
+    _prime_meter_voltage(client, 0x03)
+    # Empty-but-ACK'd slots at 0x07 and 0x08 — primed with zeros explicitly.
+    _prime_cache(client, 0x07, {IR(60): 0})
+    _prime_cache(client, 0x08, {IR(60): 0})
+
+    # All four addresses respond to the probe; only the valid pair survives the filter.
+    responding = {0x01, 0x03, 0x07, 0x08}
+
+    async def _probe_side_effect(request, *, timeout, retries):
+        return request.device_address in responding
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
+        with patch.object(client, "_probe", side_effect=_probe_side_effect):
+            caps = await client.detect()
+
+    assert caps.meter_addresses == [0x01, 0x03]
+
+
+@pytest.mark.asyncio
+async def test_detect_cold_handles_non_contiguous_meters():
+    """The meter filter is per-slot, not break-on-fail.
+
+    Meters can be non-contiguous (Nick's installation has 0x01 and 0x03 populated
+    with 0x02 absent). A real meter following an empty slot must still be discovered.
+    """
+    client = _make_client()
+    _prime_cache(client, 0x32, {HR(0): 0x2001, HR(21): 0})
+    # Real meters at 0x01 and 0x05 — non-contiguous.
+    _prime_meter_voltage(client, 0x01)
+    _prime_meter_voltage(client, 0x05)
+    # Empty-but-ACK'd at 0x06–0x08.
+    for addr in (0x06, 0x07, 0x08):
+        _prime_cache(client, addr, {IR(60): 0})
+
+    # 0x02–0x04 don't respond at all; 0x01, 0x05, 0x06, 0x07, 0x08 all ACK.
+    responding = {0x01, 0x05, 0x06, 0x07, 0x08}
+
+    async def _probe_side_effect(request, *, timeout, retries):
+        return request.device_address in responding
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
+        with patch.object(client, "_probe", side_effect=_probe_side_effect):
+            caps = await client.detect()
+
+    assert caps.meter_addresses == [0x01, 0x05]
+
+
+@pytest.mark.asyncio
+async def test_detect_hinted_drops_ghost_meter_with_mismatch():
+    """Prior caps carrying a ghost address get cleaned up on next hinted detect.
+
+    Migration path for any user whose persisted prior was captured before #95
+    landed — the empty slot drops out of caps and PlantTopologyMismatch is raised,
+    which the consumer (givenergy-hass#62) auto-accepts and re-persists.
+    """
+    client = _make_client()
+    _prime_cache(client, 0x32, {HR(0): 0x2001, HR(21): 0})
+    _prime_battery_serial(client, 0x32)
+    _prime_meter_voltage(client, 0x01)
+    _prime_meter_voltage(client, 0x03)
+    # 0x07 is the ghost: cached, probes ACK, but v_phase_1 = 0.
+    _prime_cache(client, 0x07, {IR(60): 0})
+
+    prior = PlantCapabilities(
+        device_type=Model.HYBRID_GEN1,
+        meter_addresses=[0x01, 0x03, 0x07],
+        lv_battery_addresses=[0x32],
+    )
+
+    # All hinted meter addresses respond to the probe.
+    async def _probe_side_effect(request, *, timeout, retries):
+        return request.device_address in {0x01, 0x03, 0x07}
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
+        with patch.object(client, "_probe", side_effect=_probe_side_effect):
+            with pytest.raises(PlantTopologyMismatch) as exc_info:
+                await client.detect(prior=prior)
+
+    assert exc_info.value.prior is prior
+    assert exc_info.value.actual.meter_addresses == [0x01, 0x03]
+    assert client.plant.capabilities is None
+
+
+@pytest.mark.asyncio
+async def test_detect_hinted_drops_meter_with_transient_zero_voltage():
+    """A previously-valid meter reading v_phase_1=0 at the instant of hinted detect is dropped.
+
+    This is the trade-off documented in the design discussion for #95: a real meter
+    that has lost AC reference (e.g. warm restart during a grid outage) will fail
+    is_valid() at detect time. We deliberately surface this as PlantTopologyMismatch
+    rather than carrying the meter through with a transient zero — symmetry with the
+    Battery path, and the consumer (givenergy-hass#62) handles the auto-accept and
+    advisory Repairs note. Documented as a test so the choice is visible to future
+    readers rather than buried in commit history.
+    """
+    client = _make_client()
+    _prime_cache(client, 0x32, {HR(0): 0x2001, HR(21): 0})
+    _prime_battery_serial(client, 0x32)
+    # 0x01 probes ACK but v_phase_1 == 0 — the transient-zero case.
+    _prime_cache(client, 0x01, {IR(60): 0})
+
+    prior = PlantCapabilities(
+        device_type=Model.HYBRID_GEN1,
+        meter_addresses=[0x01],
+        lv_battery_addresses=[0x32],
+    )
+
+    async def _probe_side_effect(request, *, timeout, retries):
+        return request.device_address == 0x01
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
+        with patch.object(client, "_probe", side_effect=_probe_side_effect):
+            with pytest.raises(PlantTopologyMismatch) as exc_info:
+                await client.detect(prior=prior)
+
+    assert exc_info.value.prior is prior
+    assert exc_info.value.actual.meter_addresses == []
+    assert client.plant.capabilities is None
 
 
 @pytest.mark.asyncio
@@ -374,6 +518,7 @@ async def test_detect_hinted_confirms_known_layout():
     _prime_cache(client, 0x32, {HR(0): 0x2001, HR(21): 0})
     _prime_battery_serial(client, 0x32)
     _prime_battery_serial(client, 0x33)
+    _prime_meter_voltage(client, 0x01)
 
     prior = PlantCapabilities(
         device_type=Model.HYBRID_GEN1,
@@ -421,6 +566,7 @@ async def test_detect_hinted_raises_when_hinted_address_missing():
     client = _make_client()
     _prime_cache(client, 0x32, {HR(0): 0x2001, HR(21): 0})
     _prime_battery_serial(client, 0x32)
+    _prime_meter_voltage(client, 0x01)
 
     prior = PlantCapabilities(
         device_type=Model.HYBRID_GEN1,

--- a/tests/client/test_load_refresh.py
+++ b/tests/client/test_load_refresh.py
@@ -76,11 +76,15 @@ async def test_load_config_extended_slots():
 
 
 async def test_load_config_ems():
-    """EMS models add HR 2040–2075."""
+    """EMS plant controllers expose HR(0,60) (identity/firmware/serial) and HR(2040,36) only.
+
+    The inverter-style HR(60,60), HR(120,60) and IR(120,60) banks time out on EMS devices.
+    Regression: #86. Wire capture confirmed via dewet22/givenergy-hass#52.
+    """
     client = _client_with_caps(Model.EMS)
     with patch.object(client, "execute", new_callable=AsyncMock) as mock_exec:
         await client.load_config()
-    assert _reqs(mock_exec) == [_hr(0, 60), _hr(60, 60), _hr(120, 60), _ir(120, 60), _hr(2040, 36)]
+    assert _reqs(mock_exec) == [_hr(0, 60), _hr(2040, 36)]
 
 
 # ---------------------------------------------------------------------------
@@ -122,11 +126,17 @@ async def test_refresh_three_phase():
 
 
 async def test_refresh_ems():
-    """EMS adds IR 2040–2094 as one read of 55 registers."""
+    """EMS skips the inverter-style IR(0,60)/IR(180,60) reads — only IR 2040–2094 is requested.
+
+    Regression: #86. The IR(2040,55) append matches what the library models for EMS today;
+    the wire capture in dewet22/givenergy-hass#52 ran without populated capabilities so it
+    can't independently confirm whether the EMS responds to that bank — revisit if a
+    caps-populated capture shows otherwise.
+    """
     client = _client_with_caps(Model.EMS)
     with patch.object(client, "execute", new_callable=AsyncMock) as mock_exec:
         await client.refresh()
-    assert _reqs(mock_exec) == [_ir(0, 60), _ir(180, 60), _ir(2040, 55)]
+    assert _reqs(mock_exec) == [_ir(2040, 55)]
 
 
 async def test_refresh_gateway():


### PR DESCRIPTION
Backport of the two EMS-related fixes that landed on `main` (the 2.x stable line) so they ship on the v2.1 alpha track too.

## Picks

- **#93** — `fix(client): skip inverter-style HR/IR reads on EMS plant controllers`. `Client.detect()`, `load_config()` and `refresh()` learn `caps.is_ems` and skip the inverter-shape HR/IR banks that EMS plant controllers don't expose. Wire-verified against a real EMS in #86; resolves the timeout/coordinator-failure loop reported in [dewet22/givenergy-hass#52](https://github.com/dewet22/givenergy-hass/issues/52).

- **#96** — `fix(client): drop empty meter slots in detect() via Meter.is_valid()`. Some EMS firmwares ACK every address in `0x01..0x08` with all-zero registers regardless of whether a meter is wired. After a successful probe, `detect()` now also requires `Meter.from_register_cache(...).is_valid()` to commit the address, matching the convention already used for Battery and BCU validation. Applied symmetrically across cold and hinted modes — see #96 for the trade-off discussion.

## Why

Per the project's branch-propagation convention: bug fixes that land on `main` are evaluated for v2.1 propagation, and these are pure bug fixes with no behaviour drift between branches. Both cherry-picks applied cleanly (one auto-merge each in `client.py`, no manual conflict resolution needed).

## Verification

`uv run --group test tox` — full matrix green on the v2.1 base (py314 + format + lint + build + docs). Both squashed commits preserve their original `Changelog:` trailers so the v2.1 changelog generator will pick them up correctly on the next alpha cut.
