### PR TITLE
feat: expose per-attribute display precision derived from register scaling

### DIFF
--- a/givenergy_modbus/model/battery.py
+++ b/givenergy_modbus/model/battery.py
@@ -1,8 +1,14 @@
 from enum import IntEnum
+from typing import ClassVar
 
 from pydantic import ConfigDict, create_model
 
-from givenergy_modbus.model.register import IR, RegisterGetter, is_valid_serial
+from givenergy_modbus.model.register import (
+    IR,
+    RegisterGetter,
+    RegisterMetadataMixin,
+    is_valid_serial,
+)
 from givenergy_modbus.model.register import Converter as DT
 from givenergy_modbus.model.register import RegisterDefinition as Def
 
@@ -79,8 +85,10 @@ _BatteryBase = create_model(  # type: ignore[call-overload]
 )
 
 
-class Battery(_BatteryBase):  # type: ignore[misc,valid-type]
+class Battery(_BatteryBase, RegisterMetadataMixin):  # type: ignore[misc,valid-type]
     """GivEnergy battery data model."""
+
+    REGISTER_GETTER: ClassVar[type[RegisterGetter]] = BatteryRegisterGetter
 
     @classmethod
     def from_register_cache(cls, register_cache) -> "Battery":

--- a/givenergy_modbus/model/ems.py
+++ b/givenergy_modbus/model/ems.py
@@ -1,11 +1,13 @@
 """GivEnergy EMS (Energy Management System) data model."""
 
+from typing import ClassVar
+
 from pydantic import ConfigDict, create_model
 
 from givenergy_modbus.model.devices import InverterSummary
 from givenergy_modbus.model.inverter import Status
 from givenergy_modbus.model.meter import MeterStatus
-from givenergy_modbus.model.register import HR, IR, RegisterGetter
+from givenergy_modbus.model.register import HR, IR, RegisterGetter, RegisterMetadataMixin
 from givenergy_modbus.model.register import Converter as C
 from givenergy_modbus.model.register import RegisterDefinition as Def
 
@@ -113,8 +115,10 @@ _EmsBase = create_model(  # type: ignore[call-overload]
 )
 
 
-class Ems(_EmsBase):  # type: ignore[misc,valid-type]
+class Ems(_EmsBase, RegisterMetadataMixin):  # type: ignore[misc,valid-type]
     """GivEnergy EMS plant-level data (device address 0x11)."""
+
+    REGISTER_GETTER: ClassVar[type[RegisterGetter]] = EmsRegisterGetter
 
     @classmethod
     def from_register_cache(cls, register_cache) -> "Ems":

--- a/givenergy_modbus/model/hv_bcu.py
+++ b/givenergy_modbus/model/hv_bcu.py
@@ -13,11 +13,11 @@ which resolves all addresses before model creation.
 
 import warnings
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, ClassVar
 
 from pydantic import ConfigDict, create_model
 
-from givenergy_modbus.model.register import IR, RegisterGetter
+from givenergy_modbus.model.register import IR, RegisterGetter, RegisterMetadataMixin
 from givenergy_modbus.model.register import Converter as C
 from givenergy_modbus.model.register import RegisterDefinition as Def
 
@@ -66,8 +66,10 @@ _BcuBase = create_model(  # type: ignore[call-overload]
 )
 
 
-class Bcu(_BcuBase):  # type: ignore[misc,valid-type]
+class Bcu(_BcuBase, RegisterMetadataMixin):  # type: ignore[misc,valid-type]
     """GivEnergy HV Battery Control Unit (BCU) cluster-level data."""
+
+    REGISTER_GETTER: ClassVar[type[RegisterGetter]] = BcuRegisterGetter
 
     @classmethod
     def from_register_cache(cls, register_cache) -> "Bcu":

--- a/givenergy_modbus/model/inverter.py
+++ b/givenergy_modbus/model/inverter.py
@@ -1,11 +1,12 @@
 import math
 import warnings
 from enum import Enum, IntEnum, StrEnum
+from typing import ClassVar
 
 from pydantic import ConfigDict, computed_field, create_model
 
 from givenergy_modbus.client.commands import _InverterCommands
