### PR TITLE
chore: clear actionable in-code TODOs (PEP 758 parens, reserve bounds, stray debug line)

### DIFF
--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -539,7 +539,7 @@ class Client:
                 try:
                     if not Battery.from_register_cache(self.plant.register_caches[batt_addr]).is_valid():
                         break
-                except (KeyError, ValueError):  # fmt: skip  # TODO: drop parens when 3.13 support ends (PEP 758)
+                except KeyError, ValueError:
                     break
                 caps.lv_battery_addresses.append(batt_addr)
             _logger.info(

--- a/givenergy_modbus/client/commands.py
+++ b/givenergy_modbus/client/commands.py
@@ -212,8 +212,12 @@ def set_shallow_charge(val: int) -> list[TransparentRequest]:
 
 
 def set_battery_soc_reserve(val: int) -> list[TransparentRequest]:
-    """Set the minimum level of charge to maintain."""
-    # TODO what are valid values? 4-100?
+    """Set the minimum level of charge to maintain.
+
+    Bounds [4-100]% are unconfirmed against GE firmware docs (gone) but match
+    GivTCP's independent choice for the same register — treat as the working
+    assumption until a portal capture contradicts it.
+    """
     val = int(val)
     if not 4 <= val <= 100:
         raise ValueError(f"Minimum SOC / shallow charge ({val}) must be in [4-100]%")
@@ -237,8 +241,12 @@ def set_battery_discharge_limit(val: int) -> list[TransparentRequest]:
 
 
 def set_battery_power_reserve(val: int) -> list[TransparentRequest]:
-    """Set the battery power reserve to maintain."""
-    # TODO what are valid values?
+    """Set the battery power reserve to maintain.
+
+    Bounds [4-100]% are unconfirmed against GE firmware docs (gone) but match
+    GivTCP's independent choice for the same register — treat as the working
+    assumption until a portal capture contradicts it.
+    """
     val = int(val)
     if not 4 <= val <= 100:
         raise ValueError(f"Battery power reserve ({val}) must be in [4-100]%")

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -526,7 +526,7 @@ class Plant(GivEnergyBaseModel):
         for i in range(6):
             try:
                 battery = Battery.from_register_cache(self.register_caches[i + 0x32])
-            except (KeyError, ValueError):  # fmt: skip  # TODO: drop parens when 3.13 support ends (PEP 758)
+            except KeyError, ValueError:
                 # KeyError: no cache for that device yet. ValueError: an enum-typed
                 # register held a value outside the known set. Either way, treat as
                 # "not a battery" and stop probing rather than aborting the caller.

--- a/tests/client/test_detect.py
+++ b/tests/client/test_detect.py
@@ -344,6 +344,32 @@ async def test_detect_finds_lv_batteries():
 
 
 @pytest.mark.asyncio
+async def test_detect_battery_decode_value_error_stops_probe(monkeypatch):
+    """A battery register-decode ValueError stops the probe rather than propagating.
+
+    An out-of-range enum value while decoding a battery must be swallowed and treated
+    as "no valid battery" — it must not propagate out of detect().
+    """
+    from givenergy_modbus.model.battery import Battery
+
+    client = _make_client()
+    _prime_cache(client, 0x11, {HR(0): 0x2001, HR(21): 0})
+    _prime_battery_serial(client, 0x32)  # battery #1 present at 0x32
+
+    def _raise(cache):
+        raise ValueError("11 is not a valid BatteryState")
+
+    monkeypatch.setattr(Battery, "from_register_cache", staticmethod(_raise))
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
+        with patch.object(client, "_probe", new=AsyncMock(return_value=False)):
+            caps = await client.detect()
+
+    # The decode error at 0x32 is treated as "no valid battery" — probe stops, no raise.
+    assert caps.lv_battery_addresses == []
+
+
+@pytest.mark.asyncio
 async def test_detect_finds_meters():
     client = _make_client()
     _prime_cache(client, 0x11, {HR(0): 0x2001, HR(21): 0})

--- a/tests/test_pdu.py
+++ b/tests/test_pdu.py
@@ -1,4 +1,3 @@
-import logging
 import struct
 from typing import Any
 
@@ -182,12 +181,10 @@ def test_decoding(
     mbap_header: bytes,
     inner_frame: bytes,
     ex: ExceptionBase | None,
-    caplog,
 ):
     """Ensure we correctly decode Request messages to their unencapsulated PDU."""
     assert mbap_header[-1] == pdu_class.function_code
     frame = mbap_header + inner_frame
-    caplog.set_level(logging.DEBUG)  # FIXME remove
 
     if issubclass(pdu_class, ClientIncomingMessage):
         decoder = ClientIncomingMessage.decode_bytes


### PR DESCRIPTION
Housekeeping pass clearing the actionable in-code TODOs surfaced in the open-work review.

- **PEP 758 paren-drops.** Two `except (KeyError, ValueError):` clauses carried `# fmt: skip` + a "drop parens when 3.13 support ends" TODO. The floor is now `requires-python >= 3.14` (CI is 3.14-only), so that condition is met: dropped to the unparenthesised `except KeyError, ValueError:` form ruff format prefers on 3.14, matching the existing unparenthesised excepts elsewhere (e.g. `register_cache.py`). The `framer.py` except is left parenthesised — it binds `as e`, which PEP 758 still requires parens for.
- **Reserve-setter bounds.** `set_battery_soc_reserve` / `set_battery_power_reserve` had "what are valid values?" TODOs. GE's docs are gone; GivTCP independently uses the same `[4-100]%` bounds (carrying the same TODO). Reworded to record `[4-100]` as the GivTCP-corroborated working assumption rather than an open question.
- **Stray debug line.** Removed `caplog.set_level(DEBUG)  # FIXME remove` in `test_pdu` (the test doesn't assert on logs) plus the now-unused `caplog` param and `logging` import.

Left `read_registers.py`'s "FIXME how to test crc" — that's a genuine open testing question, not a trivial cleanup. No behaviour change; tox green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
