### PR TITLE
fix(test): exercise strip path with partial-padding serial in EMS rollup test

### DIFF
--- a/tests/model/test_devices.py
+++ b/tests/model/test_devices.py
@@ -237,25 +237,27 @@ def test_ems_managed_inverters_strips_serial_padding():
     that padding — comparison would silently fail if we stored the
     raw padded form.
     """
-    # Build a slot 1 with serial "XX1234A567" plus an extra trailing null and space
-    # encoded into the register block. Manually crafted to exercise the strip path:
-    # raw bytes XX1234A56 in the first 4.5 registers, then 7\x20 (space) padding,
-    # which leaves a visible padded suffix the strip() call must trim.
+    # Build slot 1 with a 9-char serial "XX1234A56" plus a trailing space byte in the
+    # last register. The raw decoded form is "XX1234A56 " (10 chars, trailing space),
+    # which is what ``Converter.string`` returns; the strip path must trim it back to
+    # "XX1234A56". Earlier revisions of this test used a 10-char serial that exactly
+    # filled the register block, leaving no padding to trim — the test passed even
+    # without the strip call. Use a partial-padding case so the strip codepath is
+    # genuinely exercised.
     values = {
         IR(2044): 1,
         IR(2066): (ord("X") << 8) | ord("X"),
         IR(2067): (ord("1") << 8) | ord("2"),
         IR(2068): (ord("3") << 8) | ord("4"),
         IR(2069): (ord("A") << 8) | ord("5"),
-        IR(2070): (ord("6") << 8) | ord("7"),
+        IR(2070): (ord("6") << 8) | ord(" "),
     }
     ems = Ems.from_register_cache(RegisterCache(values))
 
     managed = ems.managed_inverters
     assert len(managed) == 1
-    # No trailing nulls or spaces should remain.
-    assert managed[0].serial_number == "XX1234A567"
-    assert managed[0].serial_number == managed[0].serial_number.strip("\x00 ")
+    # Trailing space stripped — stored serial is the 9-char unpadded form.
+    assert managed[0].serial_number == "XX1234A56"
 
 
 def test_ems_managed_inverters_skips_whitespace_only_serials():


### PR DESCRIPTION
Tiny test-only fix flagged by gemini-code-assist on the v2.1 backport [#101](https://github.com/dewet22/givenergy-modbus/pull/101) — applies to main first per the project's branch-propagation convention.

## What was wrong

`test_ems_managed_inverters_strips_serial_padding` in #98 encoded a 10-character serial that exactly filled the 5-register block. Raw decoded form had no trailing nulls or spaces, so `serial.strip("\x00 ")` in `Ems.managed_inverters` was a no-op for this test. It passed whether the strip call existed or not — false sense of coverage.

## What this changes

Use a 9-character serial with a trailing space in the low byte of `IR(2070)`. The raw decoded form is now `"XX1234A56 "` (with a real trailing space) and the strip transforms it to `"XX1234A56"`. Verified by temporarily removing the strip in `ems.py` and seeing the test fail.

## Test plan

- [x] `uv run --group test pytest tests/model/test_devices.py -v` — 12 cases pass
- [x] `uv run --group test tox` — py314, format, lint, build all green
- [x] Manual proof: removed the `strip()` call in `Ems.managed_inverters` → test fails with `'XX1234A56 ' != 'XX1234A56'`. Restored.

## v2.1 propagation

Will be backported to v2.1 alongside or after the merge of #101 (the original feature backport).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for serial number padding handling to validate edge cases with partially padded serials and trailing spaces, ensuring accurate serial number trimming behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dewet22/givenergy-modbus/pull/102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->