### PR TITLE
Backport #98 — unified Inverter facade for EMS-managed plant topology

### DIFF
--- a/givenergy_modbus/model/devices.py
+++ b/givenergy_modbus/model/devices.py
@@ -1,0 +1,263 @@
+"""Generic energy-topology device abstractions.
+
+These types are intentionally manufacturer- and protocol-agnostic — they
+describe the shape of devices on an energy Plant graph regardless of how
+their data is actually obtained. The GivEnergy-specific concrete decoders
+(:class:`SinglePhaseInverter`, :class:`ThreePhaseInverter`, :class:`Ems`,
+etc.) live in their own modules and populate these generic types.
+
+Phase 1 of the Plant refactor introduces :class:`Inverter` as a read-only
+facade unifying three data sources (direct register cache, EMS-rollup
+view, or both reconciled). The design discipline these shapes are
+written under — no concrete GivEnergy or Modbus types leak into the
+generic surface, so an eventual extract to a base package is a code-org
+refactor rather than an architectural redesign — is tracked alongside
+the wider refactor sketch in the v2.1 roadmap (see ``docs/v2.1-roadmap.md``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+# ``Inverter`` deliberately accepts the concrete decoders as ``Any`` because
+# the generic shape doesn't depend on their identity, only on their attribute
+# surface (``serial_number``, ``status``, ``p_inverter_out``, ``battery_soc``,
+# ``t_inverter_heatsink``). Keeping the concrete types out of the generic
+# module preserves the hoistability discipline documented in
+# ``project_plant_abstraction_direction``.
+
+DataSource = Literal["direct", "ems_rollup", "merged"]
+
+
+@dataclass(frozen=True)
+class InverterSummary:
+    """Compact runtime summary of one inverter's state.
+
+    The shape mirrors what a controller-level rollup typically exposes:
+    identity (serial number), liveness (status), instantaneous power,
+    battery charge level, and temperature. Per-PV-string / per-MPPT
+    detail is *not* here — those require a direct register cache and
+    live on the per-manufacturer concrete model.
+
+    Field names match the directly-reachable inverter surface so the
+    unified :class:`Inverter` facade can pull from either source by the
+    same attribute name (``status``, ``p_inverter_out``,
+    ``battery_soc``, ``t_inverter_heatsink``). Populated from any
+    source that knows the rollup fields. GivEnergy's EMS exposes them
+    at ``IR(2040..2094)`` and constructs one ``InverterSummary`` per
+    managed slot; other manufacturers' rollups would populate the same
+    shape from their own register / API surface.
+    """
+
+    serial_number: str
+    status: Any | None = None  # Status enum value (manufacturer-specific), or None
+    p_inverter_out: int | None = None  # active output power, W (signed)
+    battery_soc: int | None = None  # battery state of charge, 0–100
+    t_inverter_heatsink: float | None = None  # inverter heatsink temperature in °C
+
+
+class Inverter:
+    """Unified inverter facade — one node on the Plant graph.
+
+    Represents one logical inverter regardless of how its data is sourced:
+
+    - ``data_source="direct"`` — full register cache available (e.g. a
+      reachable modbus dongle on the inverter itself). Read-through to
+      the concrete model gives access to every per-PV-string and per-MPPT
+      field. Returned by :py:meth:`from_direct`.
+    - ``data_source="ems_rollup"`` — only an :class:`InverterSummary`
+      from a controller-level rollup is available ("blinded"
+      inverter — managed by an EMS but no separate dongle). Returned by
+      :py:meth:`from_summary`.
+    - ``data_source="merged"`` — both a direct cache and a summary are
+      available, reconciled by serial number. The direct source is
+      preferred for any field it knows; the summary fills gaps. Returned
+      by :py:meth:`merge`.
+
+    Phase 1 of the Plant refactor uses this purely as a read-only facade.
+    Write commands continue to flow through the manufacturer-specific
+    concrete models (e.g. :class:`SinglePhaseInverter`) — moving them
+    onto this class is reconciled with :issue:`75` in phase 2.
+
+    The class is deliberately not a Pydantic model. It's a thin
+    multiplexer over its data sources; serialisation is the consumer's
+    concern via the underlying sources.
+    """
+
+    __slots__ = ("data_source", "_direct", "_summary")
+
+    def __init__(
+        self,
+        data_source: DataSource,
+        direct: Any | None = None,
+        summary: InverterSummary | None = None,
+    ) -> None:
+        """Construct directly (prefer the factory methods).
+
+        The constructor is permissive about which source is present so
+        the class can be tested with mocks; the factories enforce the
+        invariant that ``data_source`` matches the supplied sources.
+        """
+        self.data_source = data_source
+        self._direct = direct
+        self._summary = summary
+
+    @classmethod
+    def from_direct(cls, direct: Any) -> "Inverter":
+        """Construct from a directly-reachable concrete inverter model.
+
+        ``direct`` is duck-typed: anything exposing the standard inverter
+        attribute surface (``serial_number``, ``status``,
+        ``p_inverter_out``, ``battery_soc``, ``t_inverter_heatsink``)
+        works. In practice today this is :class:`SinglePhaseInverter` or
+        :class:`ThreePhaseInverter`. Note that ``p_inverter_out`` is
+        only directly exposed on :class:`ThreePhaseInverter`;
+        single-phase direct sources will return ``None`` for that field
+        unless the rollup ``summary`` is also merged in.
+        """
+        return cls(data_source="direct", direct=direct)
+
+    @classmethod
+    def from_summary(cls, summary: InverterSummary) -> "Inverter":
+        """Construct from a rollup summary (e.g. EMS-managed, no direct dongle).
+
+        The resulting inverter is "blinded": :attr:`batteries` is empty,
+        per-PV-string fields aren't available. Consumers see the same
+        interface as a directly-reachable inverter, just with fewer
+        populated fields.
+        """
+        return cls(data_source="ems_rollup", summary=summary)
+
+    @classmethod
+    def merge(cls, direct: Any, summary: InverterSummary) -> "Inverter":
+        """Construct from a direct source reconciled with a rollup summary.
+
+        Reconciliation is the caller's responsibility (typically matching
+        on serial number at end of detect). Once merged, direct fields
+        are preferred; the summary fills any gap the direct source has.
+        """
+        return cls(data_source="merged", direct=direct, summary=summary)
+
+    # ------------------------------------------------------------------
+    # Identity
+    # ------------------------------------------------------------------
+
+    @property
+    def serial_number(self) -> str:
+        """The inverter's serial number.
+
+        Prefer the direct source (more authoritative), fall back to the
+        summary. At least one is always present by construction.
+        """
+        if self._direct is not None:
+            value = getattr(self._direct, "serial_number", None)
+            if value:
+                return value
+        if self._summary is not None:
+            return self._summary.serial_number
+        # Should be unreachable by construction, but keep the contract honest.
+        return ""
+
+    @property
+    def is_blinded(self) -> bool:
+        """True when no direct register cache is available for this inverter.
+
+        Blinded inverters expose only the controller-level rollup fields
+        (status, power, SoC, temperature, serial). Per-PV-string detail,
+        battery-level detail, and write access are all unavailable.
+        """
+        return self._direct is None
+
+    # ------------------------------------------------------------------
+    # Read-through fields
+    # ------------------------------------------------------------------
+
+    def _from_direct(self, name: str) -> Any | None:
+        if self._direct is None:
+            return None
+        return getattr(self._direct, name, None)
+
+    def _from_summary(self, name: str) -> Any | None:
+        if self._summary is None:
+            return None
+        return getattr(self._summary, name, None)
+
+    def _resolve(self, name: str) -> Any | None:
+        """Direct source preferred; summary fills gaps."""
+        value = self._from_direct(name)
+        if value is not None:
+            return value
+        return self._from_summary(name)
+
+    @property
+    def status(self) -> Any | None:
+        """Current operating status (enum value or None if unknown)."""
+        return self._resolve("status")
+
+    @property
+    def p_inverter_out(self) -> int | None:
+        """Inverter active output power in watts (signed).
+
+        Resolved from :class:`ThreePhaseInverter.p_inverter_out` on direct
+        sources, or :attr:`InverterSummary.p_inverter_out` on rollup
+        sources. Single-phase direct sources don't expose an aggregate
+        active-output field today, so this returns ``None`` for them
+        unless a rollup summary has been merged in.
+        """
+        return self._resolve("p_inverter_out")
+
+    @property
+    def battery_soc(self) -> int | None:
+        """Battery state of charge, 0–100."""
+        return self._resolve("battery_soc")
+
+    @property
+    def t_inverter_heatsink(self) -> float | None:
+        """Inverter heatsink temperature in °C."""
+        return self._resolve("t_inverter_heatsink")
+
+    # ------------------------------------------------------------------
+    # Sub-devices
+    # ------------------------------------------------------------------
+
+    @property
+    def batteries(self) -> list[Any]:
+        """List of batteries attached to this inverter.
+
+        Empty list when the inverter is blinded — we honestly do not
+        know what batteries (if any) are attached, since the EMS rollup
+        does not expose per-battery serials or SoC. Phase 2 of the Plant
+        refactor populates this from the inverter's own register cache;
+        for now phase 1 conservatively returns ``[]`` for all sources
+        because the legacy ``Plant.batteries`` accessor already serves
+        directly-reachable installs.
+        """
+        return []
+
+    # ------------------------------------------------------------------
+    # Diagnostics
+    # ------------------------------------------------------------------
+
+    @property
+    def direct(self) -> Any | None:
+        """The underlying directly-reachable inverter model, or None if blinded.
+
+        Exposed so consumers that need per-PV-string / per-MPPT fields
+        not surfaced on this facade can read through. Future-friendly:
+        when the unified surface grows, consumers can migrate off this
+        accessor at their own pace.
+        """
+        return self._direct
+
+    @property
+    def summary(self) -> InverterSummary | None:
+        """The underlying rollup summary, or None when only a direct source is present."""
+        return self._summary
+
+    def __repr__(self) -> str:
+        return (
+            f"Inverter(serial_number={self.serial_number!r}, "
+            f"data_source={self.data_source!r}, "
+            f"is_blinded={self.is_blinded})"
+        )

--- a/givenergy_modbus/model/ems.py
+++ b/givenergy_modbus/model/ems.py
@@ -2,11 +2,18 @@
 
 from pydantic import ConfigDict, create_model
 
+from givenergy_modbus.model.devices import InverterSummary
 from givenergy_modbus.model.inverter import Status
 from givenergy_modbus.model.meter import MeterStatus
 from givenergy_modbus.model.register import HR, IR, RegisterGetter
 from givenergy_modbus.model.register import Converter as C
 from givenergy_modbus.model.register import RegisterDefinition as Def
+
+# Maximum number of managed inverters an EMS firmware reports. The EMS
+# register block at IR(2045+) packs status / power / SoC / temp / serial
+# fields for slots 1..MAX_MANAGED_INVERTERS; slots beyond ``inverter_count``
+# are unpopulated and skipped by ``Ems.managed_inverters``.
+MAX_MANAGED_INVERTERS = 4
 
 
 class EmsRegisterGetter(RegisterGetter):
@@ -117,3 +124,43 @@ class Ems(_EmsBase):  # type: ignore[misc,valid-type]
     def is_valid(self) -> bool:
         """Try to detect if an EMS is present based on its attributes."""
         return self.ems_status is not None  # type: ignore[attr-defined]
+
+    @property
+    def managed_inverters(self) -> list[InverterSummary]:
+        """Return :class:`InverterSummary` for each non-empty managed-inverter slot.
+
+        The EMS rollup at IR(2045+) carries status / power / SoC / temp
+        / serial for up to :data:`MAX_MANAGED_INVERTERS` (4) slots. An
+        empty slot is identified by a missing or whitespace-only serial
+        number — mirroring the ``is_valid()`` pattern used for Meter
+        and Battery elsewhere.
+
+        Slots are returned in order (1..N), filtered to the populated
+        ones. Per-slot serial presence is the authoritative signal of
+        whether a slot is wired; ``inverter_count`` is not consulted,
+        since the serial test catches the same case more directly and
+        gracefully handles the (rare) firmware where ``inverter_count``
+        disagrees with the per-slot data.
+        """
+        summaries: list[InverterSummary] = []
+        for slot in range(1, MAX_MANAGED_INVERTERS + 1):
+            raw_serial = getattr(self, f"inverter_{slot}_serial_number", None)
+            if not raw_serial:
+                continue
+            # Strip padding before storing — the EMS pads short / empty slots with
+            # null bytes and spaces, and the *stored* value will later be compared
+            # against directly-reported inverter serials during reconciliation.
+            # Validity check and the stored value must use the same form.
+            serial = raw_serial.strip("\x00 ")
+            if not serial:
+                continue
+            summaries.append(
+                InverterSummary(
+                    serial_number=serial,
+                    status=getattr(self, f"inverter_{slot}_status", None),
+                    p_inverter_out=getattr(self, f"inverter_{slot}_power", None),
+                    battery_soc=getattr(self, f"inverter_{slot}_soc", None),
+                    t_inverter_heatsink=getattr(self, f"inverter_{slot}_temp", None),
+                )
+            )
+        return summaries

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from givenergy_modbus.model import GivEnergyBaseModel
 from givenergy_modbus.model.battery import Battery, BatteryRegisterGetter
+from givenergy_modbus.model.devices import Inverter as UnifiedInverter
 from givenergy_modbus.model.ems import Ems
 from givenergy_modbus.model.gateway import GatewayV1, GatewayV2, select_gateway
 from givenergy_modbus.model.hv_bcu import Bcu, BcuRegisterGetter, Bmu, HvStack
@@ -514,6 +515,33 @@ class Plant(GivEnergyBaseModel):
             return None
         cache = self.register_caches.get(self.capabilities.inverter_address, RegisterCache())
         return Ems.from_register_cache(cache)
+
+    @property
+    def inverters(self) -> list[UnifiedInverter]:
+        """Return one :class:`Inverter` facade per inverter in this plant.
+
+        Phase 1 of the Plant refactor — the unified surface that makes
+        EMS-managed (blinded) inverters visible without breaking the
+        existing :attr:`inverter` / :attr:`ems` accessors.
+
+        For an EMS plant: yields one :class:`Inverter` per non-empty
+        managed-inverter slot in the EMS's IR(2040+) rollup
+        (``data_source="ems_rollup"``). Direct register-cache inverters
+        on the same plant are not yet exposed here — that happens in
+        phase 2 once Multi-Client orchestration lands and free-standing
+        inverters can be reconciled with the EMS rollup by serial.
+
+        For a non-EMS plant: yields a single :class:`Inverter` wrapping
+        the existing :attr:`inverter` (``data_source="direct"``). The
+        legacy :attr:`inverter` (singular) accessor remains for
+        back-compat and continues to return the directly-decoded
+        :class:`SinglePhaseInverter` / :class:`ThreePhaseInverter`.
+
+        See ``docs/v2.1-roadmap.md`` for the wider refactor sketch.
+        """
+        if self.ems is not None:
+            return [UnifiedInverter.from_summary(s) for s in self.ems.managed_inverters]
+        return [UnifiedInverter.from_direct(self.inverter)]
 
     @property
     def gateway(self) -> GatewayV1 | GatewayV2 | None:

--- a/tests/model/test_devices.py
+++ b/tests/model/test_devices.py
@@ -237,25 +237,27 @@ def test_ems_managed_inverters_strips_serial_padding():
     that padding — comparison would silently fail if we stored the
     raw padded form.
     """
