### PR TITLE
Backport #109 — EMS rollup cross-check at detect time

### DIFF
--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -11,6 +11,7 @@ from givenergy_modbus.client import commands
 from givenergy_modbus.exceptions import CommunicationError, ExceptionBase, PlantTopologyMismatch
 from givenergy_modbus.framer import ClientFramer, Framer
 from givenergy_modbus.model.battery import Battery
+from givenergy_modbus.model.ems import EmsRegisterGetter
 from givenergy_modbus.model.inverter import resolve_model
 from givenergy_modbus.model.meter import Meter
 from givenergy_modbus.model.plant import Plant, PlantCapabilities
@@ -26,6 +27,12 @@ from givenergy_modbus.pdu import (
 )
 
 _logger = logging.getLogger(__name__)
+
+# Standard GE 10-char serial in the textual / decoded form — `[A-Z]{2}\d{4}[A-Z]\d{3}`,
+# matches both real serials (e.g. ``CE2231G454``) and the CLI-redacted form
+# (``CE0000G000``). Used to sanity-check serial strings decoded out of the EMS rollup.
+_GE_SERIAL_STR_PATTERN = re.compile(r"^[A-Z]{2}\d{4}[A-Z]\d{3}$")
+
 
 # GivEnergy serial numbers are 10 ASCII bytes. Two shapes have been
 # observed in real captures:
@@ -308,6 +315,77 @@ class Client:
                 num_modules = bcu_cache.get(IR(64)) or 0
                 caps.bcu_stacks.append((i, num_modules))
 
+    async def _ems_rollup_cross_check(self, timeout: float, retries: int) -> None:
+        """Read IR(2040,55) at detect time and sanity-check the per-managed-inverter rollup.
+
+        Populating the rollup during discovery means consumers don't need to
+        wait for the first refresh cycle to see per-managed-inverter and
+        per-meter data. The sanity check catches malformed rollups (or
+        parser regressions) early.
+
+        Best-effort end-to-end: a timeout on the read, or any anomaly during
+        validation, only logs a warning — discovery never fails on this soft
+        data check. See #95.
+        """
+        try:
+            await self.send_request_and_await_response(
+                ReadInputRegistersRequest(base_register=2040, register_count=55, device_address=0x11),
+                timeout=timeout,
+                retries=retries,
+            )
+        except TimeoutError:
+            _logger.warning("detect: EMS rollup read at IR(2040,55) timed out — skipping cross-check")
+            return
+        self._validate_ems_rollup()
+
+    def _validate_ems_rollup(self) -> None:
+        """Sanity-check the EMS IR(2040,55) rollup decoded into the inverter's register cache.
+
+        Logs warnings for any anomaly (no data, decode failure, implausible
+        ``inverter_count``, malformed serial strings) but never raises —
+        ``detect()`` shouldn't fail discovery on a soft data check. The
+        intent is to surface parser regressions early without breaking the
+        rest of the discovery flow.
+        """
+        cache = self.plant.register_caches.get(0x32)
+        if cache is None:
+            _logger.warning("detect: EMS rollup read returned no data at 0x32 — skipping cross-check")
+            return
+        try:
+            ems = EmsRegisterGetter(cache).build()
+        except Exception as e:  # noqa: BLE001 — best-effort sanity check, log and move on
+            _logger.warning("detect: EMS rollup decode failed during cross-check: %s", e)
+            return
+        inverter_count = ems.get("inverter_count")
+        if inverter_count is None or not (0 < inverter_count <= 4):
+            _logger.warning(
+                "detect: EMS rollup reports implausible inverter_count=%r (expected 1..4)",
+                inverter_count,
+            )
+            return
+        serials: list[str | None] = []
+        for i in range(1, inverter_count + 1):
+            raw = ems.get(f"inverter_{i}_serial_number")
+            # Decoded serial fields can carry trailing NUL or space padding when the
+            # underlying registers were partially populated; strip before matching so
+            # a padded-but-valid serial doesn't fire a false warning.
+            cleaned = raw.strip("\x00 ") if isinstance(raw, str) else raw
+            serials.append(cleaned)
+            if not (isinstance(cleaned, str) and _GE_SERIAL_STR_PATTERN.fullmatch(cleaned)):
+                _logger.warning(
+                    "detect: EMS rollup inverter_%d_serial_number=%r doesn't match GE serial format",
+                    i,
+                    cleaned,
+                )
+        # Decoded serials carry identifying information; keep them out of INFO-level
+        # application logs to stay consistent with the wire-capture redaction posture
+        # (`redact()` / PR #99). The per-slot WARNING already surfaces anomalies.
+        _logger.debug(
+            "detect: EMS rollup cross-check — inverter_count=%d, serials=[%s]",
+            inverter_count,
+            ", ".join(repr(s) for s in serials),
+        )
+
     async def detect(
         self,
         timeout: float = 2.0,
@@ -441,6 +519,10 @@ class Client:
                 "detect: lv_battery_addresses=[%s]",
                 ", ".join(f"0x{a:02x}" for a in caps.lv_battery_addresses),
             )