-from givenergy_modbus.model.register import HR, IR, RegisterGetter
+from givenergy_modbus.model.register import HR, IR, RegisterGetter, RegisterMetadataMixin
 from givenergy_modbus.model.register import Converter as C
 from givenergy_modbus.model.register import RegisterDefinition as Def
 
@@ -637,7 +638,9 @@ _SinglePhaseInverterBase = create_model(  # type: ignore[call-overload]
 )
 
 
-class SinglePhaseInverter(_SinglePhaseInverterBase, _InverterCommands):  # type: ignore[valid-type,misc]
+class SinglePhaseInverter(  # type: ignore[valid-type,misc]
+    _SinglePhaseInverterBase, _InverterCommands, RegisterMetadataMixin
+):
     """GivEnergy single-phase inverter data model.
 
     Composes the `_InverterCommands` mixin so consumers can call
@@ -647,6 +650,8 @@ class SinglePhaseInverter(_SinglePhaseInverterBase, _InverterCommands):  # type:
     command mixins (three-phase, EMS, pause-mode) will compose in additively
     in later 2.x minors — see #75.
     """
+
+    REGISTER_GETTER: ClassVar[type[RegisterGetter]] = SinglePhaseInverterRegisterGetter
 
     @classmethod
     def from_register_cache(cls, register_cache) -> "SinglePhaseInverter":

--- a/givenergy_modbus/model/inverter_threephase.py
+++ b/givenergy_modbus/model/inverter_threephase.py
@@ -1,6 +1,7 @@
 """GivEnergy three-phase inverter data model."""
 
 import warnings
+from typing import ClassVar
 
 from pydantic import ConfigDict, computed_field, create_model
 
@@ -17,7 +18,7 @@ from givenergy_modbus.model.inverter import (
     Status,
     _battery_max_power,
 )
-from givenergy_modbus.model.register import HR, IR, RegisterGetter
+from givenergy_modbus.model.register import HR, IR, RegisterGetter, RegisterMetadataMixin
 from givenergy_modbus.model.register import Converter as C
 from givenergy_modbus.model.register import RegisterDefinition as Def
 