-    # Build a slot 1 with serial "XX1234A567" plus an extra trailing null and space
-    # encoded into the register block. Manually crafted to exercise the strip path:
-    # raw bytes XX1234A56 in the first 4.5 registers, then 7\x20 (space) padding,
-    # which leaves a visible padded suffix the strip() call must trim.
+    # Build slot 1 with a 9-char serial "XX1234A56" plus a trailing space byte in the
+    # last register. The raw decoded form is "XX1234A56 " (10 chars, trailing space),
+    # which is what ``Converter.string`` returns; the strip path must trim it back to
+    # "XX1234A56". Earlier revisions of this test used a 10-char serial that exactly
+    # filled the register block, leaving no padding to trim — the test passed even
+    # without the strip call. Use a partial-padding case so the strip codepath is
+    # genuinely exercised.
     values = {
         IR(2044): 1,
         IR(2066): (ord("X") << 8) | ord("X"),
         IR(2067): (ord("1") << 8) | ord("2"),
         IR(2068): (ord("3") << 8) | ord("4"),
         IR(2069): (ord("A") << 8) | ord("5"),
-        IR(2070): (ord("6") << 8) | ord("7"),
+        IR(2070): (ord("6") << 8) | ord(" "),
     }
     ems = Ems.from_register_cache(RegisterCache(values))
 
     managed = ems.managed_inverters
     assert len(managed) == 1
