### PR TITLE
fix(client): raise refresh default budget to 2.0s/1 retry for contended buses

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -127,10 +127,17 @@ is not yet confirmed.
 
 `refresh`, `load_config` and `one_shot_command` all accept the same three knobs:
 
-- `timeout` (default 1.0s for refresh, 1.5s for `one_shot_command`) — how long to wait for
-  each response.
-- `retries` (default 0) — number of additional attempts after a timeout.
+- `timeout` — how long to wait for each response. Defaults: `refresh` 2.0s, `load_config`
+  2.0s, `one_shot_command` 1.5s.
+- `retries` — number of additional attempts after a timeout. Defaults: `refresh` 1,
+  `load_config` 3, `one_shot_command` 0.
 - `retry_delay` (default 0.5s) — seconds to wait between a timed-out attempt and the next.
+
+`refresh` defaults to `timeout=2.0, retries=1` because the inverter serialises requests:
+when other clients (GivTCP, the vendor app, Predbat) poll the same unit, a tighter budget
+loses the race and produces spurious "register read failed" timeouts even though the
+device is responsive (#132). If you own the bus exclusively and want genuine failures
+surfaced faster, pass a tighter `timeout`/`retries`.
 
 The retry delay exists because some inverters exhibit multi-second silent windows where
 they stop responding to anything; firing the retry immediately tends to land it inside

--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -672,11 +672,17 @@ class Client:
         await self._execute_reads(reqs, timeout=timeout, retries=retries, retry_delay=retry_delay)
         return self.plant
 
-    async def refresh(self, timeout: float = 1.0, retries: int = 0, retry_delay: float = 0.5) -> Plant:
+    async def refresh(self, timeout: float = 2.0, retries: int = 1, retry_delay: float = 0.5) -> Plant:
         """Read IR measurement blocks for all known devices.
 
         Returns the populated plant on full success. On partial/total read
         failure raises ``RefreshPartiallySucceeded`` / ``RefreshFailed``.
+
+        The ``timeout=2.0, retries=1`` defaults are tuned for a contended bus: the
+        inverter serialises requests, so when other clients (GivTCP, the vendor app,
+        Predbat) poll the same unit a tighter budget produces spurious timeouts even
+        though the device is responsive (#132). Pass a tighter budget if you own the
+        bus exclusively and want genuine failures surfaced faster.
         """
         caps = self.plant.capabilities
         if caps is None:
@@ -724,8 +730,8 @@ class Client:
         self,
         full_refresh: bool = True,
         max_batteries: int = 5,
-        timeout: float = 1.0,
-        retries: int = 0,
+        timeout: float = 2.0,
+        retries: int = 1,
         retry_delay: float = 0.5,
     ) -> Plant:
         """Deprecated orchestrator — run ``detect()`` once, then drive your own loop.
@@ -763,8 +769,8 @@ class Client:
         handler: Callable | None = None,
         refresh_period: float = 15.0,
         max_batteries: int = 5,
-        timeout: float = 1.0,
-        retries: int = 0,
+        timeout: float = 2.0,
+        retries: int = 1,
         retry_delay: float = 0.5,
         passive: bool = False,
     ):

--- a/tests/client/test_load_refresh.py
+++ b/tests/client/test_load_refresh.py
@@ -242,6 +242,20 @@ async def test_refresh_plant_skips_load_config_when_not_full_refresh():
     mock_rf.assert_awaited_once_with(timeout=2.0, retries=1, retry_delay=0.3)
 
 
+async def test_refresh_default_budget_tuned_for_contended_bus():
+    """refresh() defaults to timeout=2.0s / retries=1 — the contended-bus tuning (#132).
+
+    The hot poll path used to default to 1.0s / 0 retries, which produced spurious
+    timeouts when other clients (GivTCP, the app, Predbat) share the inverter bus.
+    """
+    client = _client_with_caps(Model.HYBRID)
+    with patch.object(client, "_execute_reads", new_callable=AsyncMock) as mock_reads:
+        await client.refresh()
+    _, kwargs = mock_reads.call_args
+    assert kwargs["timeout"] == 2.0
+    assert kwargs["retries"] == 1
+
+
 async def test_probe_passes_zero_retry_delay():
     """_probe() must explicitly use retry_delay=0.
 


### PR DESCRIPTION
Raises the `refresh()` / `refresh_plant()` / `watch_plant()` default request budget from `timeout=1.0s, retries=0` to **`timeout=2.0, retries=1`**, fixing the contended-bus fragility in #132.

## Why

The inverter serialises Modbus requests, so when other clients (GivTCP, the vendor app, Predbat) poll the same unit, the old tight budget on the *hot poll path* lost the race and emitted spurious `register read failed` / `treating plant as unreachable` timeouts even though the device was responsive. Seen live on a HYBRID_GEN1 and on Nick's EMS (givenergy-hass#52); the #132 probe confirmed a 3s + 1-retry read succeeds 4/4 at every address under the same contention.

Odd asymmetry this corrects: `load_config` (config banks, run occasionally) was already patient at `2.0s/3`, while `refresh` (run every poll cycle) was the aggressive one. The hot path had it backwards.

## Change

- `refresh` / `refresh_plant` / `watch_plant` defaults → `timeout=2.0, retries=1` (kept below `load_config`'s 3 retries — refresh runs far more often, so a runaway retry budget there costs more poll latency).
- `load_config` (2.0s/3) and the low-level `send_request_and_await_response` (no default — explicit is correct) unchanged.
- Test pinning the new default budget; `usage.md` tuning section updated with the values + contention rationale.

## Trade-off

A genuinely unreachable inverter now surfaces as failed a bit slower (~4s worst case vs ~1s). The hass coordinator's timeout-tolerance already absorbs transient blips, so this mainly stops crying wolf. Consumers wanting fail-fast can still pass a tighter budget.

Closes #132.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
