### PR TITLE
ci: run per-PR checks on Linux only, cross-OS on a weekly schedule

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -5,16 +5,44 @@ on:
     branches: ['main', 'v[0-9]+.[0-9]+']
   pull_request:
     branches: ['main', 'v[0-9]+.[0-9]+']
+  schedule:
+    # Weekly cross-OS safety net (Mondays 06:30 UTC). Per-PR CI is Linux-only;
+    # this catches macOS/Windows-specific regressions without slowing every push.
+    - cron: '30 6 * * 1'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 jobs:
   test:
+    # Canonical per-PR check: full tox (tests + ruff + mypy + bandit + build + docs).
+    # lint/build/docs are OS-independent, so they run here only.
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          python-version: '3.14'
+      - name: Build & test with tox
+        run: uv run --group test tox
+      - uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
+          files: coverage.xml
+
+  cross-os:
+    # macOS + Windows run the test env only — and only on the weekly schedule or a
+    # manual dispatch, never on a PR. lint/build/docs are OS-independent (skipped here).
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ['3.14']
-        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+        os: ['macos-latest', 'windows-latest']
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -24,11 +52,6 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-          python-version: ${{ matrix.python-version }}
-      - name: Build & test with tox
-        run: uv run --group test tox
-      - uses: codecov/codecov-action@v6
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false
-          files: coverage.xml
+          python-version: '3.14'
+      - name: Test with tox
+        run: uv run --group test tox -e py314

--- a/tests/debug/replay.py
+++ b/tests/debug/replay.py
@@ -47,7 +47,7 @@ def load_rx_frames(paths: list[Path]) -> list[tuple[str, bytes]]:
     """Read all rx frames from the given capture files, sorted by timestamp."""
     entries: list[tuple[str, bytes]] = []
     for path in paths:
-        with open(path) as f:
+        with open(path, encoding="utf-8") as f:
             for line in f:
                 m = CAPTURE_LINE.match(line.strip())
                 if not m or m.group(2) != "rx":
@@ -283,7 +283,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.output == "-":
         output = sys.stdout
     else:
-        output = open(args.output, "w")
+        output = open(args.output, "w", encoding="utf-8")
         output_owned = True
 
     print(


### PR DESCRIPTION
Trims the per-PR CI to Linux-only and moves macOS/Windows to a weekly safety net.

## Why

The matrix ran the **full** tox (tests + ruff + mypy + bandit + build + docs) on ubuntu, macOS *and* windows for every push/PR. But:

- `ruff`/`mypy`/`bandit`/`mkdocs`/`twine` are deterministic across operating systems — running them on three OSes is pure redundancy.
- The test suite mocks all socket I/O, so the one place OS genuinely matters at runtime (asyncio event loop / sockets on Windows) isn't actually exercised. The macOS/Windows legs mostly re-ran identical pure-Python logic.
- The only real cross-OS surface left is file encoding / paths — a thin slice.

For a pure-Python library that's overkill, and the Windows leg is the slow one (~2m18s vs ~45s on Linux).

## What changed

- **Per-PR / push** → a single `test` job on `ubuntu-latest` running the full tox.
- **macOS + Windows** → a `cross-os` job running the **test env only** (`tox -e py314`), gated to the weekly `schedule` (Mondays 06:30 UTC) and manual `workflow_dispatch` — never on a PR.
- Pinned the replay harness's file reads/writes to `encoding="utf-8"`, so the main cross-OS risk (Windows defaulting to cp1252) is handled in code rather than relying on the schedule to catch it.

No workflow input uses untrusted event data, so there's no injection surface.

Follow-up: cherry-pick to `v2.1` so the active 2.1 line gets the same leaner per-PR CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