-    # No trailing nulls or spaces should remain.
-    assert managed[0].serial_number == "XX1234A567"
-    assert managed[0].serial_number == managed[0].serial_number.strip("\x00 ")
+    # Trailing space stripped — stored serial is the 9-char unpadded form.
+    assert managed[0].serial_number == "XX1234A56"
 
 
 def test_ems_managed_inverters_skips_whitespace_only_serials():

--- a/tests/model/test_devices.py
+++ b/tests/model/test_devices.py
@@ -1,0 +1,358 @@
+"""Tests for the unified Inverter facade and InverterSummary.
+
+Phase 1 of the Plant refactor — see ``docs/v2.1-roadmap.md`` for the
+wider design these tests verify.
+"""
+
+from givenergy_modbus.model.devices import Inverter, InverterSummary
+from givenergy_modbus.model.ems import Ems
+from givenergy_modbus.model.inverter import Model, Status
+from givenergy_modbus.model.plant import Plant, PlantCapabilities
+from givenergy_modbus.model.register import IR
+from givenergy_modbus.model.register_cache import RegisterCache
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+def _encode_serial(serial: str) -> dict[int, int]:
+    """Encode a 10-char serial as the five raw IR values the EMS rollup expects.
+
+    Slot 1 uses IR(2066..2070); callers shift the keys for other slots.
+    Returns ``{0: reg_value_0, 1: reg_value_1, ...}`` keyed by offset so
+    the caller can compose into the right slot.
+    """
+    assert len(serial) == 10, f"serial must be 10 chars, got {len(serial)}"
+    out = {}
+    for i in range(5):
+        hi = ord(serial[i * 2])
+        lo = ord(serial[i * 2 + 1])
+        out[i] = (hi << 8) | lo
+    return out
+
+
+def _add_rollup_slot(values: dict, slot: int, *, serial: str, **fields) -> dict:
+    """Add one managed-inverter slot's register values into ``values`` in place.
+
+    ``slot`` is 1-based. Optional kwargs populate the per-slot fields:
+    ``status``, ``power``, ``soc``, ``temp_deci`` (raw deci-scaled).
+
+    Mutates and returns ``values`` so callers can chain. The shared
+    bitfield register IR(2045) (which packs status for all 4 slots into
+    one word) is OR-merged with whatever is already there — necessary
+    when multiple slots are added sequentially, otherwise slot 2's
+    status would overwrite slot 1's.
+    """
+    serial_offset = 2066 + (slot - 1) * 5
+    for i, v in _encode_serial(serial).items():
+        values[IR(serial_offset + i)] = v
+    if "power" in fields:
+        # IR(2054..2057) holds inverter_N_power, slot 1 = 2054
+        values[IR(2053 + slot)] = fields["power"] & 0xFFFF
+    if "soc" in fields:
+        # IR(2058..2061) holds inverter_N_soc, slot 1 = 2058
+        values[IR(2057 + slot)] = fields["soc"]
+    if "temp_deci" in fields:
+        # IR(2062..2065) holds inverter_N_temp at C.deci scaling
+        values[IR(2061 + slot)] = fields["temp_deci"]
+    if "status" in fields:
+        # IR(2045) packs 4 inverter statuses as 3-bit fields. Converter.bitfield
+        # extracts MSB-first: bitfield(low=0, high=2) reads ``val >> (15 - high)``,
+        # i.e. bits 15..13 for slot 1. So shifts are 13, 10, 7, 4 for slots 1..4.
+        shift = 13 - (slot - 1) * 3
+        values[IR(2045)] = values.get(IR(2045), 0) | ((fields["status"] & 0x7) << shift)
+    return values
+
+
+# ---------------------------------------------------------------------------
+# InverterSummary
+# ---------------------------------------------------------------------------
+
+
+def test_inverter_summary_construction():
+    """Dataclass holds the five summary fields plus optional defaults."""
+    s = InverterSummary(serial_number="XX1234A567")
+    assert s.serial_number == "XX1234A567"
+    assert s.status is None
+    assert s.p_inverter_out is None
+    assert s.battery_soc is None
+    assert s.t_inverter_heatsink is None
+
+    s2 = InverterSummary(
+        serial_number="XX1234A567",
+        status=Status.NORMAL,
+        p_inverter_out=2500,
+        battery_soc=72,
+        t_inverter_heatsink=35.0,
+    )
+    assert s2.p_inverter_out == 2500
+    assert s2.battery_soc == 72
+
+
+# ---------------------------------------------------------------------------
+# Unified Inverter facade
+# ---------------------------------------------------------------------------
+
+
+def test_unified_inverter_from_summary_is_blinded():
+    """from_summary() produces a blinded inverter; fields resolve from the summary."""
+    s = InverterSummary(
+        serial_number="XX1234A567",
+        status=Status.NORMAL,
+        p_inverter_out=1800,
+        battery_soc=65,
+        t_inverter_heatsink=28.5,
+    )
+    inv = Inverter.from_summary(s)
+
+    assert inv.data_source == "ems_rollup"
+    assert inv.is_blinded is True
+    assert inv.serial_number == "XX1234A567"
+    assert inv.status == Status.NORMAL
+    assert inv.p_inverter_out == 1800
+    assert inv.battery_soc == 65
+    assert inv.t_inverter_heatsink == 28.5
+
+    # Blinded inverters honestly report no batteries — see plan, not stubs.
+    assert inv.batteries == []
+    assert inv.direct is None
+    assert inv.summary is s
+
+
+def test_unified_inverter_from_direct_not_blinded():
+    """from_direct() produces a not-blinded inverter that reads through to the source."""
+
+    class FakeDirect:
+        serial_number = "ZZ9876B543"
+        status = Status.NORMAL
+        battery_soc = 88
+        t_inverter_heatsink = 31.2
+        # p_inverter_out intentionally absent — single-phase direct sources don't expose it.
+
+    inv = Inverter.from_direct(FakeDirect())
+
+    assert inv.data_source == "direct"
+    assert inv.is_blinded is False
+    assert inv.serial_number == "ZZ9876B543"
+    assert inv.battery_soc == 88
+    assert inv.t_inverter_heatsink == 31.2
+    # p_inverter_out not exposed on single-phase direct → resolves to None
+    assert inv.p_inverter_out is None
+    assert inv.summary is None
+
+
+def test_unified_inverter_merge_prefers_direct_then_summary():
+    """merge() prefers the direct source per-field; the summary fills only what's missing."""
+
+    class FakeDirect:
+        serial_number = "ZZ9876B543"
+        status = Status.NORMAL
+        battery_soc = 90
+        t_inverter_heatsink = 30.0
+        # p_inverter_out missing on direct — summary should fill it.
+
+    summary = InverterSummary(
+        serial_number="ZZ9876B543",
+        status=Status.WAITING,  # superseded by direct
+        p_inverter_out=2200,  # only source — fills the gap
+        battery_soc=65,  # superseded by direct
+        t_inverter_heatsink=27.0,  # superseded by direct
+    )
+
+    inv = Inverter.merge(FakeDirect(), summary)
+
+    assert inv.data_source == "merged"
+    assert inv.is_blinded is False  # direct present
+    # Direct preferred where present:
+    assert inv.status == Status.NORMAL
+    assert inv.battery_soc == 90
+    assert inv.t_inverter_heatsink == 30.0
+    # Summary fills the gap direct can't:
+    assert inv.p_inverter_out == 2200
+
+
+def test_blinded_inverter_reports_empty_batteries():
+    """Regression-style: a blinded inverter must return an empty battery list, not stubs.
+
+    The EMS rollup doesn't expose per-battery serials/SoC/cell voltages,
+    so honestly answering "we cannot see batteries from here" is the
+    contract. Consumers iterating ``inverter.batteries`` see an empty
+    iterable rather than fake ``is_valid=False`` placeholders.
+    """
+    inv = Inverter.from_summary(InverterSummary(serial_number="XX1234A567"))
+    assert inv.batteries == []
+
+
+# ---------------------------------------------------------------------------
+# Ems.managed_inverters
+# ---------------------------------------------------------------------------
+
+
+def test_ems_managed_inverters_constructs_summaries_per_populated_slot():
+    """Ems.managed_inverters yields one InverterSummary per non-empty slot."""
+    values: dict = {IR(2044): 2}  # inverter_count = 2
+    _add_rollup_slot(
+        values,
+        1,
+        serial="XX1234A567",
+        power=1800,
+        soc=65,
+        temp_deci=285,  # 28.5 °C (deci scaling)
+        status=Status.NORMAL.value,
+    )
+    _add_rollup_slot(
+        values,
+        2,
+        serial="ZZ9876B543",
+        power=2200,
+        soc=78,
+        temp_deci=312,
+        status=Status.NORMAL.value,
+    )
+    ems = Ems.from_register_cache(RegisterCache(values))
+
+    managed = ems.managed_inverters
+    assert len(managed) == 2
+    assert managed[0].serial_number == "XX1234A567"
+    # Asserting on status as well as the simpler fields guards the bitfield
+    # encode/decode contract — the bit positions for the per-slot status
+    # fields are MSB-first (see ``Converter.bitfield``), so a regression in
+    # the encoder shift direction or in the decoder slice would surface here.
+    assert managed[0].status == Status.NORMAL
+    assert managed[0].p_inverter_out == 1800
+    assert managed[0].battery_soc == 65
+    assert managed[0].t_inverter_heatsink == 28.5
+    assert managed[1].serial_number == "ZZ9876B543"
+    assert managed[1].status == Status.NORMAL
+    assert managed[1].p_inverter_out == 2200
+
+
+def test_ems_managed_inverters_strips_serial_padding():
+    """Serial numbers with trailing null / space padding must be stripped before storage.
+
+    The EMS pads short or empty serials with null bytes. The stored
+    ``InverterSummary.serial_number`` is used later for reconciliation
+    against directly-reported inverter serials, which arrive without
+    that padding — comparison would silently fail if we stored the
+    raw padded form.
+    """
+    # Build a slot 1 with serial "XX1234A567" plus an extra trailing null and space
+    # encoded into the register block. Manually crafted to exercise the strip path:
+    # raw bytes XX1234A56 in the first 4.5 registers, then 7\x20 (space) padding,
+    # which leaves a visible padded suffix the strip() call must trim.
+    values = {
+        IR(2044): 1,
+        IR(2066): (ord("X") << 8) | ord("X"),
+        IR(2067): (ord("1") << 8) | ord("2"),
+        IR(2068): (ord("3") << 8) | ord("4"),
+        IR(2069): (ord("A") << 8) | ord("5"),
+        IR(2070): (ord("6") << 8) | ord("7"),
+    }
+    ems = Ems.from_register_cache(RegisterCache(values))
+
+    managed = ems.managed_inverters
+    assert len(managed) == 1
+    # No trailing nulls or spaces should remain.
+    assert managed[0].serial_number == "XX1234A567"
+    assert managed[0].serial_number == managed[0].serial_number.strip("\x00 ")
+
+
+def test_ems_managed_inverters_skips_whitespace_only_serials():
+    """A slot whose serial is purely whitespace / null bytes is treated as empty.
+
+    Mirrors the strip-then-validate path that pairs with
+    test_ems_managed_inverters_strips_serial_padding — establishes that
+    the validity check operates on the same form as the stored value.
+    """
+    values = {
+        IR(2044): 1,
+        # All bytes 0x20 (space) — decodes to "          " which strips to "".
+        IR(2066): 0x2020,
+        IR(2067): 0x2020,
+        IR(2068): 0x2020,
+        IR(2069): 0x2020,
+        IR(2070): 0x2020,
+    }
+    ems = Ems.from_register_cache(RegisterCache(values))
+    assert ems.managed_inverters == []
+
+
+def test_unified_inverter_falls_through_when_direct_has_no_serial():
+    """A merged/direct facade with a missing or empty direct serial falls through to the summary.
+
+    Defensive path: protects against a partially-populated direct
+    source where the serial cache hasn't yet been read but the summary
+    has. Keeps the facade honest rather than returning an empty string.
+    """
+
+    class FakeDirect:
+        serial_number = ""  # falsy — should fall through to summary
+        status = Status.NORMAL
+
+    summary = InverterSummary(serial_number="XX1234A567", status=Status.NORMAL)
+    inv = Inverter.merge(FakeDirect(), summary)
+
+    assert inv.serial_number == "XX1234A567"
+
+
+def test_ems_managed_inverters_skips_empty_slots():
+    """Slots with empty / whitespace / null serial are filtered out.
+
+    Mirrors the Meter.is_valid() pattern: signal of "nothing wired here"
+    is a missing identity, not a separate flag.
+    """
+    values: dict = {IR(2044): 1}
+    _add_rollup_slot(values, 1, serial="XX1234A567")
+    # Slot 2 and beyond: deliberately leave serial registers unpopulated.
+    ems = Ems.from_register_cache(RegisterCache(values))
+
+    managed = ems.managed_inverters
+    assert len(managed) == 1
+    assert managed[0].serial_number == "XX1234A567"
+
+
+# ---------------------------------------------------------------------------
+# Plant.inverters
+# ---------------------------------------------------------------------------
+
+
+def test_plant_inverters_ems_returns_blinded_per_managed_slot():
+    """For an EMS plant: one blinded Inverter per managed-inverter slot.
+
+    The headline Phase 1 use case (Nick's installation): an EMS dongle
+    with two managed inverters should surface as two ``Inverter``
+    instances, each ``data_source="ems_rollup"`` and ``is_blinded=True``.
+    """
+    values: dict = {IR(2040): 1, IR(2044): 2}  # ems_status set, inverter_count = 2
+    _add_rollup_slot(values, 1, serial="XX1234A567", power=1800, soc=65)
+    _add_rollup_slot(values, 2, serial="ZZ9876B543", power=2200, soc=78)
+
+    plant = Plant()
+    plant.capabilities = PlantCapabilities(device_type=Model.EMS, inverter_address=0x32)
+    plant.register_caches[0x32] = RegisterCache(values)
+
+    inverters = plant.inverters
+    assert len(inverters) == 2
+    assert all(inv.is_blinded for inv in inverters)
+    assert all(inv.data_source == "ems_rollup" for inv in inverters)
+    serials = {inv.serial_number for inv in inverters}
+    assert serials == {"XX1234A567", "ZZ9876B543"}
+
+
+def test_plant_inverters_non_ems_returns_single_direct_inverter():
+    """For a non-EMS plant: one Inverter wrapping the directly-decoded inverter.
+
+    Back-compat shape: existing single-inverter consumers continue to
+    work via ``plant.inverter`` (singular); the new ``plant.inverters``
+    (plural) surface returns the same data wrapped in a ``data_source="direct"`` facade.
+    """
+    plant = Plant()
+    plant.capabilities = PlantCapabilities(device_type=Model.HYBRID_GEN3, inverter_address=0x32)
+
+    inverters = plant.inverters
+    assert len(inverters) == 1
+    assert inverters[0].data_source == "direct"
+    assert inverters[0].is_blinded is False
+    # The wrapped direct source is the same instance Plant.inverter returns.
+    assert inverters[0].direct is not None


