### PR TITLE
feat!: raise RefreshPartiallySucceeded/RefreshFailed on partial/total poll failure

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -17,8 +17,11 @@ async def main():
     client = Client(host="192.168.99.99", port=8899)
     await client.connect()
 
-    # Read current state first (needed for slot_map)
-    await client.refresh_plant(full_refresh=True)
+    # Detect the topology once, then read the config banks (needed for slot_map).
+    # load_config()/refresh() raise RefreshPartiallySucceeded / RefreshFailed on
+    # read failures — see "Polling the plant" below for handling.
+    await client.detect()
+    await client.load_config()
     plant = client.plant
 
     # Write configuration to the device
@@ -43,24 +46,54 @@ async def main():
 asyncio.run(main())
 ```
 
-## Watching for updates
+## Polling the plant
 
-Use `watch_plant` to keep the plant state refreshed in the background:
+Run `detect()` once after connecting, then drive your own poll loop over the
+primitives: `load_config()` reads the HR configuration banks, `refresh()` reads
+the IR measurement banks. Both return the populated `Plant` on full success, and
+raise on read failures:
+
+- `RefreshPartiallySucceeded` — some reads failed, some succeeded. The data that
+  *did* arrive is on `exc.plant`; `exc.failures` lists the dropped reads (device
+  address, request type, base register) and `exc.cause` is an `ExceptionGroup` of
+  the raw errors. This is the one chance to use the partial data — cache it,
+  surface it, count it — before deciding how to treat the gaps. How to treat them
+  is the consumer's policy, not the library's.
+- `RefreshFailed` — every read failed; the link is effectively dead and there is
+  no partial data. Treat the device as unavailable.
+
+Both share the base `RefreshError`, so a consumer that doesn't care to
+distinguish can catch that.
 
 ```python
+from givenergy_modbus.exceptions import RefreshFailed, RefreshPartiallySucceeded
+
 async def main():
     client = Client(host="192.168.99.99", port=8899)
+    await client.connect()
+    await client.detect()
 
-    def on_update():
-        print(f"SOC: {client.plant.batteries[0].soc}%")
+    while True:
+        try:
+            plant = await client.refresh()
+        except RefreshPartiallySucceeded as exc:
+            plant = exc.plant                  # use what we did collect
+            # ...consumer policy: log exc.failures, bump a counter, etc.
+        except RefreshFailed:
+            plant = None                       # mark unavailable; maybe reconnect
 
-    await client.watch_plant(handler=on_update, refresh_period=15.0)
+        if plant is not None:                  # full or partial success
+            print(f"SOC: {plant.batteries[0].soc}%")
+        await asyncio.sleep(15)
 ```
+
+> `Client.watch_plant()` and `Client.refresh_plant()` are deprecated and will be
+> removed in 3.0 — own the loop as above. They now also propagate
+> `RefreshPartiallySucceeded` / `RefreshFailed`.
 
 ## Tuning timeouts and retries
 
-`refresh_plant`, `refresh`, `load_config`, `one_shot_command` and `watch_plant` all accept
-the same three knobs:
+`refresh`, `load_config` and `one_shot_command` all accept the same three knobs:
 
 - `timeout` (default 1.0s for refresh, 1.5s for `one_shot_command`) — how long to wait for
   each response.
@@ -237,15 +270,26 @@ The library does the redaction; persistence and format are the caller's choice. 
 ```python
 from datetime import UTC, datetime
 
+from givenergy_modbus.exceptions import RefreshError
+
 with open("capture.txt", "w") as f:
     def write_line(direction, frame):
         ts = datetime.now(UTC).isoformat(timespec="microseconds")
         f.write(f"{ts} {direction} {frame.hex()}\n")
         f.flush()
     async with Client("inverter.local", 8899) as client:
