### PR TITLE
fix(client): extend redact() for EMS serials and IPv4 addresses

### DIFF
--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -26,28 +26,58 @@ from givenergy_modbus.pdu import (
 
 _logger = logging.getLogger(__name__)
 
-# GivEnergy serial numbers are 10 ASCII bytes: AA0000A000 (two letters, four
-# digits, one letter, three digits). Only the digits identify the unit; the
-# prefix is documented to indicate hardware family (Gen 2 vs Gen 3 vs AIO,
-# dongle vs inverter). The middle letter's semantics aren't documented — we
-# preserve it on the same principle in case it later turns out to carry
-# signal worth keeping. Zero only the digits so the family info survives for
-# diagnostics.
+# GivEnergy serial numbers are 10 ASCII bytes. Two shapes have been
+# observed in real captures:
+#
+# - Standard form `AA0000A000` (two letters, four digits, one letter,
+#   three digits) — covers inverters, dongles, batteries, meters.
+# - EMS plant controller form `AAA0000000` (three letters, seven digits)
+#   — distinct enough to warrant its own pattern.
+#
+# In both shapes only the digits identify the unit; the letter prefix
+# is documented to indicate hardware family. For the standard form the
+# middle letter is preserved on the same principle in case it later
+# turns out to carry signal worth keeping. Zero only the digits so the
+# family info survives for diagnostics.
 _SERIAL_PATTERN = re.compile(rb"([A-Z]{2})\d{4}([A-Z])\d{3}")
+_EMS_SERIAL_PATTERN = re.compile(rb"([A-Z]{3})\d{7}")
+
+# Some inverter dongles emit their network configuration as an ASCII
+# CSV inside protocol responses — observed as the WO-prefix heartbeat
+# carrying `ip,netmask,gateway` every three minutes (see #100). Per-
+# octet digit-zeroing preserves the dot-separated structure and total
+# length, consistent with the same-offset guarantee the serial
+# patterns above already make.
+_IPV4_PATTERN = re.compile(rb"\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}")
 
 Direction = Literal["rx", "tx"]
 
 
-def redact(frame: bytes) -> bytes:
-    """Replace serial-number byte runs with the unit's digits zeroed.
+def _zero_digits(match: re.Match[bytes]) -> bytes:
+    """Replace every digit in the matched span with `0`. Length-preserving."""
+    return re.sub(rb"\d", b"0", match.group(0))
 
-    Preserves the surrounding letters (the prefix carries documented family
-    info; the middle letter is preserved on the same principle, in case it
-    later turns out to be diagnostically useful). Same length, same byte
-    offsets — frame-level CRC/length fields remain consistent so offline
-    parsing tools still work on the redacted output.
+
+def redact(frame: bytes) -> bytes:
+    """Replace identifying byte runs with the unit's digits zeroed.
+
+    Currently covers:
+
+    - Standard 10-char GE serials (`AA####A###`) — letters preserved,
+      digits zeroed.
+    - EMS plant-controller serials (`AAA#######`) — letters preserved,
+      digits zeroed.
+    - IPv4 dotted-quads — dots preserved, every digit zeroed. Catches
+      LAN topology leaks like the WO-prefix dongle heartbeat (see #100).
+
+    Same length, same byte offsets across all substitutions — frame-level
+    CRC/length fields remain consistent so offline parsing tools still
+    work on the redacted output.
     """
-    return _SERIAL_PATTERN.sub(rb"\g<1>0000\g<2>000", frame)
+    frame = _SERIAL_PATTERN.sub(rb"\g<1>0000\g<2>000", frame)
+    frame = _EMS_SERIAL_PATTERN.sub(rb"\g<1>0000000", frame)
+    frame = _IPV4_PATTERN.sub(_zero_digits, frame)
+    return frame
 
 
 class Client:

--- a/tests/client/test_capture.py
+++ b/tests/client/test_capture.py
@@ -42,6 +42,72 @@ def test_redact_preserves_length_with_mixed_content():
     assert redacted == b"\x01\x02 SA0000X000 \x03\x04 SA0000Z000 \x05"
 
 
+def test_redact_ems_serial():
+    """EMS plant controller serials are redacted via a dedicated 3+7 pattern.
+
+    EMS units use a 3-letter + 7-digit format that the standard pattern
+    doesn't match (e.g. ``EMS2522018``). The dedicated pattern zeroes the
+    seven trailing digits while preserving the prefix letters.
+    """
+    frame = b"prefix EMS2522018 suffix"
+    redacted = redact(frame)
+    assert redacted == b"prefix EMS0000000 suffix"
+    assert len(redacted) == len(frame)
+
+
+def test_redact_mixed_standard_and_ems_serials():
+    """Standard and EMS serials in the same frame are each rewritten.
+
+    Either pattern leaves the other's structure alone, so a single redact()
+    call covers a frame that mentions both shapes.
+    """
+    frame = b"adapter FO2522G018 ems EMS2522018 inverter CE2231G454"
+    redacted = redact(frame)
+    assert redacted == b"adapter FO0000G000 ems EMS0000000 inverter CE0000G000"
+    assert len(redacted) == len(frame)
+
+
+def test_redact_ipv4_dotted_quad():
+    """IPv4 dotted-quad gets its digits zeroed per-octet; dots preserved.
+
+    Some inverter dongles emit network config as ASCII in protocol responses;
+    see issue #100. Same-length substitution keeps frame offsets / lengths
+    intact.
+    """
+    frame = b"prefix 192.168.4.47 suffix"
+    redacted = redact(frame)
+    assert redacted == b"prefix 000.000.0.00 suffix"
+    assert len(redacted) == len(frame)
+
+
+def test_redact_ipv4_csv_triplet():
+    """The observed WO-heartbeat shape: ip,netmask,gateway as a CSV blob."""
+    frame = b",192.168.4.47,255.255.252.0,192.168.4.1\r\n\r\n"
+    redacted = redact(frame)
+    assert redacted == b",000.000.0.00,000.000.000.0,000.000.0.0\r\n\r\n"
+    assert len(redacted) == len(frame)
+
+
+def test_redact_ipv4_mixed_with_serials():
+    """A frame containing both serial-shaped runs and IPv4 gets both redacted in one pass."""
+    frame = b"from FO2522G018 to 10.0.0.1 by EMS2522018"
+    redacted = redact(frame)
+    assert redacted == b"from FO0000G000 to 00.0.0.0 by EMS0000000"
+    assert len(redacted) == len(frame)
+
+
+def test_redact_is_idempotent():
+    """Running redact() twice yields the same output as running it once.
+
+    Important: future tooling that pipes capture data through redact() on
+    re-export shouldn't accidentally double-substitute or lose information.
+    """
+    frame = b"FO2522G018 EMS2522018 192.168.4.47"
+    once = redact(frame)
+    twice = redact(once)
+    assert once == twice
+
+
 # ---------------------------------------------------------------------------
 # Client.capture_frames integration
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Two leak categories the launch redactor pattern misses. Folding both into the same change because they're the same shape of fix — additional patterns for `client.redact()`, same per-character zero-substitution convention, same length-preservation guarantee.

## Changes

### 1. EMS-style serials (`EMS#######`)

EMS plant controllers use a 3-letter + 7-digit serial format that the existing pattern — shaped for the standard 2+4+1+3 form (`XX####X###`) — doesn't match. The unit identifier digits leaked through on every capture of an EMS plant.

Adds `_EMS_SERIAL_PATTERN` and a substitution pass in `redact()`:
- preserve the letter prefix (carries family info)
- zero the seven trailing digits
- same length, frame offsets preserved

### 2. IPv4 dotted-quads

Some inverter dongles emit their network configuration as an ASCII CSV (`ip,netmask,gateway`) inside protocol responses. Observed as the WO-prefix dongle heartbeat at three-minute intervals — full investigation in [#100](https://github.com/dewet22/givenergy-modbus/issues/100), including the dongle-firmware divergence that means only some dongles emit these frames at all.

Adds `_IPV4_PATTERN` and a per-octet digit-zeroing substitution:
- dots preserved (the dotted-quad structure remains visible)
- every digit zeroed
- same length per octet, frame offsets preserved

The pattern is intentionally permissive (`\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}`) — strict octet bounds (`(?:25[0-5]|2[0-4]\d|[01]?\d\d?)`) would catch a problem we don't have (Modbus frames don't contain ASCII strings outside the well-characterised serial and CSV cases) at substantial regex-complexity cost.

## Evidence

Across four real-world 30-minute captures from one EMS install (committed as fixtures in a separate PR):

- **906 EMS-serial substitutions** — appears in essentially every `IR(2040+)` rollup response from the plant controller
- **30 IPv4-substring substitutions** — exactly the ten WO-heartbeat frames in one inverter capture, each containing three IPv4-shaped strings

The remaining residual case (truncated GE serials at frame boundaries, e.g. `CE22` fragments left when a wire frame ends mid-serial in the `IR(2066..2085)` rollup) stays fixture-side. The broader regex needed to catch those reliably (`[A-Z]{2}\d{2,}`) has too much false-positive risk to codify in a library-wide redactor.

## Test plan

- [x] `tests/client/test_capture.py::test_redact_ems_serial` — EMS form gets zeroed
- [x] `tests/client/test_capture.py::test_redact_mixed_standard_and_ems_serials` — both serial shapes in one frame, single pass covers both
- [x] `tests/client/test_capture.py::test_redact_ipv4_dotted_quad` — single IPv4 standalone
- [x] `tests/client/test_capture.py::test_redact_ipv4_csv_triplet` — the actual observed WO-heartbeat layout (ip,netmask,gateway CSV)
- [x] `tests/client/test_capture.py::test_redact_ipv4_mixed_with_serials` — IPv4 + serials in one frame, single pass covers both
- [x] `tests/client/test_capture.py::test_redact_is_idempotent` — double-redaction stays a no-op
- [x] Existing redact tests unchanged and still passing
- [x] `uv run --group test tox` — full matrix green
