### PR TITLE
docs: reconcile v2.1 roadmap with shipped reality (a3→a11)

### DIFF
--- a/docs/v2.1-roadmap.md
+++ b/docs/v2.1-roadmap.md
@@ -6,160 +6,140 @@ small, frequent prereleases rather than a single "land everything, then
 release" push — each alpha self-contained enough that scope can move
 between alphas, or fall out to v2.2, without blocking the line.
 
-The roadmap groups open `v2.1`-labelled GitHub issues and items from
-[post-v2-improvement-plan.md](post-v2-improvement-plan.md) by theme; each
-alpha is roughly one theme.
+> **Reconciled 2026-05-31** against shipped reality (a3 → a11). The original
+> a4/a5/b1 theme plan was overtaken by a real-user-driven arc (EMS support for
+> a live install via [givenergy-hass#52](https://github.com/dewet22/givenergy-hass/issues/52)),
+> which produced more than the plan pencilled in — including the wire-capture
+> fixtures and golden-master harness originally slated for beta. The cadence
+> philosophy held; the specific themes didn't. "What's next" below is now
+> re-derived from the actual open issues rather than the superseded plan.
 
 ## Cadence philosophy
 
 - Release often, iterate visibly. The PyPI alpha publishes downstream
   dispatch events to `givenergy-hass` and `givenergy-cli`, so each cut
-  becomes a tester checkpoint.
+  becomes a tester checkpoint. This worked exactly as intended — Nick's
+  live EMS install drove a4–a11 through fast feedback on each alpha.
 - Self-contained alphas. If scope slips on one item, it falls out and
   becomes a v2.2.0 candidate rather than gating the line. Better a
   shipped narrower release than a wider one that never ships.
-- Investigation items (#91, #78) ride alongside but don't gate any
-  release. They produce findings and shape later design decisions.
-- Documentation: each alpha bumps the relevant section of the changelog
-  via conventional-commit prefixes; the release workflow walks the
-  range since the previous tag (see `scripts/release.py`).
+- Investigation items ride alongside but don't gate any release. They
+  produce findings and shape later design decisions.
+- Documentation: each alpha's changelog section is generated from
+  conventional-commit prefixes; the release workflow walks the range
+  since the previous tag (see `scripts/release.py`).
 
-## Sequence
+## Shipped (a3 → a11)
 
-### 2.1.0a3 — infrastructure consolidation *(shipped 2026-05-28)*
+What actually landed. Grouped by theme rather than strict per-alpha, since
+the work cut across alphas.
 
-Low-risk hardening of the foundation. Zero library-behaviour change as
-far as a tester observes, but unblocks safer work in subsequent alphas
-and validates the release workflow itself — this was the first release
-after the fetch-depth bug fix, and the generated CHANGELOG section came
-out complete.
+**EMS support** — the dominant arc, driven by a live EMS + 2-inverter install:
+- EMS-aware polling: skip inverter-style banks on EMS controllers (#93, a4);
+  read + sanity-check the IR(2040) rollup at detect (#109/#111, a5).
+- Device addressing redesign: `0x11` is the inverter's canonical address, not
+  `0x32`; removed the blanket rewrite, made addressing model-derived (#119/#121,
+  a5). Live-validated on HYBRID_GEN1 hardware (reads `0x31`, writes `0x11`).
+- EMS plant writes: charge/discharge/export slots, SoC targets, export power
+  limit (#134, a7); per-endpoint + EMS-named export setters for HA entity
+  parity (#138 a8, #143 a10); `plant_enabled` read-back (#145, a11).
+- EMS serial-format recognition to silence per-poll warnings (a7).
 
-Shipped:
+**Wire-capture fixtures + golden master** *(was planned for b1; landed early)*:
+- Real redacted EMS/hybrid/AIO captures with per-plant READMEs (#103 a4, #120 a5).
+- Date-preserving serial redaction (#113/#116, a5).
+- Golden-master regression tests replaying fixtures through the full
+  classification/decode machinery (#137, a7); register-node documentation (#140, a9).
 
-- Documentation warning cleanup
-  ([post-v2 §9](post-v2-improvement-plan.md#9-documentation-warning-cleanup)):
-  nav entries for the planning docs landed earlier (in the a2-prep
-  doc sweep); a3 fixed the remaining `../LICENSE` relative-link warning
-  by switching to an absolute GitHub URL.
-- Cleaner release artifact checks
-  ([§8](post-v2-improvement-plan.md#8-cleaner-release-artifact-checks)):
-  `tox -e build` now builds into the per-env tempdir so `twine check`
-  only sees the current run's artifacts.
-- Fail CI on async resource warnings
-  ([§4](post-v2-improvement-plan.md#4-fail-ci-on-async-resource-warnings)):
-  `PytestUnraisableExceptionWarning` and unawaited-coroutine
-  `RuntimeWarning` are now errors. Full suite stayed green.
-- Stricter type checking
-  ([§7](post-v2-improvement-plan.md#7-stricter-type-checking)):
-  `check_untyped_defs = true` for production code. Production passed
-  cleanly across all 26 source files; 58 historical findings in
-  `tests/*` were scoped-deferred via a per-module override.
+**Resilience + correctness:**
+- `RefreshPartiallySucceeded` / `RefreshFailed` partial-failure contract (#125, a5).
+- Contended-bus refresh defaults `2.0s/1 retry` (#132, a9).
+- Per-attribute display precision (#129, a6); unified `Inverter` facade for
+  EMS-managed topology (#98, a4).
 
-Slipped: the stretch goal **dry-run write validation
-([§2](post-v2-improvement-plan.md#2-dry-run-write-validation))** —
-deferred so it can land alongside the closely-coupled write-safety work
-in a5 (or earlier as an a4 stretch if it fits).
+**Infra:** lean CI matrix (Linux per-PR, cross-OS weekly, a5); `uv` security
+bump (a9); release-workflow hardening (a3).
 
-### 2.1.0a4 — model-layer correctness
+## What's next
 
-Mechanical refactors plus one small slice of `RegisterCache` design
-work.
+Re-derived from the open issue tracker. No fixed alpha assignments — pick by
+what a consumer needs next or what unblocks the beta.
 
-- [#74](https://github.com/dewet22/givenergy-modbus/issues/74) re-apply
-  reverted v2.0 model-layer correctness fixes — needs a history-dig to
-  enumerate what was reverted before applying.
-- [#76](https://github.com/dewet22/givenergy-modbus/issues/76) battery-energy
-  register unification behind computed properties — design context from
-  the [#78](https://github.com/dewet22/givenergy-modbus/issues/78)
-  investigation: the `_alt` source registers can be cached-and-stale
-  during V2 dongle bursts, so the facade needs to know to prefer the
-  primary source when both are available rather than treating them as
-  equally trustworthy.
-- [#65](https://github.com/dewet22/givenergy-modbus/issues/65) RegisterCache
-  freshness timestamps — start narrow: record per-bank `last_updated` and
-  expose via an accessor. Defer freshness-aware invalidation policy to a
-  later alpha (or v2.2).
-- *Stretch*: dry-run write validation
-  ([post-v2 §2](post-v2-improvement-plan.md#2-dry-run-write-validation))
-  — deferred from a3. Independent of the items above but small; will
-  slot in if there's room, otherwise lands in a5 next to §1 where the
-  write-safety theming fits naturally.
+**Original a4/a5 items never actioned** (still open, still wanted):
+- [#74](https://github.com/dewet22/givenergy-modbus/issues/74) — re-apply
+  reverted v2.0 model-layer correctness fixes (needs the history-dig first).
+- [#76](https://github.com/dewet22/givenergy-modbus/issues/76) — unify the
+  battery-energy registers behind computed properties.
+- [#65](https://github.com/dewet22/givenergy-modbus/issues/65) — RegisterCache
+  freshness timestamps (record-only; invalidation policy stays a v2.2 item).
+- [#75](https://github.com/dewet22/givenergy-modbus/issues/75) — *re-scoped*:
+  the command mixin landed; what remains is the per-model write-safety contract
+  (reject setters that don't apply to the detected model).
 
-### 2.1.0a5 — command dispatch and write safety
+**Surfaced by the EMS arc:**
+- [#144](https://github.com/dewet22/givenergy-modbus/issues/144) — identify
+  registers for self-heating / winter conditioning / EPS-enable / export-priority
+  (blocked on GE-portal write-captures; the rest of the EMS-parity request shipped).
+- [#117](https://github.com/dewet22/givenergy-modbus/issues/117) — cross-frame
+  redactor serial-leak edge (a genuine redaction gap worth closing).
+- [#108](https://github.com/dewet22/givenergy-modbus/issues/108) — EMS rollup
+  bitfield decode mismatch against real capture.
+- [#48](https://github.com/dewet22/givenergy-modbus/issues/48) — field-validate
+  register mappings inherited from britkat's fork (open-ended audit).
 
-Pairs the two write-safety items that are clearly coupled. Largest design
-load of the alpha series, but #75 has a natural incremental shape (move
-existing commands first, layer model-specific contracts on top).
+## Path to 2.1.0b1
 
-- [#75](https://github.com/dewet22/givenergy-modbus/issues/75) move
-  commands onto Inverter so model-specific contracts are enforceable.
-  First slice: relocate existing commands from
-  `givenergy_modbus.client.commands` onto `SinglePhaseInverter` /
-  `ThreePhaseInverter` (the `_InverterCommands` mixin scaffolding is
-  already in place). Subsequent slices: introduce model-specific mixins
-  (three-phase, EMS, pause-mode) that compose additively.
-- Model-aware write policy at the Client boundary
-  ([post-v2 §1](post-v2-improvement-plan.md#1-model-aware-write-policy-at-the-client-boundary)) —
-  layered on top of #75. Once commands know their model, the
-  `Client.execute()` boundary can reject writes whose target register
-  isn't in the detected model's safe set.
-- Dry-run write validation
-  ([post-v2 §2](post-v2-improvement-plan.md#2-dry-run-write-validation))
-  if it didn't already land as an a4 stretch. Themewise it fits here:
-  §1 rejects unsafe writes at the boundary, §2 lets callers ask
-  "would this write be accepted?" without actually firing it.
+The line has had 11 alphas and the model layer has settled — the original beta
+criterion ("API stable, done rearranging the model layer") is largely met. Before
+promoting to beta:
 
-### 2.1.0b1 — API surface stabilisation
+- **Confirm the EMS write path on live hardware.** #134 shipped EMS writes
+  correct-by-construction + register-safety-reviewed, but they haven't been
+  exercised against a real EMS. The live write-test is being driven from
+  givenergy-hass#52; a clean result is the last gate on the EMS feature.
+- **Decide [#106](https://github.com/dewet22/givenergy-modbus/issues/106)
+  (graph-shaped Plant) in-or-out.** It's the one large architectural item left.
+  If it's a v2.2 effort (likely — it's a big abstraction shift), say so explicitly
+  so it stops shadowing the beta.
+- Pick up whichever of the "what's next" items are tractable; let the rest fall
+  to v2.2 rather than gate the beta.
 
-First beta. The breaking changes (Pydantic v2 migrations, `work_time_total_hours`
-rename) have had several alphas of soak time by this point. Beta promotes
-the line out of "still rearranging the model layer" and into "API is
-stable, fix bugs and tighten contracts".
+Beta then promotes the line out of "still rearranging the model layer" into "API
+stable, fix bugs and tighten contracts", with public-API compatibility tests and
+register provenance/confidence
+([post-v2 §5/§10](post-v2-improvement-plan.md)) as the beta's own scope.
 
-- Register provenance and confidence
-  ([post-v2 §5](post-v2-improvement-plan.md#5-register-provenance-and-confidence)) —
-  attach source / freshness / bounds-passed metadata to register reads.
-  Easier now that `RegisterDefinition` is a Pydantic model.
-- Public API compatibility tests
-  ([post-v2 §10](post-v2-improvement-plan.md#10-public-api-compatibility-tests)) —
-  start with a snapshot of the import surface (`__all__`,
-  module-level exports) and grow from there.
-- Broader golden-frame fixtures
-  ([post-v2 §6](post-v2-improvement-plan.md#6-broader-golden-frame-fixtures)) —
-  the [#78](https://github.com/dewet22/givenergy-modbus/issues/78)
-  investigation has produced wire captures; promote a curated subset
-  into durable, redacted test fixtures spanning device families.
-- [#48](https://github.com/dewet22/givenergy-modbus/issues/48)
-  field-validate register mappings inherited from britkat's fork —
-  open-ended audit; scope to whatever's tractable inside the beta
-  window.
+## 2.1.0rc1 → 2.1.0
 
-### 2.1.0rc1 → 2.1.0
-
-Soak period. No new scope; only bug fixes from beta tester feedback.
-Final cut when consumers report clean.
+Soak period. No new scope; only bug fixes from beta-tester feedback. Final cut
+when consumers report clean.
 
 ## Investigation threads (no release gating)
 
-- [#91](https://github.com/dewet22/givenergy-modbus/issues/91) detect
-  frozen BMS cache during firmware updates — needs more wire capture
-  data covering firmware-update events.
-- [#78](https://github.com/dewet22/givenergy-modbus/issues/78) Pattern
-  A/B dongle behaviour — ongoing record, framing for related fixes.
+- [#91](https://github.com/dewet22/givenergy-modbus/issues/91) — detect frozen
+  BMS cache during firmware updates (needs firmware-update wire captures).
+- [#147](https://github.com/dewet22/givenergy-modbus/issues/147) — BMS block
+  dropouts on the battery sub-bus (Pattern B from #78; needs paired RS485 capture).
+- [#114](https://github.com/dewet22/givenergy-modbus/issues/114) — undecoded
+  function #57 frame; [#100](https://github.com/dewet22/givenergy-modbus/issues/100)
+  — WO-prefix LAN-config broadcast; [#115](https://github.com/dewet22/givenergy-modbus/issues/115)
+  — function #134 Gen1 BPM workaround.
+- [#141](https://github.com/dewet22/givenergy-modbus/issues/141) — three-phase
+  grid-power register nodes (needs a 3-phase capture).
 - Internal refresh serialization
   ([post-v2 §3](post-v2-improvement-plan.md#3-internal-refresh-serialization)) —
-  needs design for the locking model before code. Could be a v2.2 item
-  if it grows; flagged here so it doesn't get forgotten.
+  needs the locking-model design first; likely a v2.2 item.
 
 ## Out of scope for v2.1
 
-If something falls out of an alpha and won't fit before beta, it becomes
-a v2.2 candidate. Better a shipped narrower v2.1 than a perpetually
-in-progress one. Likely v2.2 candidates if v2.1 stays disciplined:
+If something falls out and won't fit before beta, it becomes a v2.2 candidate.
+Better a shipped narrower v2.1 than a perpetually in-progress one. Likely v2.2:
 
-- Freshness-aware invalidation policy on `RegisterCache` (the policy
-  layer above [#65](https://github.com/dewet22/givenergy-modbus/issues/65)'s
-  recording layer).
-- Broader EMS / Gateway command surface (sibling to #75's pattern).
-- Internal refresh serialization (post-v2 §3) if the design work hasn't
-  matured by beta.
+- The graph-shaped Plant abstraction
+  ([#106](https://github.com/dewet22/givenergy-modbus/issues/106)) if it doesn't
+  make the beta cut.
+- Freshness-aware `RegisterCache` invalidation policy (the layer above
+  [#65](https://github.com/dewet22/givenergy-modbus/issues/65)'s recording).
+- Internal refresh serialization
+  ([post-v2 §3](post-v2-improvement-plan.md#3-internal-refresh-serialization)) if
+  the design hasn't matured.


### PR DESCRIPTION
Reconciles `docs/v2.1-roadmap.md` with what actually shipped.

## The gap

The doc described a clean `a3→a4→a5→b1` theme sequence (model-layer correctness, then command dispatch, then beta). Reality ran `a3→a11`, driven by a live EMS install (givenergy-hass#52) rather than the planned themes — and the doc was never updated, so it misrepresented both what's done (#74/#76/#65 shown as a4 work that never happened) and what's next (a6-a11 absent entirely; the b1 golden-frame fixtures already shipped during the alphas).

## Refresh

- **Shipped (a3→a11)** ledger, grouped by theme (EMS support, fixtures/golden-master, resilience, infra) — faithful to the actual commits.
- **What's next** re-derived from the open tracker: the still-unactioned originals (#74/#76/#65, #75 re-scoped) plus what the work surfaced (#144/#117/#108/#48).
- **Path to 2.1.0b1** — new section: the line's had 11 alphas and the model layer has settled, so the gates are now the live EMS write-test (#134, driven from hass#52) and a decision on #106 (graph-Plant) in-or-out.
- Cadence philosophy + rc/soak plan kept — those held even though the themes didn't.

Docs-only; mkdocs build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