+
+        # Step 5 — EMS rollup cross-check. See `_ems_rollup_cross_check()` for the contract.
+        if caps.is_ems:
+            await self._ems_rollup_cross_check(timeout=timeout, retries=retries)
 
         if prior is not None and prior != caps:
             self.plant.capabilities = None

--- a/tests/client/test_detect.py
+++ b/tests/client/test_detect.py
@@ -245,6 +245,39 @@ def _prime_meter_voltage(client: Client, device_address: int, raw_v_phase_1: int
     _prime_cache(client, device_address, {IR(60): raw_v_phase_1})
 
 
+def _pack_serial_into_registers(serial: str, base: int) -> dict:
+    """Pack a 10-char serial string into 5 consecutive 16-bit IR registers at `base`.
+
+    Mirrors how the EMS rollup encodes per-inverter serial strings in IR(2066..2070)
+    etc. Used to prime register caches for the EMS rollup cross-check tests.
+    """
+    assert len(serial) == 10, f"GE serials are 10 chars, got {len(serial)}: {serial!r}"
+    return {IR(base + i): (ord(serial[i * 2]) << 8) | ord(serial[i * 2 + 1]) for i in range(5)}
+
+
+def _prime_ems_rollup(
+    client: Client,
+    inverter_count: int = 2,
+    serials: tuple[str, ...] = ("CE0000G000", "CE0000G000"),
+    meter_count: int = 2,
+) -> None:
+    """Prime IR(2040+) on the EMS cache with a plausible rollup payload.
+
+    Mirrors a real EMS plant: status NORMAL, the given inverter and meter counts,
+    serials packed into their canonical register slots. `serials` is a tuple of up
+    to four 10-char strings; each is packed into 5 consecutive IR registers
+    starting at IR(2066) for inverter_1, IR(2071) for inverter_2, etc.
+    """
+    rollup = {
+        IR(2040): 1,  # ems_status = NORMAL
+        IR(2041): meter_count,
+        IR(2044): inverter_count,
+    }
+    for slot, serial in enumerate(serials):
+        rollup.update(_pack_serial_into_registers(serial, 2066 + slot * 5))
+    _prime_cache(client, 0x32, rollup)
+
+
 @pytest.mark.asyncio
 async def test_detect_no_peripherals_returns_empty_lists():
     client = _make_client()
@@ -482,6 +515,8 @@ async def test_detect_ems_skips_lv_battery_probing():
     client = _make_client()
     # DTC 0x5001 → Model.EMS (first-digit prefix "5")
     _prime_cache(client, 0x32, {HR(0): 0x5001, HR(21): 0})
+    # Prime a plausible EMS rollup so the cross-check at the end of detect() is happy.
+    _prime_ems_rollup(client)
 
     with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock) as mock_send:
         with patch.object(client, "_probe", new=AsyncMock(return_value=False)):
