### PR TITLE
fix: address inverter at its model-specific device address, not 0x32 (#119)

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -301,9 +301,15 @@ The serialised form is stable and includes a `schema_version` field:
 {
   "schema_version": 1,
   "device_type": "HYBRID",
-  "inverter_address": "0x32",
+  "inverter_address": "0x11",
   "meter_addresses": ["0x01"],
   "lv_battery_addresses": ["0x32", "0x33"],
   "bcu_stacks": []
 }
 ```
+
+`inverter_address` is derived from the model: `0x11` for most inverters, `0x31`
+for `AC` and `HYBRID_GEN1`. LV battery pack #1 lives at `0x32`, additional packs
+at `0x33`–`0x37`. State persisted before this mapping (which used `0x32` as the
+inverter address) reloads unchanged and self-heals on the next `detect()` via a
+one-off `PlantTopologyMismatch`.

--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -357,14 +357,15 @@ class Client:
         intent is to surface parser regressions early without breaking the
         rest of the discovery flow.
         """
-        cache = self.plant.register_caches.get(0x32)
-        # The cache at 0x32 is already populated by Step 1's HR(0,60) read, so `cache is None`
-        # is unreachable in practice — the meaningful check is whether the rollup's IR
-        # registers actually landed. `RegisterCache` is a defaultdict returning 0 for missing
-        # keys, so without this guard a silently-failed rollup read would decode as
-        # inverter_count=0 and mis-fire the implausible-count warning.
+        cache = self.plant.register_caches.get(0x11)
+        # EMS data is served at 0x11 (the rollup read above targets it, and Step 1's
+        # HR(0,60) read populated the same cache). `cache is None` is therefore
+        # unreachable in practice — the meaningful check is whether the rollup's IR
+        # registers actually landed. `RegisterCache` is a defaultdict returning 0 for
+        # missing keys, so without this guard a silently-failed rollup read would decode
+        # as inverter_count=0 and mis-fire the implausible-count warning.
         if cache is None or IR(2040) not in cache:
-            _logger.warning("detect: EMS rollup read returned no data at 0x32 — skipping cross-check")
+            _logger.warning("detect: EMS rollup read returned no data at 0x11 — skipping cross-check")
             return
         try:
             ems = EmsRegisterGetter(cache).build()
@@ -443,13 +444,16 @@ class Client:
             )
 
         # Step 1 — read the inverter's configuration block to get DTC and ARM firmware.
-        # 0x11 is the address used during initial discovery; plant.update() rewrites it to 0x32.
+        # 0x11 is the inverter's canonical address; discovery always reads there and the
+        # response is cached under 0x11 (issue #119). resolve_model() below maps the DTC to
+        # the model, from which PlantCapabilities derives the address used for later polling
+        # (0x11, or 0x31 for AC/HYBRID_GEN1).
         await self.send_request_and_await_response(
             ReadHoldingRegistersRequest(base_register=0, register_count=60, device_address=0x11),
             timeout=timeout,
             retries=retries,
         )
-        cache: RegisterCache = self.plant.register_caches.get(0x32, RegisterCache())
+        cache: RegisterCache = self.plant.register_caches.get(0x11, RegisterCache())
         raw_dtc = cache.get(HR(0))
         if raw_dtc is None:
             raise CommunicationError(
@@ -503,10 +507,10 @@ class Client:
             ", ".join(f"0x{a:02x}" for a in caps.meter_addresses),
         )
 
-        # Step 4 — LV battery detection. Battery #1 shares the inverter's IR bank at 0x32;
-        # additional batteries are at 0x33–0x37. All slots are validated via Battery.is_valid().
-        # Skipped for HV systems (handled at step 2) and EMS plant controllers (don't expose
-        # IR at the inverter address — wire capture confirms; see #86).
+        # Step 4 — LV battery detection. Battery pack #1 is at 0x32, additional batteries at
+        # 0x33–0x37 (the inverter itself now lives at 0x11/0x31, not 0x32 — issue #119). All
+        # slots are validated via Battery.is_valid(). Skipped for HV systems (handled at step 2)
+        # and EMS plant controllers (don't expose IR at the inverter address — see #86).
         if not caps.is_hv and not caps.is_ems:
             await self.send_request_and_await_response(
                 ReadInputRegistersRequest(base_register=60, register_count=60, device_address=0x32),

--- a/givenergy_modbus/model/inverter.py
+++ b/givenergy_modbus/model/inverter.py
@@ -214,6 +214,31 @@ def resolve_model(raw_dtc: int, arm_fw: int) -> Model:
     return _DTC_PREFIX_TO_MODEL.get(prefix, Model(dtc))
 
 
+# Models whose inverter registers are served at device address 0x31 rather than
+# the 0x11 default. Mirrors GivTCP's detect() map: it forces 0x11 during
+# detection, then switches only AC and HYBRID_GEN1 to 0x31. 0x32 is battery
+# pack #1 and is never the inverter address.
+_INVERTER_ADDRESS_0X31_MODELS: frozenset[Model] = frozenset({Model.AC, Model.HYBRID_GEN1})
+
+
+def inverter_address_for(model: Model) -> int:
+    """Return the modbus device address the inverter's registers are served at.
+
+    `0x11` is the inverter's canonical address for every model except AC and
+    HYBRID_GEN1, which expose their registers at `0x31` (GivTCP's map). EMS and
+    All-in-One controllers serve all their data — including the IR/HR(2040)
+    rollup — at `0x11`.
+
+    The `0x31` special-case is load-bearing, not a hedge: the
+    ``hybrid_2_bat_a`` fixture (HYBRID_GEN1, ARM 449) answers identity-only at
+    `0x11` and serves its full register banks at `0x31`, so the generic `0x11`
+    default would silently lose most banks for these models. If a future model
+    turns out to be firmware-dependent, this would grow an ``arm_fw`` argument
+    and key on it like ``resolve_model()`` does (issue #119).
+    """
+    return 0x31 if model in _INVERTER_ADDRESS_0X31_MODELS else 0x11
+
+
 class UsbDevice(int, Enum):
     """USB devices that can be inserted into inverters."""
 

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -10,7 +10,12 @@ from givenergy_modbus.model.devices import Inverter as UnifiedInverter
 from givenergy_modbus.model.ems import Ems
 from givenergy_modbus.model.gateway import GatewayV1, GatewayV2, select_gateway
 from givenergy_modbus.model.hv_bcu import Bcu, BcuRegisterGetter, Bmu, HvStack
-from givenergy_modbus.model.inverter import Model, SinglePhaseInverter, SinglePhaseInverterRegisterGetter
+from givenergy_modbus.model.inverter import (
+    Model,
+    SinglePhaseInverter,
+    SinglePhaseInverterRegisterGetter,
+    inverter_address_for,
+)
 from givenergy_modbus.model.inverter_threephase import ThreePhaseInverter, select_inverter
 from givenergy_modbus.model.meter import Meter, MeterRegisterGetter
 from givenergy_modbus.model.register import HR, IR, RegisterGetter
@@ -91,6 +96,41 @@ def _map_legacy_aliases(kwargs: dict[str, Any], *, stacklevel: int) -> None:
         kwargs[new] = kwargs.pop(old)
 
 
+def _coerce_model(value: Any) -> Model | None:
+    """Best-effort coerce a device_type input to a Model, or None if it can't.
+
+    Accepts a Model instance, the enum name (``"HYBRID_GEN1"``), or the enum
+    value (``"2"`` / ``2``). Returns None on failure so the caller can defer to
+    Pydantic's own field validation for the canonical error.
+    """
+    if isinstance(value, Model):
+        return value
+    try:
+        return Model[value]
+    except KeyError, TypeError:
+        pass
+    try:
+        return Model(str(value))
+    except ValueError:
+        return None
+
+
+def _derive_inverter_address(mapping: dict[str, Any]) -> None:
+    """Fill in ``inverter_address`` from ``device_type`` when not pinned explicitly.
+
+    Mutates ``mapping`` in place. 0x11 for most models, 0x31 for AC/HYBRID_GEN1
+    (issue #119). Payloads that already carry an explicit ``inverter_address``
+    (e.g. persisted state via ``from_dict``) are left untouched — so a stored
+    pre-#119 ``0x32`` surfaces as a PlantTopologyMismatch on the next detect()
+    and self-heals rather than being silently rewritten.
+    """
+    if mapping.get("inverter_address") is not None:
+        return
+    model = _coerce_model(mapping.get("device_type"))
+    if model is not None:
+        mapping["inverter_address"] = inverter_address_for(model)
+
+
 class PlantCapabilities(BaseModel):
     """Describes the hardware topology discovered by Client.detect().
 
@@ -159,6 +199,7 @@ class PlantCapabilities(BaseModel):
             return data
         normalised = dict(data)
         _map_legacy_aliases(normalised, stacklevel=2)
+        _derive_inverter_address(normalised)
         return normalised
 
     @property
@@ -369,13 +410,27 @@ class Plant(GivEnergyBaseModel):
             self.register_caches = {0x32: RegisterCache()}
 
     def _getter_for_device_address(self, device_address: int) -> type[RegisterGetter] | None:
-        """Return the RegisterGetter class appropriate for a given device address."""
-        if device_address == 0x32:
-            return SinglePhaseInverterRegisterGetter
+        """Return the RegisterGetter class appropriate for a given device address.
+
+        With capabilities the inverter lives at its model-specific address
+        (0x11, or 0x31 for AC/HYBRID_GEN1 — issue #119) and 0x32 is LV battery
+        pack #1. Without capabilities we fall back to the legacy mapping where
+        the inverter was cached at 0x32, and also treat 0x11/0x31 as inverter so
+        replay/debug tooling (which feeds PDUs to a bare Plant) keeps validating
+        inverter banks that now arrive at their true wire address.
+        """
+        if self.capabilities is not None:
+            if device_address == self.capabilities.inverter_address:
+                return SinglePhaseInverterRegisterGetter
+            if 0x32 <= device_address <= 0x37:
+                return BatteryRegisterGetter
+        else:
+            if device_address in (0x11, 0x31, 0x32):
+                return SinglePhaseInverterRegisterGetter
+            if 0x33 <= device_address <= 0x37:
+                return BatteryRegisterGetter
         if 0x01 <= device_address <= 0x08:
             return MeterRegisterGetter
-        if 0x33 <= device_address <= 0x37:
-            return BatteryRegisterGetter
         if 0x70 <= device_address <= 0x8F:
             return BcuRegisterGetter
         return None
@@ -393,11 +448,15 @@ class Plant(GivEnergyBaseModel):
             return
         _logger.debug(f"Handling {pdu}")
 
-        if pdu.device_address in (0x11, 0x00):
-            # rewrite cloud and mobile app responses to "normal" inverter address
-            device_address = 0x32
-        else:
-            device_address = pdu.device_address
+        # Store responses under their true wire device address. The old 0x11/0x00 → 0x32
+        # fold was a courtesy to GivEnergy's cloud, not an inverter requirement: querying
+        # 0x11 was relayed upstream by the dongle, and sub-5-minute polling there disturbed
+        # their 5-minute dashboards — 0x32 was the side-door that left the cloud product
+        # alone (0x00 was app traffic folded in on an assumption). Both rationales are now
+        # moot (cloud is premium-only). The fold masked that 0x11 is the inverter's
+        # canonical address and 0x32 is LV battery pack #1 (issue #119); detect() now
+        # resolves the inverter address per model and reads/caches consistently at it.
+        device_address = pdu.device_address
 
         if device_address not in self.register_caches:
             _logger.debug(f"First time encountering device address 0x{device_address:02x}")
@@ -446,11 +505,16 @@ class Plant(GivEnergyBaseModel):
 
     @property
     def inverter(self) -> SinglePhaseInverter | ThreePhaseInverter:
-        """Return the inverter model, dispatching on device type when capabilities are available."""
+        """Return the inverter model, dispatching on device type when capabilities are available.
+
+        Tolerates the inverter-address cache not yet existing — for AC/HYBRID_GEN1 the
+        address is 0x31, which detect() doesn't populate (it only reads identity at 0x11),
+        so this would otherwise KeyError between detect() and the first poll. Returns an
+        empty-cache model in that window, matching the .ems / .gateway accessors. (#119)
+        """
         if self.capabilities:
-            return select_inverter(
-                self.capabilities.device_type, self.register_caches[self.capabilities.inverter_address]
-            )
+            cache = self.register_caches.get(self.capabilities.inverter_address, RegisterCache())
+            return select_inverter(self.capabilities.device_type, cache)
         return SinglePhaseInverter.from_register_cache(self.register_caches[0x32])
 
     @property

--- a/tests/client/test_detect.py
+++ b/tests/client/test_detect.py
@@ -206,6 +206,34 @@ def test_plant_capabilities_is_hv():
     assert PlantCapabilities(device_type=Model.EMS).is_hv is False
 
 
+def test_plant_capabilities_derives_inverter_address_from_model():
+    """Without an explicit address, inverter_address derives from the model (issue #119)."""
+    assert PlantCapabilities(device_type=Model.HYBRID).inverter_address == 0x11
+    assert PlantCapabilities(device_type=Model.EMS).inverter_address == 0x11
+    assert PlantCapabilities(device_type=Model.ALL_IN_ONE).inverter_address == 0x11
+    assert PlantCapabilities(device_type=Model.AC).inverter_address == 0x31
+    assert PlantCapabilities(device_type=Model.HYBRID_GEN1).inverter_address == 0x31
+
+
+def test_plant_capabilities_explicit_address_overrides_derivation():
+    """An explicitly supplied address always wins over the model-derived default.
+
+    This is what lets a persisted pre-#119 capability (inverter_address=0x32) round-trip
+    through from_dict() unchanged, surfacing as a PlantTopologyMismatch on the next detect()
+    rather than being silently rewritten.
+    """
+    assert PlantCapabilities(device_type=Model.ALL_IN_ONE, inverter_address=0x32).inverter_address == 0x32
+    persisted = {
+        "schema_version": 1,
+        "device_type": "ALL_IN_ONE",
+        "inverter_address": "0x32",
+        "meter_addresses": [],
+        "lv_battery_addresses": [],
+        "bcu_stacks": [],
+    }
+    assert PlantCapabilities.from_dict(persisted).inverter_address == 0x32
+
+
 # ---------------------------------------------------------------------------
 # Client.detect()
 # ---------------------------------------------------------------------------
@@ -215,7 +243,7 @@ def test_plant_capabilities_is_hv():
 async def test_detect_resolves_model_from_hr0_hr21():
     client = _make_client()
     # DTC 0x2001 → "2001" prefix "20", arm_fw=300 → century 3 → HYBRID_GEN3
-    _prime_cache(client, 0x32, {HR(0): 0x2001, HR(21): 300})
+    _prime_cache(client, 0x11, {HR(0): 0x2001, HR(21): 300})
 
     with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock) as mock_req:
         mock_req.return_value = object()
@@ -275,13 +303,14 @@ def _prime_ems_rollup(
     }
     for slot, serial in enumerate(serials):
         rollup.update(_pack_serial_into_registers(serial, 2066 + slot * 5))
-    _prime_cache(client, 0x32, rollup)
+    # EMS serves all its data, including the IR(2040+) rollup, at 0x11 (issue #119).
+    _prime_cache(client, 0x11, rollup)
 
 
 @pytest.mark.asyncio
 async def test_detect_no_peripherals_returns_empty_lists():
     client = _make_client()
-    _prime_cache(client, 0x32, {HR(0): 0x2001, HR(21): 0})
+    _prime_cache(client, 0x11, {HR(0): 0x2001, HR(21): 0})
     # No battery serial primed at 0x32 → Battery.is_valid() returns False → no battery devices.
 
     with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
@@ -296,8 +325,8 @@ async def test_detect_no_peripherals_returns_empty_lists():
 @pytest.mark.asyncio
 async def test_detect_finds_lv_batteries():
     client = _make_client()
-    _prime_cache(client, 0x32, {HR(0): 0x2001, HR(21): 0})
-    # Battery #1 shares the inverter cache at 0x32; #2 is at 0x33.
+    _prime_cache(client, 0x11, {HR(0): 0x2001, HR(21): 0})
+    # Battery pack #1 is at 0x32, #2 at 0x33 (the inverter is at 0x11 — issue #119).
     _prime_battery_serial(client, 0x32)
     _prime_battery_serial(client, 0x33)
 
@@ -317,7 +346,7 @@ async def test_detect_finds_lv_batteries():
 @pytest.mark.asyncio
 async def test_detect_finds_meters():
     client = _make_client()
-    _prime_cache(client, 0x32, {HR(0): 0x2001, HR(21): 0})
+    _prime_cache(client, 0x11, {HR(0): 0x2001, HR(21): 0})
     # Prime IR(60) on the responding meters so Meter.is_valid() passes.
     _prime_meter_voltage(client, 0x01)
     _prime_meter_voltage(client, 0x03)
@@ -343,7 +372,7 @@ async def test_detect_cold_filters_empty_meter_slots():
     in plant.meters. Regression: #95 item 1 (wire evidence in #86).
     """
     client = _make_client()
-    _prime_cache(client, 0x32, {HR(0): 0x2001, HR(21): 0})
+    _prime_cache(client, 0x11, {HR(0): 0x2001, HR(21): 0})
     # Real meters at 0x01 and 0x03 (mirrors Nick's grid + load CTs).
     _prime_meter_voltage(client, 0x01)
     _prime_meter_voltage(client, 0x03)
@@ -372,7 +401,7 @@ async def test_detect_cold_handles_non_contiguous_meters():
     with 0x02 absent). A real meter following an empty slot must still be discovered.
     """
     client = _make_client()
-    _prime_cache(client, 0x32, {HR(0): 0x2001, HR(21): 0})
+    _prime_cache(client, 0x11, {HR(0): 0x2001, HR(21): 0})
     # Real meters at 0x01 and 0x05 — non-contiguous.
     _prime_meter_voltage(client, 0x01)
     _prime_meter_voltage(client, 0x05)
@@ -402,7 +431,7 @@ async def test_detect_hinted_drops_ghost_meter_with_mismatch():
     which the consumer (givenergy-hass#62) auto-accepts and re-persists.
     """
     client = _make_client()
-    _prime_cache(client, 0x32, {HR(0): 0x2001, HR(21): 0})
+    _prime_cache(client, 0x11, {HR(0): 0x2001, HR(21): 0})
     _prime_battery_serial(client, 0x32)
     _prime_meter_voltage(client, 0x01)
     _prime_meter_voltage(client, 0x03)
@@ -442,7 +471,7 @@ async def test_detect_hinted_drops_meter_with_transient_zero_voltage():
     readers rather than buried in commit history.
     """
     client = _make_client()
-    _prime_cache(client, 0x32, {HR(0): 0x2001, HR(21): 0})
+    _prime_cache(client, 0x11, {HR(0): 0x2001, HR(21): 0})
     _prime_battery_serial(client, 0x32)
     # 0x01 probes ACK but v_phase_1 == 0 — the transient-zero case.
     _prime_cache(client, 0x01, {IR(60): 0})
@@ -470,7 +499,7 @@ async def test_detect_hinted_drops_meter_with_transient_zero_voltage():
 async def test_detect_hv_probes_bcus():
     client = _make_client()
     # ALL_IN_ONE → is_hv=True
-    _prime_cache(client, 0x32, {HR(0): 0x8000, HR(21): 0})
+    _prime_cache(client, 0x11, {HR(0): 0x8000, HR(21): 0})
     # BMS at 0xA0 reports 2 BCUs via IR(61)
     _prime_cache(client, 0xA0, {IR(61): 2})
     # BCU 0 has 3 modules (IR(64)=3), BCU 1 has 2 modules
@@ -494,7 +523,7 @@ async def test_detect_hv_probes_bcus():
 @pytest.mark.asyncio
 async def test_detect_hv_skips_lv_battery_probing():
     client = _make_client()
-    _prime_cache(client, 0x32, {HR(0): 0x8000, HR(21): 0})
+    _prime_cache(client, 0x11, {HR(0): 0x8000, HR(21): 0})
     _prime_cache(client, 0xA0, {IR(61): 0})
 
     with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
@@ -514,7 +543,7 @@ async def test_detect_ems_skips_lv_battery_probing():
     """
     client = _make_client()
     # DTC 0x5001 → Model.EMS (first-digit prefix "5")
-    _prime_cache(client, 0x32, {HR(0): 0x5001, HR(21): 0})
+    _prime_cache(client, 0x11, {HR(0): 0x5001, HR(21): 0})
     # Prime a plausible EMS rollup so the cross-check at the end of detect() is happy.
     _prime_ems_rollup(client)
 
@@ -539,7 +568,7 @@ async def test_detect_ems_reads_rollup_at_detect_time():
     inverter and per-meter rollup data.
     """
     client = _make_client()
-    _prime_cache(client, 0x32, {HR(0): 0x5001, HR(21): 0})
+    _prime_cache(client, 0x11, {HR(0): 0x5001, HR(21): 0})
     _prime_ems_rollup(client)
 
     with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock) as mock_send:
@@ -557,10 +586,10 @@ async def test_detect_ems_reads_rollup_at_detect_time():
 async def test_detect_ems_warns_on_implausible_inverter_count(caplog):
     """If the rollup decodes with inverter_count outside [1, 4], log a warning rather than raise."""
     client = _make_client()
-    _prime_cache(client, 0x32, {HR(0): 0x5001, HR(21): 0})
+    _prime_cache(client, 0x11, {HR(0): 0x5001, HR(21): 0})
     # IR(2040) signals the rollup actually populated; without it the validator
     # short-circuits on the "no rollup data" path before reaching inverter_count.
-    _prime_cache(client, 0x32, {IR(2040): 1, IR(2044): 7})  # ems_status NORMAL, inverter_count = 7 — implausible
+    _prime_cache(client, 0x11, {IR(2040): 1, IR(2044): 7})  # ems_status NORMAL, inverter_count = 7 — implausible
 
     with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
         with patch.object(client, "_probe", new=AsyncMock(return_value=False)):
@@ -581,7 +610,7 @@ async def test_detect_ems_tolerates_rollup_read_timeout(caplog):
     raise `TimeoutError` before the validation helper ever ran. See #109 review.
     """
     client = _make_client()
-    _prime_cache(client, 0x32, {HR(0): 0x5001, HR(21): 0})
+    _prime_cache(client, 0x11, {HR(0): 0x5001, HR(21): 0})
 
     async def _send_or_timeout(request, *, timeout, retries):
         if request.base_register == 2040 and request.register_count == 55:
@@ -600,9 +629,9 @@ async def test_detect_ems_tolerates_rollup_read_timeout(caplog):
 
 @pytest.mark.asyncio
 async def test_detect_ems_warns_on_missing_rollup_registers(caplog):
-    """If the cache at 0x32 has HR data but no IR rollup registers, log and continue.
+    """If the cache at 0x11 has HR data but no IR rollup registers, log and continue.
 
-    Realistic shape — Step 1's HR(0,60) always populates the cache for 0x32, so the
+    Realistic shape — Step 1's HR(0,60) always populates the cache for 0x11, so the
     "cache is None" branch is unreachable at runtime. The actual failure mode is the
     rollup read silently returning no IR data: the cache exists but IR(2040+) is
     absent, in which case the defaultdict-shaped `RegisterCache` would otherwise
@@ -612,14 +641,14 @@ async def test_detect_ems_warns_on_missing_rollup_registers(caplog):
     client = _make_client()
     # HR(0)/(21) prime the EMS resolution; we deliberately don't prime IR(2040+) to
     # simulate the rollup read happening but yielding no data into the cache.
-    _prime_cache(client, 0x32, {HR(0): 0x5001, HR(21): 0})
+    _prime_cache(client, 0x11, {HR(0): 0x5001, HR(21): 0})
 
     with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
         with patch.object(client, "_probe", new=AsyncMock(return_value=False)):
             with caplog.at_level("WARNING", logger="givenergy_modbus.client.client"):
                 await client.detect()
 
-    assert any("returned no data at 0x32" in rec.message for rec in caplog.records), (
+    assert any("returned no data at 0x11" in rec.message for rec in caplog.records), (
         f"expected no-data warning; got {[r.message for r in caplog.records]}"
     )
     # Specifically should NOT log the implausible-count message — the early-out
@@ -635,7 +664,7 @@ async def test_detect_ems_warns_on_rollup_decode_failure(caplog):
     client = _make_client()
     # IR(2040) signals the rollup populated; without it the validator short-circuits
     # before reaching EmsRegisterGetter.build() and the patched failure never fires.
-    _prime_cache(client, 0x32, {HR(0): 0x5001, HR(21): 0, IR(2040): 1})
+    _prime_cache(client, 0x11, {HR(0): 0x5001, HR(21): 0, IR(2040): 1})
 
     # Force EmsRegisterGetter(...).build() to raise — simulates a parser regression.
     with patch("givenergy_modbus.client.client.EmsRegisterGetter") as MockGetter:
@@ -654,7 +683,7 @@ async def test_detect_ems_warns_on_rollup_decode_failure(caplog):
 async def test_detect_ems_warns_on_malformed_serial(caplog):
     """If a per-slot serial string doesn't match the GE 10-char format, log a warning."""
     client = _make_client()
-    _prime_cache(client, 0x32, {HR(0): 0x5001, HR(21): 0})
+    _prime_cache(client, 0x11, {HR(0): 0x5001, HR(21): 0})
     # Inverter slot 1 has a malformed serial (junk bytes), slot 2 is a normal redacted form.
     _prime_ems_rollup(client, inverter_count=2, serials=("!!!garbage", "CE0000G000"))
 
@@ -695,7 +724,7 @@ async def test_detect_raises_when_hr0_missing():
 async def test_detect_hinted_confirms_known_layout():
     """When prior matches reality, hinted detect returns equivalent caps and skips empty-slot probes."""
     client = _make_client()
-    _prime_cache(client, 0x32, {HR(0): 0x2001, HR(21): 0})
+    _prime_cache(client, 0x11, {HR(0): 0x2001, HR(21): 0})
     _prime_battery_serial(client, 0x32)
     _prime_battery_serial(client, 0x33)
     _prime_meter_voltage(client, 0x01)
@@ -726,7 +755,7 @@ async def test_detect_hinted_raises_on_device_type_change():
     """If the inverter reports a different device_type than prior, raise and clear plant.capabilities."""
     client = _make_client()
     # Hardware now reports HYBRID_GEN1 (DTC 0x2001, arm_fw=0)
-    _prime_cache(client, 0x32, {HR(0): 0x2001, HR(21): 0})
+    _prime_cache(client, 0x11, {HR(0): 0x2001, HR(21): 0})
     # Caller's prior says ALL_IN_ONE_HYBRID — a different family entirely.
     prior = PlantCapabilities(device_type=Model.ALL_IN_ONE_HYBRID)
 
@@ -744,7 +773,7 @@ async def test_detect_hinted_raises_on_device_type_change():
 async def test_detect_hinted_raises_when_hinted_address_missing():
     """If a hinted meter doesn't confirm, raise PlantTopologyMismatch carrying both views."""
     client = _make_client()
-    _prime_cache(client, 0x32, {HR(0): 0x2001, HR(21): 0})
+    _prime_cache(client, 0x11, {HR(0): 0x2001, HR(21): 0})
     _prime_battery_serial(client, 0x32)
     _prime_meter_voltage(client, 0x01)
 
@@ -772,7 +801,7 @@ async def test_detect_hinted_raises_when_hinted_address_missing():
 async def test_detect_hinted_hv_skips_bms_read():
     """Hinted HV mode probes the BCUs (skipping BMS at 0xA0) and reads actual module counts."""
     client = _make_client()
-    _prime_cache(client, 0x32, {HR(0): 0x8000, HR(21): 0})
+    _prime_cache(client, 0x11, {HR(0): 0x8000, HR(21): 0})
     # Crucially: no cache primed at 0xA0 — if hinted mode tries to read it, it'll fail downstream.
     # Prime each BCU's IR(64) so the actual-module read returns the expected count.
     _prime_cache(client, 0x70, {IR(64): 3})
@@ -801,7 +830,7 @@ async def test_detect_hinted_hv_skips_bms_read():
 async def test_detect_hinted_raises_on_bcu_module_count_drift():
     """If a BCU now reports a different module count than prior, the final topology check raises."""
     client = _make_client()
-    _prime_cache(client, 0x32, {HR(0): 0x8000, HR(21): 0})
+    _prime_cache(client, 0x11, {HR(0): 0x8000, HR(21): 0})
     # Stack 0 originally had 3 modules; it now reports 2 (a module was removed).
     _prime_cache(client, 0x70, {IR(64): 2})
     _prime_cache(client, 0x71, {IR(64): 2})

--- a/tests/client/test_load_refresh.py
+++ b/tests/client/test_load_refresh.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import AsyncMock, patch
 
+import pytest
+
 from givenergy_modbus.client.client import Client
 from givenergy_modbus.model.inverter import Model
 from givenergy_modbus.model.plant import PlantCapabilities
@@ -18,11 +20,13 @@ def _sig(req) -> tuple:
     return (type(req).__name__, req.device_address, req.base_register, req.register_count)
 
 
-def _hr(base, count, device=0x32) -> tuple:
+# 0x11 is the inverter's canonical address for every model except AC/HYBRID_GEN1
+# (which use 0x31); battery/meter reads pass an explicit device= (issue #119).
+def _hr(base, count, device=0x11) -> tuple:
     return ("ReadHoldingRegistersRequest", device, base, count)
 
 
-def _ir(base, count, device=0x32) -> tuple:
+def _ir(base, count, device=0x11) -> tuple:
     return ("ReadInputRegistersRequest", device, base, count)
 
 
@@ -36,19 +40,38 @@ def _reqs(mock_execute) -> list[tuple]:
 
 
 async def test_load_config_no_caps():
-    """Without capabilities, only the four base blocks are requested."""
+    """Without capabilities, only the four base blocks are requested, at the legacy 0x32."""
     client = Client("localhost", 8899)
     with patch.object(client, "execute", new_callable=AsyncMock) as mock_exec:
         await client.load_config()
-    assert _reqs(mock_exec) == [_hr(0, 60), _hr(60, 60), _hr(120, 60), _ir(120, 60)]
+    assert _reqs(mock_exec) == [
+        _hr(0, 60, device=0x32),
+        _hr(60, 60, device=0x32),
+        _hr(120, 60, device=0x32),
+        _ir(120, 60, device=0x32),
+    ]
 
 
 async def test_load_config_single_phase():
-    """Standard single-phase HYBRID requests the four base blocks only."""
+    """Standard single-phase HYBRID requests the four base blocks only, at 0x11."""
     client = _client_with_caps(Model.HYBRID)
     with patch.object(client, "execute", new_callable=AsyncMock) as mock_exec:
         await client.load_config()
     assert _reqs(mock_exec) == [_hr(0, 60), _hr(60, 60), _hr(120, 60), _ir(120, 60)]
+
+
+@pytest.mark.parametrize("model", [Model.AC, Model.HYBRID_GEN1])
+async def test_load_config_ac_gen1_uses_0x31(model: Model):
+    """AC and HYBRID_GEN1 both expose their registers at 0x31, not 0x11 (issue #119)."""
+    client = _client_with_caps(model)
+    with patch.object(client, "execute", new_callable=AsyncMock) as mock_exec:
+        await client.load_config()
+    assert _reqs(mock_exec) == [
+        _hr(0, 60, device=0x31),
+        _hr(60, 60, device=0x31),
+        _hr(120, 60, device=0x31),
+        _ir(120, 60, device=0x31),
+    ]
 
 
 async def test_load_config_three_phase():

--- a/tests/debug/replay.py
+++ b/tests/debug/replay.py
@@ -208,9 +208,10 @@ async def replay(
             if not isinstance(pdu, TransparentResponse) or pdu.error:
                 continue
 
+            # Store under the true wire address — Plant.update() no longer rewrites
+            # 0x11/0x00 to 0x32 (issue #119), so the harness mustn't either, or its
+            # OOB scan would read a different cache than update() wrote.
             device_address = pdu.device_address
-            if device_address in (0x11, 0x00):
-                device_address = 0x32
 
             plant.update(pdu)
             stats["committed_pdus"] += 1

--- a/tests/model/test_addressing_from_captures.py
+++ b/tests/model/test_addressing_from_captures.py
@@ -1,0 +1,101 @@
+"""Regression tests for #119 device addressing, replayed from real wire captures.
+
+Rather than synthetic register primes, these feed the committed captures in
+``tests/fixtures/captures/`` through the framer into a bare ``Plant`` and assert
+the address each topology actually serves its inverter banks at — the concrete
+``0x11`` / ``0x31`` / ``0x32`` evidence the addressing redesign turns on:
+
+- **AIO** answers at ``0x11`` and exposes nothing at ``0x32`` (root cause of #105).
+- **HYBRID_GEN1** answers identity-only at ``0x11`` and serves full banks at
+  ``0x31`` — which is why GEN1/AC map to ``0x31`` rather than the ``0x11`` default.
+- **EMS** serves its IR(2040) rollup at ``0x11``.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from givenergy_modbus.framer import ClientFramer
+from givenergy_modbus.model.plant import Plant
+from givenergy_modbus.model.register import HR, IR
+from givenergy_modbus.pdu import TransparentResponse
+
+_CAPTURES = Path(__file__).parents[1] / "fixtures" / "captures"
+
+
+def _rx_frames(relpath: str) -> list[bytes]:
+    """Read the ``rx`` frames from a ``<ts> rx <hex>`` capture log."""
+    frames: list[bytes] = []
+    for line in (_CAPTURES / relpath).read_text(encoding="utf-8").splitlines():
+        parts = line.split()
+        if len(parts) >= 3 and parts[1] == "rx":
+            try:
+                frames.append(bytes.fromhex(parts[-1]))
+            except ValueError:
+                continue
+    return frames
+
+
+async def _replay(relpath: str) -> Plant:
+    """Decode a capture's rx frames into a bare (no-capabilities) Plant.
+
+    Mirrors the offline replay harness: no detect(), so Plant.update() stores
+    each response under its true wire address with no model-aware rewriting.
+    """
+    framer = ClientFramer()
+    plant = Plant()
+    for raw in _rx_frames(relpath):
+        async for pdu in framer.decode(raw):
+            if isinstance(pdu, TransparentResponse) and not pdu.error:
+                plant.update(pdu)
+    return plant
+
+
+@pytest.mark.timeout(15)
+async def test_aio_answers_at_0x11_and_nothing_at_0x32():
+    """ALL_IN_ONE serves its inverter banks at 0x11, not 0x32.
+
+    The #105 root cause is that the old code polled 0x32, where the AIO
+    answers nothing.
+    """
+    plant = await _replay("aio_a/aio_arm612_5min.log")
+
+    assert HR(0) in plant.register_caches[0x11]
+    assert IR(0) in plant.register_caches[0x11]
+    # Nothing committed at 0x32 (only the empty default pre-alloc may exist).
+    cache_32 = plant.register_caches.get(0x32, {})
+    assert HR(0) not in cache_32
+    assert IR(0) not in cache_32
+    # The integral battery is an HV BCU stack, separately addressed.
+    assert 0x70 in plant.register_caches  # BCU
+
+
+@pytest.mark.timeout(15)
+async def test_hybrid_gen1_full_banks_at_0x31_identity_only_at_0x11():
+    """HYBRID_GEN1 serves full banks at 0x31, identity-only at 0x11.
+
+    So it must map to 0x31, not the 0x11 default (#119).
+    """
+    plant = await _replay("hybrid_2_bat_a/hybrid_gen1_arm449_givbat82_givbat95gen3_60min.log")
+
+    cache_11 = plant.register_caches.get(0x11, {})
+    cache_31 = plant.register_caches.get(0x31, {})
+    # Identity is visible at 0x11, but the full banks are not.
+    assert HR(0) in cache_11
+    assert HR(60) not in cache_11
+    # 0x31 carries the full inverter map (config HR + operational IR banks).
+    assert HR(60) in cache_31
+    assert IR(0) in cache_31
+    assert len(cache_31) > len(cache_11)
+    # LV battery packs sit at 0x32 / 0x33, distinct from the inverter.
+    assert 0x32 in plant.register_caches
+    assert 0x33 in plant.register_caches
+
+
+@pytest.mark.timeout(15)
+async def test_ems_serves_rollup_at_0x11():
+    """The EMS controller serves identity and the IR(2040) plant rollup at 0x11."""
+    plant = await _replay("ems_2_inv_3_bat_a/ems_arm1036_60s.log")
+
+    assert HR(0) in plant.register_caches[0x11]
+    assert IR(2040) in plant.register_caches[0x11]

--- a/tests/model/test_inverter.py
+++ b/tests/model/test_inverter.py
@@ -14,6 +14,7 @@ from givenergy_modbus.model.inverter import (
     SinglePhaseInverter,
     Status,
     UsbDevice,
+    inverter_address_for,
     resolve_model,
 )
 from givenergy_modbus.model.register_cache import RegisterCache
@@ -949,6 +950,31 @@ def test_model_specific_variants():
 )
 def test_resolve_model(raw_dtc, arm_fw, expected):
     assert resolve_model(raw_dtc, arm_fw) is expected
+
+
+@pytest.mark.parametrize(
+    "model,expected",
+    [
+        # 0x31 only for AC and HYBRID_GEN1 (GivTCP's map; issue #119)
+        (Model.AC, 0x31),
+        (Model.HYBRID_GEN1, 0x31),
+        # everything else at the 0x11 default
+        (Model.HYBRID, 0x11),
+        (Model.HYBRID_GEN2, 0x11),
+        (Model.HYBRID_GEN3, 0x11),
+        (Model.HYBRID_GEN4, 0x11),
+        (Model.HYBRID_3PH, 0x11),
+        (Model.AC_3PH, 0x11),
+        (Model.EMS, 0x11),
+        (Model.EMS_COMMERCIAL, 0x11),
+        (Model.GATEWAY, 0x11),
+        (Model.ALL_IN_ONE, 0x11),
+        (Model.ALL_IN_ONE_HYBRID, 0x11),
+        (Model.HYBRID_HV_GEN3, 0x11),
+    ],
+)
+def test_inverter_address_for(model, expected):
+    assert inverter_address_for(model) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -19,7 +19,12 @@ from givenergy_modbus.model.inverter import (
     Status,
 )
 from givenergy_modbus.model.inverter import UsbDevice as SinglePhaseInverterUsbDevice
-from givenergy_modbus.model.plant import Plant
+from givenergy_modbus.model.plant import (
+    Plant,
+    PlantCapabilities,
+    _coerce_model,
+    _derive_inverter_address,
+)
 from givenergy_modbus.model.register import HR, IR, Register
 from givenergy_modbus.model.register_cache import RegisterCache
 from givenergy_modbus.pdu import (
@@ -1414,6 +1419,51 @@ def test_commit_bank_unknown_device_skips_validation(plant: Plant):
     pdu = _make_ir_pdu({5: 65535}, device_address=0x99)
     plant.update(pdu)
     assert plant.register_caches[0x99].get(IR(5)) == 65535
+
+
+def test_update_stores_0x11_under_its_true_address(plant: Plant):
+    """A response at 0x11 must land in register_caches[0x11], not be rewritten to 0x32.
+
+    Regression for issue #119: the old rewrite folded 0x11/0x00 into 0x32, masking
+    that 0x11 is the inverter's canonical address and 0x32 is LV battery pack #1.
+    """
+    pdu = _make_ir_pdu({5: 2367}, device_address=0x11)
+    plant.update(pdu)
+    assert plant.register_caches[0x11].get(IR(5)) == 2367
+    assert IR(5) not in plant.register_caches.get(0x32, {})
+
+
+def test_coerce_model_accepts_instance_name_value_and_rejects_garbage():
+    """_coerce_model handles a Model instance, an enum name, an enum value, and rejects garbage."""
+    assert _coerce_model(Model.EMS) is Model.EMS
+    assert _coerce_model("HYBRID") is Model.HYBRID  # enum name
+    assert _coerce_model("2") is Model.HYBRID  # enum value (name lookup misses, value lookup hits)
+    assert _coerce_model("nonsense") is None
+    assert _coerce_model(None) is None
+
+
+def test_derive_inverter_address_fills_only_when_unpinned_and_coercible():
+    """_derive_inverter_address sets the model-derived address, never overrides an explicit one."""
+    derived = {"device_type": Model.AC}
+    _derive_inverter_address(derived)
+    assert derived["inverter_address"] == 0x31
+
+    explicit = {"device_type": Model.EMS, "inverter_address": 0x99}
+    _derive_inverter_address(explicit)
+    assert explicit["inverter_address"] == 0x99  # explicit wins
+
+    uncoercible = {"device_type": "nonsense"}
+    _derive_inverter_address(uncoercible)
+    assert "inverter_address" not in uncoercible  # left for Pydantic to reject
+
+
+def test_getter_for_device_address_with_capabilities():
+    """With capabilities, the inverter getter keys at the model's address; 0x32-0x37 are batteries (#119)."""
+    plant = Plant(capabilities=PlantCapabilities(device_type=Model.HYBRID))  # inverter at 0x11
+    assert plant._getter_for_device_address(0x11).__name__ == "SinglePhaseInverterRegisterGetter"
+    assert plant._getter_for_device_address(0x32).__name__ == "BatteryRegisterGetter"
+    assert plant._getter_for_device_address(0x05).__name__ == "MeterRegisterGetter"
+    assert plant._getter_for_device_address(0x99) is None
 
 
 def test_commit_bank_incoherent_serial_discards_bank(plant: Plant, caplog):

--- a/tests/model/test_plant_accessors.py
+++ b/tests/model/test_plant_accessors.py
@@ -39,6 +39,21 @@ def test_inverter_returns_threephase_for_threephase_model():
     assert isinstance(plant.inverter, ThreePhaseInverter)
 
 
+def test_inverter_tolerates_unpopulated_inverter_address_cache():
+    """.inverter must not KeyError when its address cache isn't populated yet.
+
+    AC/HYBRID_GEN1 resolve to inverter_address 0x31, which detect() doesn't populate
+    (it only reads identity at 0x11), so .inverter would otherwise KeyError between
+    detect() and the first poll (#119).
+    """
+    from givenergy_modbus.model.inverter import SinglePhaseInverter
+
+    plant = _plant_with_caps(device_type=Model.HYBRID_GEN1)  # derives inverter_address=0x31
+    assert plant.capabilities.inverter_address == 0x31
+    assert 0x31 not in plant.register_caches  # nothing cached there yet
+    assert isinstance(plant.inverter, SinglePhaseInverter)  # no KeyError
+
+
 # ---------------------------------------------------------------------------
 # plant.batteries — uses lv_battery_addresses when capabilities set
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Restores the inverter's device address as a model-derived value used consistently for polling, caching, and accessors, and removes the blanket `0x11/0x00 → 0x32` rewrite that masked it. Targets `v2.1`.

## What changed

- `inverter_address_for(model)` (new, in `inverter.py`): `0x31` for `AC`/`HYBRID_GEN1`, `0x11` for everything else — GivTCP's map.
- `PlantCapabilities` derives `inverter_address` from the model when not pinned; explicit/persisted addresses are preserved.
- `Plant.update()` stores responses at their true wire address (rewrite removed); `detect()` reads the DTC from `0x11`, and the EMS rollup cross-check reads there too.
- `0x32` reverts to its real meaning: LV battery pack #1.

## Why this was `0x32` to begin with

The `0x11/0x00 → 0x32` fold was never a workaround for the inverter — it was a courtesy to GivEnergy's cloud. Querying `0x11` got relayed upstream by the dongle firmware, and polling it faster than the cloud's 5-minute cadence introduced artifacts in dashboards that were only ever designed for that granularity. Routing local reads to `0x32` left the cloud product undisturbed. `0x00` was mobile-app traffic I folded in on the assumption it was equivalent — at the time I couldn't tell what it was.

Both reasons are now moot: the cloud offering is premium-only. So this restores `0x11`/`0x31` as the real per-model inverter addresses and lets `0x32` mean what it always did on the wire — LV battery pack #1.

## Evidence

Backed by the wire captures added in #120 — a regression test (`tests/model/test_addressing_from_captures.py`) replays all three topologies and asserts the addressing:

- **AIO** (`aio_a`): inverter banks at `0x11`, nothing at `0x32` — the #105 root cause.
- **HYBRID_GEN1** (`hybrid_2_bat_a`, ARM 449): identity-only at `0x11`, full banks at `0x31` — why GEN1/AC need the `0x31` special-case rather than the `0x11` default.
- **EMS** (`ems_2_inv_3_bat_a`): IR(2040) rollup at `0x11`.

## Compatibility

- The single-phase-hybrid userbase moves from `0x32` to `0x11` (or `0x31` for GEN1/AC). GivTCP polls these addresses at scale, and `battery_soc` (IR59) travels in the inverter's own bank, so nothing is lost.
- `PlantCapabilities` persisted before this change keep their stored address and self-heal as a one-off `PlantTopologyMismatch` on the next `detect()` (givenergy-hass auto-accepts).
- Writes are unchanged (already `0x11`), leaving a read/write asymmetry for AC/GEN1 (read `0x31`, write `0x11`) — noted for a follow-up if a live write test shows GEN1 needs `0x31`.

Closes #119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inverter device addressing to use correct addresses (0x11 for most models, 0x31 for AC/HYBRID_GEN1 variants).
  * Improved backward compatibility: persisted configurations with legacy addressing auto-correct during the next detection cycle.

* **Documentation**
  * Updated configuration examples with corrected device addressing mappings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dewet22/givenergy-modbus/pull/121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->