### PR TITLE
fix(model): recognise EMS serial format (backport of #133 to v2.1)

### DIFF
--- a/givenergy_modbus/model/register.py
+++ b/givenergy_modbus/model/register.py
@@ -234,18 +234,22 @@ class RegisterDefinition(BaseModel):
 
 
 _SERIAL_PATTERN = re.compile(r"[A-Z]{2}\d{4}[A-Z]\d{3}")
+# EMS controllers use a 3-letter prefix followed by 7 digits (e.g. EMS2522018) and carry
+# no middle letter — a legitimate format that just isn't the inverter AA0000A000 shape.
+_EMS_SERIAL_PATTERN = re.compile(r"[A-Z]{3}\d{7}")
 
 
 def is_valid_serial(s: str | None) -> bool:
     """Return True if s looks like a real GivEnergy serial number (exactly 10 [A-Z0-9] chars).
 
-    Also logs a warning when the value passes the length/charset gate but does not match the
-    expected AA0000A000 pattern — preserving compatibility with unknown real-world variants.
+    Logs a warning when the value passes the length/charset gate but matches neither the
+    inverter (AA0000A000) nor the EMS (EMSYYWWNNN) pattern — surfacing genuinely-unknown
+    real-world variants without crying wolf on every EMS poll.
     """
     if not (s and len(s) == 10 and s.isalnum() and s == s.upper()):
         return False
-    if not _SERIAL_PATTERN.fullmatch(s):
-        _logger.warning("serial number %r is valid but does not match expected pattern AA0000A000", s)
+    if not (_SERIAL_PATTERN.fullmatch(s) or _EMS_SERIAL_PATTERN.fullmatch(s)):
+        _logger.warning("serial number %r is valid but matches no known GivEnergy pattern", s)
     return True
 
 

--- a/tests/model/test_register.py
+++ b/tests/model/test_register.py
@@ -356,13 +356,22 @@ def test_is_valid_serial_accepts_alphanumeric():
     assert is_valid_serial("BG1234G567")
 
 
+def test_is_valid_serial_accepts_ems_format_without_warning(caplog):
+    """EMS controller serials (3-letter prefix + 7 digits) are valid and must not warn."""
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="givenergy_modbus.model.register"):
+        assert is_valid_serial("EMS2522018") is True
+    assert not any("no known GivEnergy pattern" in r.message for r in caplog.records)
+
+
 def test_is_valid_serial_warns_on_unexpected_pattern(caplog):
     import logging
 
     with caplog.at_level(logging.WARNING, logger="givenergy_modbus.model.register"):
-        result = is_valid_serial("AAAAAAAAAA")  # 10 alnum uppercase but not AA0000A000
+        result = is_valid_serial("AAAAAAAAAA")  # 10 alnum uppercase, matches neither known pattern
     assert result is True
-    assert "does not match expected pattern" in caplog.text
+    assert "matches no known GivEnergy pattern" in caplog.text
 
 
 def test_is_valid_serial_rejects_wrong_length():


### PR DESCRIPTION
Backport of #133 to `v2.1`. EMS controller serials (`EMSYYWWNNN`) failed the inverter `AA0000A000` pattern check and logged a WARNING on every poll (381 in one EMS session, dewet22/givenergy-hass#52). Adds an EMS serial pattern and only warns when a serial matches neither known form.

Cherry-pick of 989f625 (merged to `main`). Detail in #133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