-        await client.refresh_plant(full_refresh=True)
+        await client.detect()
+
+        async def poll():
+            while True:
+                try:
+                    await client.refresh()
+                except RefreshError:  # ignore partial/total failures for this capture demo
+                    pass
+                await asyncio.sleep(5)
+
         await asyncio.gather(
-            client.watch_plant(refresh_period=5),
+            poll(),
             client.capture_frames(write_line, duration=60),
         )
 ```

--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -3,12 +3,20 @@ import logging
 import random
 import re
 import socket
+import warnings
 from asyncio import Future, Queue, StreamReader, StreamWriter, Task
 from collections.abc import Callable
 from typing import Literal
 
 from givenergy_modbus.client import commands
-from givenergy_modbus.exceptions import CommunicationError, ExceptionBase, PlantTopologyMismatch
+from givenergy_modbus.exceptions import (
+    CommunicationError,
+    ExceptionBase,
+    PlantTopologyMismatch,
+    ReadFailure,
+    RefreshFailed,
+    RefreshPartiallySucceeded,
+)
 from givenergy_modbus.framer import ClientFramer, Framer
 from givenergy_modbus.model.battery import Battery
 from givenergy_modbus.model.ems import EmsRegisterGetter
@@ -554,8 +562,84 @@ class Client:
         self.plant.capabilities = caps
         return caps
 
+    async def _execute_reads(
+        self,
+        requests: list[TransparentRequest],
+        *,
+        timeout: float,
+        retries: int,
+        retry_delay: float,
+    ) -> None:
+        """Run a batch of register reads, tolerating partial failure.
+
+        Successful reads have already been written to the register caches by the
+        network consumer task, so this only decides how to *signal* the failures:
+
+        - no failures → return (the caller returns the populated plant);
+        - some failed → raise ``RefreshPartiallySucceeded`` carrying the partial
+          plant plus the structured failures — the caller's one chance to use
+          the data that did come back;
+        - all failed → raise ``RefreshFailed`` (link effectively dead).
+        """
+        if not requests:
+            return
+        results = await self.execute(
+            requests, timeout=timeout, retries=retries, retry_delay=retry_delay, return_exceptions=True
+        )
+        failures: list[ReadFailure] = []
+        causes: list[Exception] = []
+        for req, res in zip(requests, results, strict=True):
+            if isinstance(res, Exception):
+                # base_register/register_count live on read requests, which is all
+                # _execute_reads is ever handed; getattr keeps mypy happy without a
+                # never-taken else branch.
+                failures.append(
+                    ReadFailure(
+                        req.device_address,
+                        type(req).__name__,
+                        getattr(req, "base_register", 0),
+                        getattr(req, "register_count", 0),
+                    )
+                )
+                causes.append(res)
+            elif isinstance(res, BaseException):
+                # Control-flow exceptions (e.g. CancelledError) must never be swallowed.
+                raise res
+        if not failures:
+            return
+        group = ExceptionGroup(f"{len(failures)}/{len(requests)} register reads failed", causes)
+        summary = ", ".join(f"{f.request_type}(0x{f.device_address:02x},{f.base_register})" for f in failures)
+        if len(failures) == len(requests):
+            _logger.warning("All %d register reads failed; treating plant as unreachable", len(requests))
+            raise RefreshFailed(f"all {len(requests)} register reads failed", failures=failures, cause=group)
+        _logger.warning("%d of %d register reads failed: %s", len(failures), len(requests), summary)
+        raise RefreshPartiallySucceeded(
+            f"{len(failures)} of {len(requests)} register reads failed",
+            plant=self.plant,
+            failures=failures,
+            cause=group,
+        )
+
+    async def _refresh_no_caps(
+        self,
+        *,
+        full_refresh: bool,
+        max_batteries: int,
+        timeout: float,
+        retries: int,
+        retry_delay: float,
+    ) -> Plant:
+        """Legacy capability-free refresh — the pre-detect fallback shape."""
+        reqs = commands.refresh_plant_data(full_refresh, self.plant.number_batteries, max_batteries)
+        await self._execute_reads(reqs, timeout=timeout, retries=retries, retry_delay=retry_delay)
+        return self.plant
+
     async def load_config(self, timeout: float = 2.0, retries: int = 3, retry_delay: float = 0.5) -> Plant:
-        """Read HR configuration blocks for the inverter."""
+        """Read HR configuration blocks for the inverter.
+
+        Returns the populated plant on full success. On partial/total read
+        failure raises ``RefreshPartiallySucceeded`` / ``RefreshFailed``.
+        """
         caps = self.plant.capabilities
         inverter = caps.inverter_address if caps else 0x32
         is_ems = bool(caps and caps.is_ems)
@@ -585,14 +669,20 @@ class Client:
                 reqs.append(ReadHoldingRegistersRequest(base_register=240, register_count=60, device_address=inverter))
             if caps.is_ems:
                 reqs.append(ReadHoldingRegistersRequest(base_register=2040, register_count=36, device_address=inverter))
-        await self.execute(reqs, timeout=timeout, retries=retries, retry_delay=retry_delay)
+        await self._execute_reads(reqs, timeout=timeout, retries=retries, retry_delay=retry_delay)
         return self.plant
 
     async def refresh(self, timeout: float = 1.0, retries: int = 0, retry_delay: float = 0.5) -> Plant:
-        """Read IR measurement blocks for all known devices."""
+        """Read IR measurement blocks for all known devices.
+
+        Returns the populated plant on full success. On partial/total read
+        failure raises ``RefreshPartiallySucceeded`` / ``RefreshFailed``.
+        """
         caps = self.plant.capabilities
         if caps is None:
-            return await self.refresh_plant(full_refresh=False)
+            return await self._refresh_no_caps(
+                full_refresh=False, max_batteries=5, timeout=timeout, retries=retries, retry_delay=retry_delay
+            )
         inverter = caps.inverter_address
         reqs: list[TransparentRequest] = []
         # EMS plant controllers don't expose IR(0,60) or IR(180,60) — see load_config() and #86.
@@ -627,7 +717,7 @@ class Client:
             reqs.append(ReadInputRegistersRequest(base_register=60, register_count=30, device_address=addr))
         for offset, _ in caps.bcu_stacks:
             reqs.append(ReadInputRegistersRequest(base_register=60, register_count=60, device_address=0x70 + offset))
-        await self.execute(reqs, timeout=timeout, retries=retries, retry_delay=retry_delay)
+        await self._execute_reads(reqs, timeout=timeout, retries=retries, retry_delay=retry_delay)
         return self.plant
 
     async def refresh_plant(
@@ -638,15 +728,35 @@ class Client:
         retries: int = 0,
         retry_delay: float = 0.5,
     ) -> Plant:
-        """Refresh data about the Plant."""
+        """Deprecated orchestrator — run ``detect()`` once, then drive your own loop.
+
+        .. deprecated::
+            Will be removed in 3.0. This composes ``load_config()`` + ``refresh()``,
+            which is trivial to do in the consumer where the partial-failure policy
+            belongs. It now also propagates ``RefreshPartiallySucceeded`` /
+            ``RefreshFailed`` like the primitives — note that on a full refresh a
+            partial failure in ``load_config()`` short-circuits before ``refresh()``
+            runs; call the primitives directly for full control.
+        """
+        warnings.warn(
+            "Client.refresh_plant() is deprecated and will be removed in 3.0. Run detect() once, then "
+            "drive your own poll loop over load_config()/refresh(). It now propagates "
+            "RefreshPartiallySucceeded/RefreshFailed on partial/total read failure.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if self.plant.capabilities:
             if full_refresh:
                 await self.load_config(timeout=timeout, retries=retries, retry_delay=retry_delay)
             await self.refresh(timeout=timeout, retries=retries, retry_delay=retry_delay)
             return self.plant
-        reqs = commands.refresh_plant_data(full_refresh, self.plant.number_batteries, max_batteries)
-        await self.execute(reqs, timeout=timeout, retries=retries, retry_delay=retry_delay)
-        return self.plant
+        return await self._refresh_no_caps(
+            full_refresh=full_refresh,
+            max_batteries=max_batteries,
+            timeout=timeout,
+            retries=retries,
+            retry_delay=retry_delay,
+        )
 
     async def watch_plant(
         self,
@@ -658,7 +768,20 @@ class Client:
         retry_delay: float = 0.5,
         passive: bool = False,
     ):
-        """Refresh data about the Plant."""
+        """Deprecated poll loop — own the loop in the consumer instead.
+
+        .. deprecated::
+            Will be removed in 3.0. Connect, ``detect()``, then loop over
+            ``load_config()`` / ``refresh()`` yourself, handling
+            ``RefreshPartiallySucceeded`` / ``RefreshFailed`` as suits the consumer.
+        """
+        warnings.warn(
+            "Client.watch_plant() is deprecated and will be removed in 3.0. Own your poll loop: "
+            "connect(), detect(), then loop over load_config()/refresh() handling "
+            "RefreshPartiallySucceeded/RefreshFailed as you see fit.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         await self.connect()
         await self.refresh_plant(
             True,

--- a/givenergy_modbus/exceptions.py
+++ b/givenergy_modbus/exceptions.py
@@ -1,3 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, NamedTuple
+
+if TYPE_CHECKING:
+    from givenergy_modbus.model.plant import Plant
+
+
 class ExceptionBase(Exception):
     """Base exception."""
 
@@ -51,3 +59,60 @@ class PlantTopologyMismatch(CommunicationError):
         super().__init__(message=message)
         self.prior = prior
         self.actual = actual
+
+
+class ReadFailure(NamedTuple):
+    """Identifies a single register read that failed (after retries) during a poll.
+
+    Structured so a consumer can reason about *which* device and bank dropped
+    (e.g. "battery 0x34 is offline") without parsing log lines.
+    """
+
+    device_address: int
+    request_type: str
+    base_register: int
+    register_count: int
+
+
+class RefreshError(CommunicationError):
+    """Base for a refresh()/load_config() that did not fully succeed.
+
+    Carries the structured set of reads that failed (``failures``) plus the raw
+    underlying exceptions grouped as an ``ExceptionGroup`` (``cause``) for
+    tracebacks / drill-down.
+    """
+
+    failures: list[ReadFailure]
+    cause: ExceptionGroup
+
+    def __init__(self, message: str, failures: list[ReadFailure], cause: ExceptionGroup) -> None:
+        super().__init__(message=message)
+        self.failures = failures
+        self.cause = cause
+
+
+class RefreshPartiallySucceeded(RefreshError):
+    """Some — but not all — register reads in a poll failed.
+
+    The data that *was* collected is attached as ``plant``. This exception is
+    the consumer's one opportunity to do something useful with that partial
+    data — cache it, surface it, count the gap — before deciding how to treat
+    the missing reads. Catching it and carrying on (even ignoring it) is a
+    legitimate choice; the point is that it's the *consumer's* choice, made
+    here, rather than something the library silently decided for them.
+    """
+
+    plant: Plant
+
+    def __init__(self, message: str, plant: Plant, failures: list[ReadFailure], cause: ExceptionGroup) -> None:
+        super().__init__(message=message, failures=failures, cause=cause)
+        self.plant = plant
+
+
+class RefreshFailed(RefreshError):
+    """Every register read in the poll failed — the link is effectively dead.
+
+    No usable data came back, so (unlike ``RefreshPartiallySucceeded``) there is
+    no partial plant to hand over; callers should treat the device as
+    unavailable.
+    """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ branch = true
 [tool.coverage.report]
 exclude_lines = [
     "pragma: no cover",
+    "if TYPE_CHECKING:",
     "def __repr__",
     "if self.debug:",
     "if settings.DEBUG",

--- a/tests/client/test_load_refresh.py
+++ b/tests/client/test_load_refresh.py
@@ -42,7 +42,7 @@ def _reqs(mock_execute) -> list[tuple]:
 async def test_load_config_no_caps():
     """Without capabilities, only the four base blocks are requested, at the legacy 0x32."""
     client = Client("localhost", 8899)
-    with patch.object(client, "execute", new_callable=AsyncMock) as mock_exec:
+    with patch.object(client, "_execute_reads", new_callable=AsyncMock) as mock_exec:
         await client.load_config()
     assert _reqs(mock_exec) == [
         _hr(0, 60, device=0x32),
@@ -55,7 +55,7 @@ async def test_load_config_no_caps():
 async def test_load_config_single_phase():
     """Standard single-phase HYBRID requests the four base blocks only, at 0x11."""
     client = _client_with_caps(Model.HYBRID)
-    with patch.object(client, "execute", new_callable=AsyncMock) as mock_exec:
+    with patch.object(client, "_execute_reads", new_callable=AsyncMock) as mock_exec:
         await client.load_config()
     assert _reqs(mock_exec) == [_hr(0, 60), _hr(60, 60), _hr(120, 60), _ir(120, 60)]
 
@@ -64,7 +64,7 @@ async def test_load_config_single_phase():
 async def test_load_config_ac_gen1_uses_0x31(model: Model):
     """AC and HYBRID_GEN1 both expose their registers at 0x31, not 0x11 (issue #119)."""
     client = _client_with_caps(model)
-    with patch.object(client, "execute", new_callable=AsyncMock) as mock_exec:
+    with patch.object(client, "_execute_reads", new_callable=AsyncMock) as mock_exec:
         await client.load_config()
     assert _reqs(mock_exec) == [
         _hr(0, 60, device=0x31),
@@ -77,7 +77,7 @@ async def test_load_config_ac_gen1_uses_0x31(model: Model):
 async def test_load_config_three_phase():
     """Three-phase models add HR 1000–1124 as three reads (60 + 60 + 5)."""
     client = _client_with_caps(Model.HYBRID_3PH)
-    with patch.object(client, "execute", new_callable=AsyncMock) as mock_exec:
+    with patch.object(client, "_execute_reads", new_callable=AsyncMock) as mock_exec:
         await client.load_config()
     assert _reqs(mock_exec) == [
         _hr(0, 60),
@@ -93,7 +93,7 @@ async def test_load_config_three_phase():
 async def test_load_config_extended_slots():
     """Extended-slot models add HR 240–299."""
     client = _client_with_caps(Model.HYBRID_GEN3)
-    with patch.object(client, "execute", new_callable=AsyncMock) as mock_exec:
+    with patch.object(client, "_execute_reads", new_callable=AsyncMock) as mock_exec:
         await client.load_config()
     assert _reqs(mock_exec) == [_hr(0, 60), _hr(60, 60), _hr(120, 60), _ir(120, 60), _hr(240, 60)]
 
@@ -105,7 +105,7 @@ async def test_load_config_ems():
     Regression: #86. Wire capture confirmed via dewet22/givenergy-hass#52.
     """
     client = _client_with_caps(Model.EMS)
-    with patch.object(client, "execute", new_callable=AsyncMock) as mock_exec:
+    with patch.object(client, "_execute_reads", new_callable=AsyncMock) as mock_exec:
         await client.load_config()
     assert _reqs(mock_exec) == [_hr(0, 60), _hr(2040, 36)]
 
@@ -115,18 +115,23 @@ async def test_load_config_ems():
 # ---------------------------------------------------------------------------
 
 
-async def test_refresh_no_caps_falls_back_to_refresh_plant():
-    """Without capabilities, refresh() delegates to refresh_plant(full_refresh=False)."""
+async def test_refresh_no_caps_runs_legacy_path():
+    """Without capabilities, refresh() runs the legacy capability-free fallback.
+
+    It must NOT route through the deprecated refresh_plant() (that would warn);
+    _refresh_no_caps() builds the legacy request list and dispatches it.
+    """
     client = Client("localhost", 8899)
-    with patch.object(client, "refresh_plant", new_callable=AsyncMock) as mock_rp:
-        await client.refresh()
-    mock_rp.assert_awaited_once_with(full_refresh=False)
+    with patch.object(client, "_execute_reads", new_callable=AsyncMock) as mock_exec:
+        plant = await client.refresh()
+    assert plant is client.plant
+    mock_exec.assert_awaited_once()
 
 
 async def test_refresh_single_phase_no_peripherals():
     """Standard single-phase with no peripherals: two base IR blocks only."""
     client = _client_with_caps(Model.HYBRID)
-    with patch.object(client, "execute", new_callable=AsyncMock) as mock_exec:
+    with patch.object(client, "_execute_reads", new_callable=AsyncMock) as mock_exec:
         await client.refresh()
     assert _reqs(mock_exec) == [_ir(0, 60), _ir(180, 60)]
 
@@ -134,7 +139,7 @@ async def test_refresh_single_phase_no_peripherals():
 async def test_refresh_three_phase():
     """Three-phase adds IR 1000–1413 as seven reads."""
     client = _client_with_caps(Model.HYBRID_3PH)
-    with patch.object(client, "execute", new_callable=AsyncMock) as mock_exec:
+    with patch.object(client, "_execute_reads", new_callable=AsyncMock) as mock_exec:
         await client.refresh()
     expected_3ph = [
         _ir(1000, 60),
@@ -157,7 +162,7 @@ async def test_refresh_ems():
     caps-populated capture shows otherwise.
     """
     client = _client_with_caps(Model.EMS)
-    with patch.object(client, "execute", new_callable=AsyncMock) as mock_exec:
+    with patch.object(client, "_execute_reads", new_callable=AsyncMock) as mock_exec:
         await client.refresh()
     assert _reqs(mock_exec) == [_ir(2040, 55)]
 
@@ -165,7 +170,7 @@ async def test_refresh_ems():
 async def test_refresh_gateway():
     """Gateway adds IR 1600–1859 as five reads."""
     client = _client_with_caps(Model.GATEWAY)
-    with patch.object(client, "execute", new_callable=AsyncMock) as mock_exec:
+    with patch.object(client, "_execute_reads", new_callable=AsyncMock) as mock_exec:
         await client.refresh()
     expected_gw = [_ir(1600, 60), _ir(1660, 60), _ir(1720, 60), _ir(1780, 60), _ir(1840, 20)]
     assert _reqs(mock_exec) == [_ir(0, 60), _ir(180, 60)] + expected_gw
@@ -174,7 +179,7 @@ async def test_refresh_gateway():
 async def test_refresh_lv_batteries():
     """LV battery devices each add an IR 60+60 read at their device address."""
     client = _client_with_caps(Model.HYBRID, lv_battery_addresses=[0x33, 0x34])
-    with patch.object(client, "execute", new_callable=AsyncMock) as mock_exec:
+    with patch.object(client, "_execute_reads", new_callable=AsyncMock) as mock_exec:
         await client.refresh()
     reqs = _reqs(mock_exec)
     assert _ir(60, 60, device=0x33) in reqs
@@ -184,7 +189,7 @@ async def test_refresh_lv_batteries():
 async def test_refresh_meter_addresses():
     """Meter devices each add an IR 60+30 read."""
     client = _client_with_caps(Model.HYBRID, meter_addresses=[0x01, 0x02])
-    with patch.object(client, "execute", new_callable=AsyncMock) as mock_exec:
+    with patch.object(client, "_execute_reads", new_callable=AsyncMock) as mock_exec:
         await client.refresh()
     reqs = _reqs(mock_exec)
     assert _ir(60, 30, device=0x01) in reqs
@@ -195,7 +200,7 @@ async def test_refresh_bcu_stacks():
     """BCU stacks each add an IR 60+60 read at 0x70 + offset."""
     # Use HYBRID_HV_GEN3 which is three-phase + HV; check BCU reads are present
     client = _client_with_caps(Model.HYBRID_HV_GEN3, bcu_stacks=[(0, 3), (1, 2)])
-    with patch.object(client, "execute", new_callable=AsyncMock) as mock_exec:
+    with patch.object(client, "_execute_reads", new_callable=AsyncMock) as mock_exec:
         await client.refresh()
     reqs = _reqs(mock_exec)
     assert _ir(60, 60, device=0x70) in reqs
@@ -212,6 +217,7 @@ async def test_refresh_plant_forwards_timeout_retries_and_retry_delay_post_detec
     with (
         patch.object(client, "load_config", new_callable=AsyncMock) as mock_lc,
         patch.object(client, "refresh", new_callable=AsyncMock) as mock_rf,
+        pytest.warns(DeprecationWarning),
     ):
         await client.refresh_plant(full_refresh=True, timeout=3.5, retries=4, retry_delay=1.2)
 
@@ -228,6 +234,7 @@ async def test_refresh_plant_skips_load_config_when_not_full_refresh():
     with (
         patch.object(client, "load_config", new_callable=AsyncMock) as mock_lc,
         patch.object(client, "refresh", new_callable=AsyncMock) as mock_rf,
+        pytest.warns(DeprecationWarning),
     ):
         await client.refresh_plant(full_refresh=False, timeout=2.0, retries=1, retry_delay=0.3)
 

--- a/tests/client/test_refresh_resilience.py
+++ b/tests/client/test_refresh_resilience.py
@@ -1,0 +1,223 @@
+"""Partial-failure contract for Client.refresh() / load_config().
+
+A poll cycle fans out many register reads (inverter banks, per-battery,
+per-meter, per-BCU). Historically ``execute()`` gathered them with
+``return_exceptions=False``, so the *first* read that timed out aborted the
+whole cycle and the caller got nothing — one offline battery discarded every
+reading that *did* come back.
+
+The contract these tests pin:
+
+- **full success** → return the ``Plant`` as before;
+- **partial** (some reads failed, some succeeded) → raise
+  ``RefreshPartiallySucceeded`` carrying the partial ``plant`` (the consumer's
+  one chance to use the data we did collect), the structured ``failures``, and
+  the raw ``cause`` ExceptionGroup;
+- **total** (every read failed — link effectively dead) → raise
+  ``RefreshFailed``.
+
+Raising on partial is deliberate: it's the most honest, hardest-to-ignore
+signal, and the ``except`` block is exactly where consumer-domain policy
+(counters, diagnostics, notifications, or a deliberate pass) belongs. Policy is
+not the library's to assume.
+
+The deprecated orchestrators ``refresh_plant()`` / ``watch_plant()`` emit a
+``DeprecationWarning`` *and* propagate the same exceptions — a double signal to
+migrate to the primitives.
+
+Failures are keyed on battery address (refresh) and base register (load_config),
+both stable across #119/#121's inverter-address rework. Resilience follow-up to
+#119; see dewet22/givenergy-hass#52.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from givenergy_modbus.client.client import Client
+from givenergy_modbus.exceptions import RefreshFailed, RefreshPartiallySucceeded
+from givenergy_modbus.model.inverter import Model
+from givenergy_modbus.model.plant import PlantCapabilities
+from givenergy_modbus.pdu import ReadInputRegistersRequest
+
+# 0x33/0x34 are LV battery pack addresses, unaffected by the inverter-address
+# rework — keying the induced failure here keeps these tests stable across #121.
+OFFLINE_BATTERY = 0x34
+
+
+def _client_with_caps(model: Model, **kwargs) -> Client:
+    client = Client("localhost", 8899)
+    client.plant.capabilities = PlantCapabilities(device_type=model, **kwargs)
+    return client
+
+
+def _selective_send(should_fail):
+    """A send_request_and_await_response stand-in.
+
+    Raises ``TimeoutError`` for any request where ``should_fail(request)`` is
+    truthy (an offline/slow device that has exhausted its retries), and returns
+    a benign successful response otherwise.
+    """
+
+    def _side(request, *args, **kwargs):
+        if should_fail(request):
+            raise TimeoutError()
+        return SimpleNamespace(error=False, device_address=request.device_address)
+
+    return _side
+
+
+def _fail_device(*addresses):
+    """Predicate: fail reads aimed at any of these device addresses."""
+    targets = set(addresses)
+    return lambda req: req.device_address in targets
+
+
+def _fail_base(*bases):
+    """Predicate: fail reads at any of these base registers (address-agnostic)."""
+    targets = set(bases)
+    return lambda req: req.base_register in targets
+
+
+def _patch_send(client, predicate):
+    return patch.object(
+        client,
+        "send_request_and_await_response",
+        new_callable=AsyncMock,
+        side_effect=_selective_send(predicate),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Partial failure → RefreshPartiallySucceeded (carrying the data we did get)
+# ---------------------------------------------------------------------------
+
+
+async def test_refresh_partial_raises_partially_succeeded():
+    """One offline battery: refresh() raises RefreshPartiallySucceeded, not bare TimeoutError.
+
+    The partial plant rides on the exception so a caller doing ``except ...``
+    never loses the tick's data.
+    """
+    client = _client_with_caps(Model.HYBRID, lv_battery_addresses=[0x33, OFFLINE_BATTERY])
+    with _patch_send(client, _fail_device(OFFLINE_BATTERY)):
+        with pytest.raises(RefreshPartiallySucceeded) as ei:
+            await client.refresh()
+    exc = ei.value
+    assert exc.plant is client.plant
+    assert any(f.device_address == OFFLINE_BATTERY for f in exc.failures)
+
+
+async def test_load_config_partial_raises_partially_succeeded():
+    """load_config() carries the same contract; here an inverter bank (base 120) drops.
+
+    Keyed on base register so it's independent of which device address the
+    inverter lands on after #121.
+    """
+    client = _client_with_caps(Model.HYBRID)
+    with _patch_send(client, _fail_base(120)):
+        with pytest.raises(RefreshPartiallySucceeded) as ei:
+            await client.load_config()
+    assert ei.value.plant is client.plant
+    assert any(f.base_register == 120 for f in ei.value.failures)
+
+
+async def test_partial_exception_carries_full_failure_detail():
+    """Structured failures (device/type/base/count) plus a cause grouping the raw errors.
+
+    No silent swallow: every dropped read is accounted for, both as a
+    ReadFailure record and inside the ExceptionGroup.
+    """
+    client = _client_with_caps(Model.HYBRID, lv_battery_addresses=[0x33, OFFLINE_BATTERY])
+    with _patch_send(client, _fail_device(OFFLINE_BATTERY)):
+        with pytest.raises(RefreshPartiallySucceeded) as ei:
+            await client.refresh()
+    exc = ei.value
+    fail = next(f for f in exc.failures if f.device_address == OFFLINE_BATTERY)
+    assert fail.request_type == "ReadInputRegistersRequest"
+    assert (fail.base_register, fail.register_count) == (60, 60)
+    assert isinstance(exc.cause, ExceptionGroup)
+    assert len(exc.cause.exceptions) == len(exc.failures)
+
+
+# ---------------------------------------------------------------------------
+# Total failure → RefreshFailed; full success → plain Plant
+# ---------------------------------------------------------------------------
+
+
+async def test_refresh_total_raises_failed():
+    """Every read times out (dead link): refresh() raises RefreshFailed."""
+    client = _client_with_caps(Model.HYBRID, lv_battery_addresses=[0x33, OFFLINE_BATTERY])
+    with _patch_send(client, lambda req: True):
+        with pytest.raises(RefreshFailed) as ei:
+            await client.refresh()
+    assert ei.value.failures
+    assert isinstance(ei.value.cause, ExceptionGroup)
+
+
+async def test_refresh_returns_plant_when_all_reads_succeed():
+    """Happy path: with no timeouts, refresh() returns the plant and raises nothing."""
+    client = _client_with_caps(Model.HYBRID, lv_battery_addresses=[0x33, OFFLINE_BATTERY])
+    with _patch_send(client, _fail_device()):
+        plant = await client.refresh()
+    assert plant is client.plant
+
+
+# ---------------------------------------------------------------------------
+# Deprecated orchestrators: warn AND propagate the new contract
+# ---------------------------------------------------------------------------
+
+
+async def test_refresh_plant_deprecated():
+    """refresh_plant() still works on the happy path but warns it's deprecated."""
+    client = _client_with_caps(Model.HYBRID)
+    with _patch_send(client, _fail_device()):
+        with pytest.warns(DeprecationWarning):
+            await client.refresh_plant()
+
+
+async def test_refresh_plant_propagates_partial():
+    """A consumer still on refresh_plant() gets the new exception too — explicit migration signal."""
+    client = _client_with_caps(Model.HYBRID, lv_battery_addresses=[0x33, OFFLINE_BATTERY])
+    with _patch_send(client, _fail_device(OFFLINE_BATTERY)):
+        with pytest.warns(DeprecationWarning), pytest.raises(RefreshPartiallySucceeded):
+            await client.refresh_plant()
+
+
+async def test_refresh_plant_no_caps_uses_legacy_path():
+    """refresh_plant() without capabilities routes to the legacy fallback (and warns)."""
+    client = Client("localhost", 8899)
+    with patch.object(client, "_refresh_no_caps", new_callable=AsyncMock) as mock_legacy:
+        with pytest.warns(DeprecationWarning):
+            await client.refresh_plant()
+    mock_legacy.assert_awaited_once()
+
+
+async def test_watch_plant_deprecated():
+    """watch_plant() warns on entry (before doing any work)."""
+    client = Client("localhost", 8899)
+    with patch.object(client, "connect", new_callable=AsyncMock, side_effect=RuntimeError("stop")):
+        with pytest.warns(DeprecationWarning), pytest.raises(RuntimeError):
+            await client.watch_plant()
+
+
+# ---------------------------------------------------------------------------
+# _execute_reads edge cases
+# ---------------------------------------------------------------------------
+
+
+async def test_execute_reads_empty_is_noop():
+    """No requests → returns without raising or touching the wire."""
+    client = _client_with_caps(Model.HYBRID)
+    assert await client._execute_reads([], timeout=1.0, retries=0, retry_delay=0.0) is None
+
+
+async def test_execute_reads_reraises_cancellation():
+    """A CancelledError result is re-raised, never collected as a failure."""
+    client = _client_with_caps(Model.HYBRID)
+    req = ReadInputRegistersRequest(base_register=0, register_count=60, device_address=0x11)
+    with patch.object(client, "execute", new_callable=AsyncMock, return_value=[asyncio.CancelledError()]):
+        with pytest.raises(asyncio.CancelledError):
+            await client._execute_reads([req], timeout=1.0, retries=0, retry_delay=0.0)


### PR DESCRIPTION
## What this changes

A poll fans out many register reads (inverter banks, per-battery, per-meter, per-BCU). Until now `execute()` gathered them with `return_exceptions=False`, so the *first* read to time out aborted the whole cycle — one offline battery discarded every reading that *did* come back, and the caller got an exception with no data.

`refresh()` / `load_config()` now return `Plant` only on **full success**, and raise on failure:

| Outcome | Behaviour |
|---|---|
| all reads succeed | returns `Plant` (as before) |
| some reads fail | raises `RefreshPartiallySucceeded` — carries `.plant` (the data that *did* arrive), `.failures` (structured `ReadFailure` records: device address, request type, base register, count), and `.cause` (an `ExceptionGroup` of the raw errors) |
| every read fails | raises `RefreshFailed` (link effectively dead; no partial data) |

Both share a `RefreshError` base for consumers that don't want to distinguish.

Raising on partial is deliberate: it's the most honest, hardest-to-ignore signal, and the `except` block is exactly where consumer-domain policy (counters, diagnostics, availability) belongs. The library reports the truth; the consumer decides what to do. The partial data rides *on* the exception so a caller catching it never loses the tick's readings.

`detect()`, `one_shot_command()` and the write path are unchanged — `execute()` still defaults to `return_exceptions=False`, so write/probe semantics (raise on first failure) are intact.

## Deprecations

`refresh_plant()` and `watch_plant()` are deprecated (removed in 3.0). They embed compose/loop policy that belongs in the consumer, and the only two consumers already split — cli drives the primitives directly, hass goes through `refresh_plant`. They now emit a `DeprecationWarning` **and** propagate the new exceptions (double signal).

## Consumer migration (givenergy-hass)

The hass coordinator + config_flow go through `refresh_plant()`; here's the mapping. The key behavioural win: catching `RefreshPartiallySucceeded` keeps the good entities live instead of dropping the whole device.

**Mapping**
- `detect()` runs once at setup (it already does).
- `refresh_plant(full_refresh=True, ...)` → `await load_config(...)` then `await refresh(...)`
- `refresh_plant(full_refresh=False, ...)` → `await refresh(...)`

**Coordinator pattern** (`custom_components/givenergy_local/coordinator.py`, ~lines 150 & 161):
```python
from givenergy_modbus.exceptions import RefreshFailed, RefreshPartiallySucceeded
from homeassistant.helpers.update_coordinator import UpdateFailed

try:
    if full_refresh:
        await self._client.load_config(retries=self.retries)
    plant = await self._client.refresh(retries=self.retries)
except RefreshPartiallySucceeded as exc:
    plant = exc.plant            # keep the good entities live
    _LOGGER.debug("partial poll: %s", exc.failures)   # or a diagnostic counter
except RefreshFailed as exc:
    raise UpdateFailed(str(exc)) from exc
return plant
```
Note `RefreshFailed` → `UpdateFailed` is the only path that should mark the device unavailable. A partial must **not** become `UpdateFailed`, or you reintroduce the "one drop nukes everything" behaviour this PR removes.

**config_flow** (`config_flow.py`, ~line 100): `refresh_plant(full_refresh=False)` → `await client.refresh()`, wrapped to accept `RefreshPartiallySucceeded` (use `exc.plant`) since setup only needs a usable snapshot.

This modbus PR and the hass migration want to land together — hass should pin the modbus version that includes this.

## Tests

New `test_refresh_resilience.py` pins the contract: partial → `RefreshPartiallySucceeded` (plant + failures carried), total → `RefreshFailed`, full success → `Plant`, payload detail, and both deprecations warn + propagate. `test_load_refresh.py` updated for the new dispatch seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
