### PR TITLE
fix(model): re-apply low-risk model-layer fixes reverted from v2.0 (#74)

### DIFF
--- a/givenergy_modbus/model/inverter_threephase.py
+++ b/givenergy_modbus/model/inverter_threephase.py
@@ -26,8 +26,11 @@ from givenergy_modbus.model.register import RegisterDefinition as Def
 def _inverter_fault_code2(val: int, word: int) -> list[str] | None:
     """Decode a 16-bit fault register for three-phase inverters.
 
-    `word` selects one of 9 fault tables (words 0–8), each covering 16 bits.
-    Three-phase inverters expose fault words at IR(1300)–IR(1307).
+    `word` selects one of 8 fault tables (words 0-7), each covering 16 bits.
+    Three-phase inverters expose fault words at IR(1300)-IR(1307); the
+    parallel-operation word at IR(1308) is documented in some firmware but
+    not surfaced by the model LUT (no `inverter_fault_codes_8` field), so the
+    decoder only ships tables for the wired-up range.
     """
     if val is None:
         return None
@@ -174,24 +177,6 @@ def _inverter_fault_code2(val: int, word: int) -> list[str] | None:
             "Battery low power",
             "NTC open",
             "Fan warning",
-            None,
-        ],
-        [  # word 8
-            "Parallel version different",
-            "Parallel output voltage different",
-            "Parallel battery voltage different",
-            "Parallel grid voltage different",
-            "Parallel grid frequency different",
-            "Parallel output setting different",
-            "Parallel parameter different",
-            None,
-            "Parallel host line loss",
-            "Parallel comm loss",
-            "Parallel low frequency sync line loss",
-            "Parallel high frequency sync line loss",
-            "Parallel fault",
-            None,
-            None,
             None,
         ],
     ]

--- a/givenergy_modbus/model/register_cache.py
+++ b/givenergy_modbus/model/register_cache.py
@@ -81,8 +81,16 @@ class RegisterCache(defaultdict[Register, int]):
         """Combine 6 registers into a datetime, with safe defaults for zeroes."""
         return datetime.datetime(self[y] + 2000, self.get(m, 1), self.get(d, 1), self[h], self[min], self[s])
 
-    def to_timeslot(self, start: Register, end: Register) -> "TimeSlot":
-        """Combine two registers into a time slot."""
+    def to_timeslot(self, start: Register, end: Register) -> "TimeSlot | None":
+        """Combine two registers into a time slot, or None if either is unset.
+
+        Mirrors Converter.timeslot: a missing/None endpoint, or the raw value 60
+        (a hardware sentinel for an unset slot — the portal shows '--:--'), means
+        "unset". Both would otherwise raise ValueError in TimeSlot.from_repr.
+        """
         from givenergy_modbus.model import TimeSlot
 
-        return TimeSlot.from_repr(self[start], self[end])
+        start_val, end_val = self.get(start), self.get(end)
+        if start_val is None or end_val is None or start_val == 60 or end_val == 60:
+            return None
+        return TimeSlot.from_repr(start_val, end_val)

--- a/tests/model/test_register.py
+++ b/tests/model/test_register.py
@@ -182,7 +182,8 @@ def test_inverter_fault_code2():
     # word 3, bit 0 (MSB) → "Battery reversed"
     result = _inverter_fault_code2(0x8000, 3)
     assert result == ["Battery reversed"]
-    # out-of-range word → None
+    # out-of-range word → None (LUT covers 0..7 only; word 8+ unreachable)
+    assert _inverter_fault_code2(0xFFFF, 8) is None
     assert _inverter_fault_code2(0xFFFF, 9) is None
     # None bits produce no output (word 4 has mostly None)
     assert _inverter_fault_code2(0x8000, 4) == []

--- a/tests/model/test_register_cache.py
+++ b/tests/model/test_register_cache.py
@@ -124,4 +124,36 @@ def test_to_timeslot():
         }
     )
     assert TimeSlot.from_components(10, 30, 23, 59) == rc.to_timeslot(HR(14), IR(17))
-    assert TimeSlot.from_components(0, 0, 0, 0) == rc.to_timeslot(IR(22), IR(23))
+    # Missing endpoints read as unset (None), not as a midnight (0,0) slot — a missing
+    # register isn't "00:00". (Previously the defaultdict returned 0 for these.)
+    assert rc.to_timeslot(IR(22), IR(23)) is None
+    # An endpoint genuinely read as 0 (HHMM 0000 = midnight) is still a valid slot.
+    rc[HR(20)] = 0
+    rc[HR(21)] = 0
+    assert TimeSlot.from_components(0, 0, 0, 0) == rc.to_timeslot(HR(20), HR(21))
+
+
+def test_to_timeslot_returns_none_for_unset_slot_sentinel():
+    """Raw value 60 is the hardware sentinel for an unset slot — mirror Converter.timeslot."""
+    rc = RegisterCache(
+        registers={
+            HR(0): 60,
+            HR(1): 60,
+            HR(2): 1030,
+        }
+    )
+    assert rc.to_timeslot(HR(0), HR(1)) is None
+    assert rc.to_timeslot(HR(0), HR(2)) is None
+    assert rc.to_timeslot(HR(2), HR(0)) is None
+
+
+def test_to_timeslot_returns_none_for_missing_or_none_endpoint():
+    """A missing or explicitly-None endpoint is unset — mirror Converter.timeslot's guard.
+
+    Uses .get() so a missing key reads as None (and doesn't mutate the defaultdict
+    by inserting a 0), rather than raising ValueError in TimeSlot.from_repr.
+    """
+    rc = RegisterCache(registers={HR(0): 1030, HR(1): None})
+    assert rc.to_timeslot(HR(0), HR(1)) is None  # endpoint explicitly None
+    assert rc.to_timeslot(HR(0), HR(9)) is None  # endpoint missing entirely
+    assert HR(9) not in rc  # .get() must not have inserted a default 0


### PR DESCRIPTION
Re-applies the low-risk subset of the five model-layer fixes bundled in `752cd9f` (reverted as `d0b25dc` to keep the v2.0 release scope tight — tracked in #74).

Each was re-evaluated on its own merits; only two are still needed, and three turned out moot:

## Re-applied (with their reverted tests)

- **#1 fault-code LUT trim** — `_inverter_fault_code2` defined a word-8 (parallel-operation) table the LUT never wires up (only `inverter_fault_codes_0..7` at IR(1300-1307)). Trimmed the unreachable table; docstring notes where IR(1308) sits if ever surfaced. Test asserts word 8 is now out-of-range → None.
- **#5 to_timeslot 60-sentinel** — `RegisterCache.to_timeslot` didn't mirror `Converter.timeslot`'s handling of raw 60 (the hardware "unset slot" sentinel), so a cache-helper caller would `ValueError` on data the model layer accepts as unset. Returns None now; test covers the sentinel in either endpoint.

## No longer needed

- **#2 from_dict optional-forwarding** — superseded by the v2.0.0-legacy `from_dict` hardening (#89); it already uses `.get(k) or []` for the optional list fields.
- **#3 frame-rewrite via `capabilities.inverter_address`** — obsolete: #121 removed the `0x11/0x00→0x32` rewrite entirely.
- **#4 ReadMeterProductRegistersResponse wiring** — stays blocked on a downstream `MeterProduct` consumer; additive and unexercised, no loss leaving it for now.

Closes #74. Tox green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
