### PR TITLE
feat(commands): per-endpoint EMS slot setters for hass API parity

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -214,7 +214,11 @@ case-by-case as model-specific mixins land in later 2.x minors.
 | `set_pause_slot_end(t)` | Set just the end of the battery pause slot |
 | `set_ems_plant(enabled)` | Enable/disable EMS plant control |
 | `set_ems_charge_slot(idx, timeslot)` | Set EMS plant charge slot `idx` (1–3), or clear if `None` |
+| `set_ems_charge_slot_start(idx, t)` | Set just the start of EMS charge slot `idx` |
+| `set_ems_charge_slot_end(idx, t)` | Set just the end of EMS charge slot `idx` |
 | `set_ems_discharge_slot(idx, timeslot)` | Set EMS plant discharge slot `idx` (1–3), or clear if `None` |
+| `set_ems_discharge_slot_start(idx, t)` | Set just the start of EMS discharge slot `idx` |
+| `set_ems_discharge_slot_end(idx, t)` | Set just the end of EMS discharge slot `idx` |
 | `set_ems_charge_target_soc(idx, soc)` | EMS charge slot `idx` target SOC (0–100%) |
 | `set_ems_discharge_target_soc(idx, soc)` | EMS discharge slot `idx` target SOC (0–100%) |
 | `set_ems_export_target_soc(idx, soc)` | EMS export slot `idx` target SOC (0–100%) |

--- a/givenergy_modbus/client/commands.py
+++ b/givenergy_modbus/client/commands.py
@@ -357,11 +357,31 @@ def set_ems_charge_slot(idx: int, timeslot: TimeSlot | None) -> list[Transparent
     return set_charge_slot(idx, timeslot, EMS_SLOTS)
 
 
+def set_ems_charge_slot_start(idx: int, t: dt_time | None) -> list[TransparentRequest]:
+    """Set just the start of EMS plant charge slot idx (1-3), or clear it if None."""
+    return set_charge_slot_start(idx, t, EMS_SLOTS)
+
+
+def set_ems_charge_slot_end(idx: int, t: dt_time | None) -> list[TransparentRequest]:
+    """Set just the end of EMS plant charge slot idx (1-3), or clear it if None."""
+    return set_charge_slot_end(idx, t, EMS_SLOTS)
+
+
 def set_ems_discharge_slot(idx: int, timeslot: TimeSlot | None) -> list[TransparentRequest]:
     """Set an EMS plant discharge time slot by index (1-3), or clear it if None."""
     if timeslot is None:
         return reset_discharge_slot(idx, EMS_SLOTS)
     return set_discharge_slot(idx, timeslot, EMS_SLOTS)
+
+
+def set_ems_discharge_slot_start(idx: int, t: dt_time | None) -> list[TransparentRequest]:
+    """Set just the start of EMS plant discharge slot idx (1-3), or clear it if None."""
+    return set_discharge_slot_start(idx, t, EMS_SLOTS)
+
+
+def set_ems_discharge_slot_end(idx: int, t: dt_time | None) -> list[TransparentRequest]:
+    """Set just the end of EMS plant discharge slot idx (1-3), or clear it if None."""
+    return set_discharge_slot_end(idx, t, EMS_SLOTS)
 
 
 def set_ems_charge_target_soc(idx: int, target_soc: int) -> list[TransparentRequest]:

--- a/tests/client/test_commands.py
+++ b/tests/client/test_commands.py
@@ -474,6 +474,43 @@ def test_set_ems_slot_none_clears():
     ]
 
 
+def test_set_ems_slot_endpoints_write_single_registers():
+    """Per-endpoint EMS setters write one register each.
+
+    For consumers (HA) that model slot start/end as independent entities — parity
+    with the inverter slot API.
+    """
+    # charge slot 1 = (2053, 2054)
+    assert commands.set_ems_charge_slot_start(1, dt_time(2, 0)) == [WriteHoldingRegisterRequest(2053, 200)]
+    assert commands.set_ems_charge_slot_end(1, dt_time(5, 30)) == [WriteHoldingRegisterRequest(2054, 530)]
+    # discharge slot 3 = (2050, 2051)
+    assert commands.set_ems_discharge_slot_start(3, dt_time(16, 0)) == [WriteHoldingRegisterRequest(2050, 1600)]
+    assert commands.set_ems_discharge_slot_end(3, dt_time(19, 0)) == [WriteHoldingRegisterRequest(2051, 1900)]
+    # None clears the single endpoint
+    assert commands.set_ems_charge_slot_start(1, None) == [WriteHoldingRegisterRequest(2053, 0)]
+
+
+def test_set_ems_slot_endpoints_compose_to_whole_slot():
+    """Start + end endpoints together produce the same frames as the whole-slot setter."""
+    ts = TimeSlot.from_components(1, 15, 6, 45)
+    composed = commands.set_ems_charge_slot_start(2, ts.start) + commands.set_ems_charge_slot_end(2, ts.end)
+    assert composed == commands.set_ems_charge_slot(2, ts)
+
+
+def test_set_ems_slot_endpoint_index_validation():
+    """EMS endpoint setters reject slot indices outside [1-3] (EMS_SLOTS has 3 slots)."""
+    for fn in (
+        commands.set_ems_charge_slot_start,
+        commands.set_ems_charge_slot_end,
+        commands.set_ems_discharge_slot_start,
+        commands.set_ems_discharge_slot_end,
+    ):
+        with pytest.raises(ValueError, match="slot index"):
+            fn(0, dt_time(1, 0))
+        with pytest.raises(ValueError, match="slot index"):
+            fn(4, dt_time(1, 0))
+
+
 def test_set_ems_target_soc():
     assert commands.set_ems_charge_target_soc(1, 80) == [WriteHoldingRegisterRequest(2055, 80)]
     assert commands.set_ems_discharge_target_soc(3, 20) == [WriteHoldingRegisterRequest(2052, 20)]


### PR DESCRIPTION
Follow-up to #134, closing an API-parity gap the givenergy-hass review surfaced.

#134 gave EMS slots only a **whole-slot** setter — `set_ems_charge_slot(idx, TimeSlot)`. But the inverter slot API also exposes **per-endpoint** `set_charge_slot_start`/`_end`, and that's what givenergy-hass wires to: it models each slot's start and end as independent `TimeEntity` entities. EMS slots had no equivalent, so the integration couldn't follow its own established pattern for them.

## Change

Adds `set_ems_charge_slot_start`/`_end` and `set_ems_discharge_slot_start`/`_end`, each delegating to the existing `set_charge_slot_start(idx, t, EMS_SLOTS)` machinery. The whole-slot setters stay. No new registers, no new write surface — purely a thinner entry point onto the same already-allowlisted EMS slot registers (so no fresh register-safety review needed beyond #134's).

Tests assert single-register writes at the right EMS addresses and that start+end compose to the whole-slot frames; docs table updated. Full tox green.

Ships in the next `v2.1` alpha alongside the live EMS test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
