### PR TITLE
feat(ems): add plant_enabled boolean read-back for Flexi EMS control

### DIFF
--- a/givenergy_modbus/model/ems.py
+++ b/givenergy_modbus/model/ems.py
@@ -2,7 +2,7 @@
 
 from typing import ClassVar
 
-from pydantic import ConfigDict, create_model
+from pydantic import ConfigDict, computed_field, create_model
 
 from givenergy_modbus.model.devices import InverterSummary
 from givenergy_modbus.model.inverter import Status
@@ -128,6 +128,20 @@ class Ems(_EmsBase, RegisterMetadataMixin):  # type: ignore[misc,valid-type]
     def is_valid(self) -> bool:
         """Try to detect if an EMS is present based on its attributes."""
         return self.ems_status is not None  # type: ignore[attr-defined]
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def plant_enabled(self) -> bool | None:
+        """Whether plant-level EMS ("Flexi EMS") control is enabled.
+
+        Boolean read-back of HR(2040), the register ``set_ems_plant()`` writes —
+        so this reflects the master-enable toggle's on/off state, suitable for
+        backing a switch entity. ``plant_status`` decodes the *same* register as
+        a coarse :class:`Status` enum; this is the dedicated boolean view (any
+        non-zero value = enabled). ``None`` if HR(2040) hasn't been read yet.
+        """
+        raw = self.plant_status  # type: ignore[attr-defined]
+        return None if raw is None else bool(raw)
 
     @property
     def managed_inverters(self) -> list[InverterSummary]:

--- a/tests/model/test_ems.py
+++ b/tests/model/test_ems.py
@@ -37,6 +37,18 @@ def test_plant_configuration():
     assert ems.export_power_limit == 5000  # type: ignore[attr-defined]
 
 
+def test_plant_enabled_readback():
+    """plant_enabled is a boolean read-back of HR(2040) — the register set_ems_plant writes."""
+    # enabled (HR2040 != 0)
+    assert Ems.from_register_cache(_cache({HR(2040): 1})).plant_enabled is True
+    # disabled (HR2040 == 0)
+    assert Ems.from_register_cache(_cache({HR(2040): 0})).plant_enabled is False
+    # unread → None, and must not break the "all None when empty" contract
+    empty = Ems.from_register_cache(RegisterCache())
+    assert empty.plant_enabled is None
+    assert "plant_enabled" in empty.model_dump()
+
+
 def test_charge_and_discharge_slots():
     cache = _cache(
         {


### PR DESCRIPTION
Adds the boolean read-back the hass EMS-parity work needs for a "Flexi EMS Control" switch (givenergy-hass#52).

## Gap

`set_ems_plant(bool)` writes HR(2040) (the EMS master-enable register), but the model only exposed `plant_status`, which decodes the **same** register as a coarse `Status` enum (WAITING/NORMAL/...). A HA switch needs a plain on/off boolean to reflect what the setter last wrote — `plant_status` can't cleanly back that.

## Change

Adds `Ems.plant_enabled: bool | None` as a `computed_field` — the boolean view of HR(2040) (non-zero = enabled, `None` if unread). `plant_status` is unchanged (kept as the enum view of the same register).

- **Polling:** no change — HR(2040) is already read for EMS (`load_config` reads HR(2040,36)).
- **Read/write pairing:** `plant_enabled` reads what `set_ems_plant` writes, so the switch state and setter agree.
- Verified against the EMS fixture (running plant → `plant_enabled=True`); empty cache → `None` (preserves the "all-None when empty" model_dump contract). Tests + tox green.

Note on a residual ambiguity (documented in the field docstring): HR(2040) is written as a 0/1 bool by `set_ems_plant` but read as a `Status` enum by `plant_status`. We've no capture of a *disabled* EMS to confirm whether the register is strictly an enable flag or an operational status — but since `plant_enabled` exists precisely to mirror the setter, `bool(HR2040)` is the right backing for the switch either way.

Part of the EMS-parity handoff; the register-unknown items stay in #144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
