### PR TITLE
feat(commands): EMS-named export slot setters for API parity

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -260,6 +260,9 @@ case-by-case as model-specific mixins land in later 2.x minors.
 | `set_ems_discharge_slot_end(idx, t)` | Set just the end of EMS discharge slot `idx` |
 | `set_ems_charge_target_soc(idx, soc)` | EMS charge slot `idx` target SOC (0–100%) |
 | `set_ems_discharge_target_soc(idx, soc)` | EMS discharge slot `idx` target SOC (0–100%) |
+| `set_ems_export_slot(idx, timeslot)` | Set EMS plant export slot `idx` (1–3), or clear if `None` |
+| `set_ems_export_slot_start(idx, t)` | Set just the start of EMS export slot `idx` |
+| `set_ems_export_slot_end(idx, t)` | Set just the end of EMS export slot `idx` |
 | `set_ems_export_target_soc(idx, soc)` | EMS export slot `idx` target SOC (0–100%) |
 | `set_ems_export_power_limit(watts)` | EMS plant export power limit (watts) |
 

--- a/givenergy_modbus/client/commands.py
+++ b/givenergy_modbus/client/commands.py
@@ -404,6 +404,26 @@ def set_ems_discharge_target_soc(idx: int, target_soc: int) -> list[TransparentR
     ]
 
 
+def set_ems_export_slot(idx: int, timeslot: TimeSlot | None) -> list[TransparentRequest]:
+    """Set an EMS plant export time slot by index (1-3), or clear it if None.
+
+    EMS export slots are the same HR(2062-2069) registers as `set_export_slot`
+    (export slots are EMS-only and already target the EMS address 0x11) — this is
+    the EMS-named alias for parity with `set_ems_charge_slot`/`set_ems_discharge_slot`.
+    """
+    return set_export_slot(idx, timeslot)
+
+
+def set_ems_export_slot_start(idx: int, t: dt_time | None) -> list[TransparentRequest]:
+    """Set just the start of EMS plant export slot idx (1-3), or clear it if None."""
+    return set_export_slot_start(idx, t)
+
+
+def set_ems_export_slot_end(idx: int, t: dt_time | None) -> list[TransparentRequest]:
+    """Set just the end of EMS plant export slot idx (1-3), or clear it if None."""
+    return set_export_slot_end(idx, t)
+
+
 def set_ems_export_target_soc(idx: int, target_soc: int) -> list[TransparentRequest]:
     """Set the SoC target (0-100%) for EMS plant export slot idx (1-3)."""
     if not 1 <= idx <= 3:

--- a/tests/client/test_commands.py
+++ b/tests/client/test_commands.py
@@ -521,6 +521,46 @@ def test_set_ems_export_power_limit():
     assert commands.set_ems_export_power_limit(3600) == [WriteHoldingRegisterRequest(2071, 3600)]
 
 
+def test_set_ems_export_slot_uses_ems_registers():
+    ts = TimeSlot.from_components(0, 0, 4, 30)
+    # EMS export slot 1 = (2062, 2063), slot 3 = (2068, 2069)
+    assert commands.set_ems_export_slot(1, ts) == [
+        WriteHoldingRegisterRequest(2062, 0),
+        WriteHoldingRegisterRequest(2063, 430),
+    ]
+    assert commands.set_ems_export_slot_start(3, dt_time(1, 0)) == [WriteHoldingRegisterRequest(2068, 100)]
+    assert commands.set_ems_export_slot_end(3, dt_time(2, 0)) == [WriteHoldingRegisterRequest(2069, 200)]
+
+
+def test_set_ems_export_slot_is_alias_of_export_slot():
+    """The EMS-named export setters are aliases of set_export_slot_* (same EMS registers)."""
+    ts = TimeSlot.from_components(1, 15, 6, 45)
+    assert commands.set_ems_export_slot(2, ts) == commands.set_export_slot(2, ts)
+    assert commands.set_ems_export_slot_start(2, ts.start) == commands.set_export_slot_start(2, ts.start)
+    assert commands.set_ems_export_slot_end(2, ts.end) == commands.set_export_slot_end(2, ts.end)
+
+
+def test_set_ems_export_slot_none_clears():
+    assert commands.set_ems_export_slot(1, None) == [
+        WriteHoldingRegisterRequest(2062, 0),
+        WriteHoldingRegisterRequest(2063, 0),
+    ]
+
+
+def test_set_ems_export_slot_index_validation():
+    for fn in (commands.set_ems_export_slot_start, commands.set_ems_export_slot_end):
+        with pytest.raises(ValueError, match="slot index"):
+            fn(0, dt_time(1, 0))
+        with pytest.raises(ValueError, match="slot index"):
+            fn(4, dt_time(1, 0))
+    # whole-slot setter validates the index too (via set_export_slot)
+    ts = TimeSlot.from_components(0, 0, 1, 0)
+    with pytest.raises(ValueError, match="slot index"):
+        commands.set_ems_export_slot(0, ts)
+    with pytest.raises(ValueError, match="slot index"):
+        commands.set_ems_export_slot(4, ts)
+
+
 def test_set_ems_target_soc_validation():
     for fn in (
         commands.set_ems_charge_target_soc,


### PR DESCRIPTION
Adds the EMS-named export slot setters the hass EMS-parity work needs (givenergy-hass#52).

The `set_ems_*` family had charge and discharge slot setters but **no export slot setter** — so wiring EMS export-schedule entities meant reaching for the un-prefixed `set_export_slot_*`. Those already write the EMS export registers `HR(2062-2069)` at the EMS address `0x11` (export slots are EMS-only and already write-safe via #134), so this is purely a naming-parity gap.

## Change

Adds `set_ems_export_slot`, `set_ems_export_slot_start`, `set_ems_export_slot_end` as thin aliases over the existing `set_export_slot_*`. **No new registers, no new write surface.** Tests assert they hit 2062-2069 and are byte-identical to the underlying setters; docs table updated.

Part of the EMS/inverter control-parity handoff. The other requested setters split into: already-covered (`set_ems_plant` for Flexi EMS Control; battery cutoff ≈ existing `set_battery_power_reserve`), and a set with **no known register** (self-heating, winter conditioning, EPS enable, export priority) that need GE-portal write-captures to identify safely — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