@@ -477,13 +478,17 @@ _ThreePhaseInverterBase = create_model(  # type: ignore[call-overload]
 from givenergy_modbus.model.slot_map import THREE_PHASE_SLOTS  # noqa: E402
 
 
-class ThreePhaseInverter(_ThreePhaseInverterBase, _InverterCommands):  # type: ignore[valid-type,misc]
+class ThreePhaseInverter(  # type: ignore[valid-type,misc]
+    _ThreePhaseInverterBase, _InverterCommands, RegisterMetadataMixin
+):
     """GivEnergy three-phase inverter data model.
 
     Composes the `_InverterCommands` mixin (same base mixin used by
     `SinglePhaseInverter`). Three-phase-specific command mixins land later in
     2.x once the register ambiguities flagged on #75 are resolved.
     """
+
+    REGISTER_GETTER: ClassVar[type[RegisterGetter]] = ThreePhaseInverterRegisterGetter
 
     @classmethod
     def from_register_cache(cls, register_cache) -> "ThreePhaseInverter":

--- a/givenergy_modbus/model/meter.py
+++ b/givenergy_modbus/model/meter.py
@@ -1,10 +1,11 @@
 """GivEnergy meter data model."""
 
 from enum import IntEnum
+from typing import ClassVar
 
 from pydantic import ConfigDict, create_model
 
-from givenergy_modbus.model.register import IR, MR, RegisterGetter
+from givenergy_modbus.model.register import IR, MR, RegisterGetter, RegisterMetadataMixin
 from givenergy_modbus.model.register import Converter as C
 from givenergy_modbus.model.register import RegisterDefinition as Def
 
@@ -65,8 +66,10 @@ _MeterBase = create_model(  # type: ignore[call-overload]
 )
 
 
-class Meter(_MeterBase):  # type: ignore[misc,valid-type]
+class Meter(_MeterBase, RegisterMetadataMixin):  # type: ignore[misc,valid-type]
     """GivEnergy external meter measurement data (FC 0x04, device addresses 0x01–0x08)."""
+
+    REGISTER_GETTER: ClassVar[type[RegisterGetter]] = MeterRegisterGetter
 
     @classmethod
     def from_register_cache(cls, register_cache) -> "Meter":
@@ -100,8 +103,10 @@ _MeterProductBase = create_model(  # type: ignore[call-overload]
 )
 
 
-class MeterProduct(_MeterProductBase):  # type: ignore[misc,valid-type]
+class MeterProduct(_MeterProductBase, RegisterMetadataMixin):  # type: ignore[misc,valid-type]
     """GivEnergy external meter identification data (FC 0x16, device addresses 0x01–0x08)."""
+
+    REGISTER_GETTER: ClassVar[type[RegisterGetter]] = MeterProductRegisterGetter
 
     @classmethod
     def from_register_cache(cls, register_cache) -> "MeterProduct":

--- a/givenergy_modbus/model/register.py
+++ b/givenergy_modbus/model/register.py
@@ -164,6 +164,7 @@ _PRECISION_BY_CONVERTER: dict[Any, int] = {
     Converter.uint32: 0,
     Converter.int32: 0,
     Converter.duint8: 0,
+    Converter.bitfield: 0,
 }
 
 

--- a/givenergy_modbus/model/register.py
+++ b/givenergy_modbus/model/register.py
@@ -2,7 +2,7 @@ import logging
 import re
 from datetime import datetime
 from json import JSONEncoder
-from typing import Any, get_type_hints
+from typing import Any, ClassVar, get_type_hints
 
 from pydantic import BaseModel, ConfigDict
 
@@ -150,6 +150,23 @@ class Converter:
         return prefix + digits
 
 
+# Decimal places implied by each numeric converter's scaling. Used to derive a
+# register's display precision (see RegisterDefinition.precision): deci/centi/
+# milli divide by 10/100/1000, the integer converters yield whole numbers.
+# Converters absent from this map (enums, bools, strings, timeslots, datetimes,
+# and any bespoke converter) are treated as non-numeric — precision None.
+_PRECISION_BY_CONVERTER: dict[Any, int] = {
+    Converter.milli: 3,
+    Converter.centi: 2,
+    Converter.deci: 1,
+    Converter.uint16: 0,
+    Converter.int16: 0,
+    Converter.uint32: 0,
+    Converter.int32: 0,
+    Converter.duint8: 0,
+}
+
+
 class RegisterDefinition(BaseModel):
     """Specifies how to convert raw register values into their actual representation.
 
@@ -196,6 +213,24 @@ class RegisterDefinition(BaseModel):
         # places that look up by register tuple.
         return hash(self.registers)
 
+    @property
+    def precision(self) -> int | None:
+        """Decimal places implied by this register's numeric scaling.
+
+        Returns 0 for integer quantities, 1/2/3 for deci-/centi-/milli-scaled
+        floats, and None for non-numeric registers (enums, bools, strings,
+        timeslots) or any converter without a defined scaling. The post-
+        converter wins when present — it produces the final value — mirroring
+        the resolution order used for return-type inference.
+        """
+        # Converters are stored as plain functions (Converter.<name> resolves
+        # through the staticmethod descriptor at Def-construction time), and a
+        # post-conv may carry a (converter, *args) tuple — unwrap to the callable.
+        conv = self.post_conv or self.pre_conv
+        if isinstance(conv, tuple):
+            conv = conv[0]
+        return _PRECISION_BY_CONVERTER.get(conv)
+
 
 _SERIAL_PATTERN = re.compile(r"[A-Z]{2}\d{4}[A-Z]\d{3}")
 
@@ -220,6 +255,16 @@ class RegisterGetter:
 
     def __init__(self, obj: Any) -> None:
         self._obj = obj
+
+    @classmethod
+    def precision_of(cls, name: str) -> int | None:
+        """Decimal places for a register-backed attribute (None if non-numeric/unknown).
+
+        Returns None for attributes not in the LUT (e.g. computed/aggregate
+        values), so callers can fall back to their own default.
+        """
+        defn = cls.REGISTER_LUT.get(name)
+        return defn.precision if defn is not None else None
 
     def get(self, key: str, default: Any = None) -> Any:
         """Return a named register's value, after pre- and post-conversion."""
@@ -358,6 +403,30 @@ class RegisterGetter:
             return Any
 
         return {k: (return_type(v) | None, None) for k, v in cls.REGISTER_LUT.items()}
+
+
+class RegisterMetadataMixin:
+    """Exposes register metadata on a device model built from a RegisterGetter.
+
+    A model instance is decoupled from the getter that built it (the LUT lives
+    on the getter class), so callers holding e.g. an ``Inverter`` can't reach
+    the register definitions directly. Concrete models set ``REGISTER_GETTER``
+    to their getter and gain queries like :meth:`precision_of` that resolve
+    against that getter's LUT. Composed as a plain mixin — same pattern as the
+    command mixins — so it adds no pydantic fields.
+    """
+
+    REGISTER_GETTER: ClassVar[type[RegisterGetter]]
+
+    @classmethod
+    def precision_of(cls, name: str) -> int | None:
+        """Decimal places for ``name`` per its register scaling (None if non-numeric/unknown).
+
+        Precision is model-specific: the same attribute may scale differently
+        across models (e.g. ``i_battery`` is centivolts on single-phase but
+        decivolts on three-phase), so always query the concrete model.
+        """
+        return cls.REGISTER_GETTER.precision_of(name)
 
 
 class RegisterEncoder(JSONEncoder):

--- a/tests/model/test_register.py
+++ b/tests/model/test_register.py
@@ -431,3 +431,73 @@ def test_is_coherent_uses_committed_plus_incoming():
     committed = RegisterCache({IR(10): 0x5341, IR(11): 0x3132, IR(12): 0x3334, IR(13): 0x4735})
     incoming = {IR(14): 0x3637}  # final register arriving now
     assert G.is_coherent(incoming, committed) is True
+
+
+# ---------------------------------------------------------------------------
+# Display precision (derived from register scaling)
+# ---------------------------------------------------------------------------
+
+
+def test_precision_from_pre_conv_scalers():
+    """milli/centi/deci scaling on the pre-converter implies 3/2/1 decimals."""
+    assert RegisterDefinition(Converter.milli, None, IR(0)).precision == 3
+    assert RegisterDefinition(Converter.centi, None, IR(0)).precision == 2
+    assert RegisterDefinition(Converter.deci, None, IR(0)).precision == 1
+
+
+def test_precision_integer_converters_are_zero():
+    assert RegisterDefinition(Converter.uint16, None, IR(0)).precision == 0
+    assert RegisterDefinition(Converter.int16, None, IR(0)).precision == 0
+    assert RegisterDefinition(Converter.uint32, None, IR(0), IR(1)).precision == 0
+
+
+def test_precision_post_conv_wins_over_pre_conv():
+    """When the scaling lives on the post-converter (e.g. uint32 -> deci) it decides."""
+    assert RegisterDefinition(Converter.uint32, Converter.deci, IR(0), IR(1)).precision == 1
+    assert RegisterDefinition(Converter.int16, Converter.centi, IR(0)).precision == 2
+
+
+def test_precision_non_numeric_is_none():
+    """Enums, bools, strings and timeslots have no numeric precision."""
+    assert RegisterDefinition(Converter.bool, None, IR(0)).precision is None
+    assert RegisterDefinition(Converter.string, None, IR(0)).precision is None
+    assert RegisterDefinition(Converter.hex, None, IR(0)).precision is None
+
+
+def test_precision_tuple_converter_unwrapped():
+    """A (converter, *args) tuple resolves to the converter's precision."""
+    assert RegisterDefinition((Converter.duint8, 0), None, IR(0)).precision == 0
+
+
+def test_getter_precision_of_known_and_unknown():
+    class _G(RegisterGetter):
+        REGISTER_LUT = {"volts": RegisterDefinition(Converter.centi, None, IR(0))}
+
+    assert _G.precision_of("volts") == 2
+    assert _G.precision_of("missing") is None  # not in LUT -> caller's default
+
+
+def test_model_precision_of_is_model_specific():
+    """The same attribute can scale differently per model — query the concrete model.
+
+    i_battery is centivolts (2 dp) on single-phase but decivolts (1 dp) on
+    three-phase; this is the whole reason precision is exposed per model.
+    """
+    from givenergy_modbus.model.inverter import SinglePhaseInverter
+    from givenergy_modbus.model.inverter_threephase import ThreePhaseInverter
+
+    assert SinglePhaseInverter.precision_of("i_battery") == 2
+    assert ThreePhaseInverter.precision_of("i_battery") == 1
+    # A computed attribute (not register-backed) falls through to None.
+    assert SinglePhaseInverter.precision_of("p_pv") is None
+
+
+def test_model_precision_of_across_models():
+    from givenergy_modbus.model.battery import Battery
+    from givenergy_modbus.model.inverter import SinglePhaseInverter
+
+    assert SinglePhaseInverter.precision_of("v_battery") == 2  # centi
+    assert SinglePhaseInverter.precision_of("e_pv_total") == 1  # uint32 -> deci
+    assert Battery.precision_of("soc") == 0  # uint16
+    assert Battery.precision_of("v_out") == 3  # uint32 -> milli
+    assert Battery.precision_of("serial_number") is None  # string

--- a/tests/model/test_register.py
+++ b/tests/model/test_register.py
@@ -467,6 +467,19 @@ def test_precision_non_numeric_is_none():
 def test_precision_tuple_converter_unwrapped():
     """A (converter, *args) tuple resolves to the converter's precision."""
     assert RegisterDefinition((Converter.duint8, 0), None, IR(0)).precision == 0
+    # A raw bitfield extracts an integer bit range -> 0 decimals.
+    assert RegisterDefinition((Converter.bitfield, 0, 1), None, IR(0)).precision == 0
+
+
+def test_precision_enum_over_bitfield_is_none():
+    """An enum post-conv over a bitfield pre-conv is non-numeric (precision None).
+
+    EMS status registers extract a bitfield then decode it to a Status enum;
+    the enum wins, so they have no numeric precision despite the integer bitfield.
+    """
+    from givenergy_modbus.model.ems import Ems
+
+    assert Ems.precision_of("meter_1_status") is None
 
 
 def test_getter_precision_of_known_and_unknown():


### PR DESCRIPTION
## What this adds

A way for consumers to ask a model *what display precision an attribute should have*, derived from the register's own scaling — so they can render values at native resolution instead of guessing or stripping trailing zeros.

- **`RegisterDefinition.precision`** — the decimal places implied by the effective converter: `deci`/`centi`/`milli` → 1/2/3, the integer converters (`uint16`/`int16`/`uint32`/`int32`/`duint8`) → 0, and non-numeric converters (enums, bool, string, timeslot, datetime, hex, …) → `None`. The post-converter wins when it carries the scale (e.g. `uint32` → `deci`), mirroring the existing return-type resolution.
- **`RegisterGetter.precision_of(name)`** — LUT lookup; `None` for attributes not in the LUT (computed/aggregate values), so callers can fall back to their own default.
- **`RegisterMetadataMixin`** — gives device models a public `precision_of()`. A model instance is otherwise decoupled from the getter that built it, so this is the bridge.

## Why per-model

Precision is **model-specific**: `i_battery` is centivolts (2 dp) on single-phase but decivolts (1 dp) on three-phase. So it resolves against the concrete model's getter rather than a global table — `SinglePhaseInverter.precision_of("i_battery") == 2`, `ThreePhaseInverter.precision_of("i_battery") == 1`.

## Scope

Wired on the single/three-phase inverter, battery, meter and BCU models (one `REGISTER_GETTER` classvar each + the mixin). `Bmu` builds its fields manually with no getter LUT, so it's deliberately left out.

A full sweep of the LUTs confirms every numeric converter yields a precision and only non-numeric converters return `None`; the two bespoke converters (`nominal_voltage`/`nominal_frequency`) fall through to `None`, i.e. consumer default.

## Consumer

This is for [givenergy-hass], which will set `suggested_display_precision` on its sensors from `type(model).precision_of(key)` so e.g. battery voltage renders as `52.10 V` (the register is centivolts) rather than `52.1`/`52` after trailing-zero stripping. The hass change pins the release that ships this.

## Tests

New coverage in `test_register.py`: precision per converter class, post-conv-wins, tuple-converter unwrapping, non-numeric → None, getter lookup of known/unknown, and the model-specific `i_battery` single-vs-three-phase split. Full suite green (636 + new), ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)