@@ -489,9 +524,142 @@ async def test_detect_ems_skips_lv_battery_probing():
 
     assert caps.is_ems is True
     assert caps.lv_battery_addresses == []
-    # Only the initial HR(0,60) read on 0x11 should have been issued — no IR(60,60) on 0x32.
+    # No IR(60,60) at 0x32 — the LV battery probe is skipped for EMS.
     sent = [call.args[0] for call in mock_send.call_args_list]
-    assert all(req.device_address != 0x32 for req in sent), f"detect() should not read from 0x32 for EMS; got {sent}"
+    assert not any(req.device_address == 0x32 for req in sent), (
+        f"detect() should not read from 0x32 for EMS; got {sent}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_detect_ems_reads_rollup_at_detect_time():
+    """EMS detect issues an IR(2040,55) read to populate the rollup early.
+
+    Consumers don't need to wait for the first refresh cycle to see the per-managed-
+    inverter and per-meter rollup data.
+    """
+    client = _make_client()
+    _prime_cache(client, 0x32, {HR(0): 0x5001, HR(21): 0})
+    _prime_ems_rollup(client)
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock) as mock_send:
+        with patch.object(client, "_probe", new=AsyncMock(return_value=False)):
+            await client.detect()
+
+    sent = [call.args[0] for call in mock_send.call_args_list]
+    rollup_reads = [
+        req for req in sent if req.base_register == 2040 and req.register_count == 55 and req.device_address == 0x11
+    ]
+    assert len(rollup_reads) == 1, f"expected exactly one IR(2040,55) at 0x11; got {sent}"
+
+
+@pytest.mark.asyncio
+async def test_detect_ems_warns_on_implausible_inverter_count(caplog):
+    """If the rollup decodes with inverter_count outside [1, 4], log a warning rather than raise."""
+    client = _make_client()
+    _prime_cache(client, 0x32, {HR(0): 0x5001, HR(21): 0})
+    _prime_cache(client, 0x32, {IR(2044): 7})  # inverter_count = 7 — implausible
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
+        with patch.object(client, "_probe", new=AsyncMock(return_value=False)):
+            with caplog.at_level("WARNING", logger="givenergy_modbus.client.client"):
+                await client.detect()
+
+    assert any(
+        "implausible inverter_count" in rec.message and "inverter_count=7" in rec.message for rec in caplog.records
+    ), f"expected implausible-inverter_count warning; got {[r.message for r in caplog.records]}"
+
+
+@pytest.mark.asyncio
+async def test_detect_ems_tolerates_rollup_read_timeout(caplog):
+    """A timeout on the IR(2040,55) read is logged and detect() still returns caps.
+
+    The cross-check is documented as best-effort end-to-end — the read itself
+    needs to be wrapped, otherwise `send_request_and_await_response` would
+    raise `TimeoutError` before the validation helper ever ran. See #109 review.
+    """
+    client = _make_client()
+    _prime_cache(client, 0x32, {HR(0): 0x5001, HR(21): 0})
+
+    async def _send_or_timeout(request, *, timeout, retries):
+        if request.base_register == 2040 and request.register_count == 55:
+            raise TimeoutError
+
+    with patch.object(client, "send_request_and_await_response", side_effect=_send_or_timeout):
+        with patch.object(client, "_probe", new=AsyncMock(return_value=False)):
+            with caplog.at_level("WARNING", logger="givenergy_modbus.client.client"):
+                caps = await client.detect()
+
+    assert caps.is_ems is True  # detection still succeeded despite the rollup timing out
+    assert any("EMS rollup read at IR(2040,55) timed out" in rec.message for rec in caplog.records), (
+        f"expected timeout warning; got {[r.message for r in caplog.records]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_detect_ems_warns_on_missing_rollup_cache(caplog):
+    """If the cache at 0x32 is somehow missing after the rollup read, log and continue."""
+    client = _make_client()
+    # Prime HR(0)/(21) so we resolve to EMS, but clear the cache afterwards to simulate
+    # the response never landing at 0x32.
+    _prime_cache(client, 0x32, {HR(0): 0x5001, HR(21): 0})
+
+    async def _send_and_drop(request, *, timeout, retries):
+        # Simulate the rollup read silently going nowhere: drop the 0x32 cache.
+        if request.base_register == 2040 and request.register_count == 55:
+            client.plant.register_caches.pop(0x32, None)
+
+    with patch.object(client, "send_request_and_await_response", side_effect=_send_and_drop):
+        with patch.object(client, "_probe", new=AsyncMock(return_value=False)):
+            with caplog.at_level("WARNING", logger="givenergy_modbus.client.client"):
+                await client.detect()
+
+    assert any("returned no data at 0x32" in rec.message for rec in caplog.records), (
+        f"expected no-data warning; got {[r.message for r in caplog.records]}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_detect_ems_warns_on_rollup_decode_failure(caplog):
+    """A decode exception during the rollup parse is caught and logged, not raised."""
+    client = _make_client()
+    _prime_cache(client, 0x32, {HR(0): 0x5001, HR(21): 0})
+
+    # Force EmsRegisterGetter(...).build() to raise — simulates a parser regression.
+    with patch("givenergy_modbus.client.client.EmsRegisterGetter") as MockGetter:
+        MockGetter.return_value.build.side_effect = RuntimeError("simulated decode failure")
+        with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
+            with patch.object(client, "_probe", new=AsyncMock(return_value=False)):
+                with caplog.at_level("WARNING", logger="givenergy_modbus.client.client"):
+                    await client.detect()
+
+    assert any(
+        "rollup decode failed" in rec.message and "simulated decode failure" in rec.message for rec in caplog.records
+    ), f"expected decode-failure warning; got {[r.message for r in caplog.records]}"
+
+
+@pytest.mark.asyncio
+async def test_detect_ems_warns_on_malformed_serial(caplog):
+    """If a per-slot serial string doesn't match the GE 10-char format, log a warning."""
+    client = _make_client()
+    _prime_cache(client, 0x32, {HR(0): 0x5001, HR(21): 0})
+    # Inverter slot 1 has a malformed serial (junk bytes), slot 2 is a normal redacted form.
+    _prime_ems_rollup(client, inverter_count=2, serials=("!!!garbage", "CE0000G000"))
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
+        with patch.object(client, "_probe", new=AsyncMock(return_value=False)):
+            with caplog.at_level("WARNING", logger="givenergy_modbus.client.client"):
+                await client.detect()
+
+    assert any(
+        "inverter_1_serial_number" in rec.message and "doesn't match GE serial format" in rec.message
+        for rec in caplog.records
+    ), f"expected malformed-serial warning for slot 1; got {[r.message for r in caplog.records]}"
+    # Slot 2 is well-formed — no warning for it.
+    assert not any(
+        "inverter_2_serial_number" in rec.message and "doesn't match GE serial format" in rec.message
+        for rec in caplog.records
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Backport of #109 from `main` to the v2.1 alpha track.

## Picks

- **#109** — `feat(client): read EMS rollup at detect time + sanity-check it`. For EMS plant controllers, `Client.detect()` now issues an `IR(2040,55)` read so the per-managed-inverter and per-meter rollup is populated as part of discovery rather than waiting for the first refresh cycle. The decoded rollup is sanity-checked (`inverter_count` in `[1, 4]`, serial strings match `[A-Z]{2}\d{4}[A-Z]\d{3}`). Best-effort end-to-end: timeouts on the read, decode failures, or malformed values only log warnings — discovery never fails on this soft data check.

## Why

Per the project's branch-propagation convention: `feat:` / `fix:` commits that land on `main` are evaluated for v2.1 propagation. This is the third item closing out #95 (items 1 and 2 already shipped via #96 and the wire-confirmation comment respectively).

## Verification

- `uv run --group test tox` — full matrix green on the v2.1 base (py314 + format + lint + build + docs)
- Cherry-pick applied without conflict
- #109's `Changelog: Added` trailer preserved so the v2.1 changelog stays cleanly auto-generated on the next alpha cut