### PR DESCRIPTION
Backport of [#98](https://github.com/dewet22/givenergy-modbus/pull/98) — unified `Inverter` facade and `Plant.inverters` surface — onto the v2.1 alpha track.

## Pick

- **#98** — `feat(model): unified Inverter facade for EMS-managed plant topology`. Adds `Inverter` (read-only facade with `data_source` discriminator), `InverterSummary` (compact runtime summary), `Ems.managed_inverters` (rollup → summaries), and `Plant.inverters` (computed property exposing the graph). Reads from the existing `Ems` register decode at `IR(2040..2094)`; no Client changes, no cache moves, no `PlantCapabilities` schema bump.

## Why

Per the project's branch-propagation convention: features that land on `main` are evaluated for v2.1 propagation, and this one applies cleanly — the v2.1 branch already has the prerequisite EMS-aware polling and meter-validity fixes (#93/#96 backports landed via #97). The unified surface is purely additive on either branch.

Cherry-pick auto-merged once in `plant.py` (no manual conflict resolution), and the v2.1 tox matrix is green on the backport branch.

## Verification

`uv run --group test tox` — full matrix green on the v2.1 base (py314 + format + lint + build + docs). The squashed commit preserves its original `Changelog: Added` trailer so the v2.1 changelog generator picks it up under ✨ Added on the next alpha cut.
