### PR TITLE
feat(model): route battery-energy registers by model, not live values (#76)

### DIFF
--- a/givenergy_modbus/model/inverter.py
+++ b/givenergy_modbus/model/inverter.py
@@ -548,10 +548,16 @@ class SinglePhaseInverterRegisterGetter(RegisterGetter):
         # Holding Registers, block 4080-4139
         #
         "pv_power_setting": Def(C.uint32, None, HR(4107), HR(4108)),
-        "e_battery_discharge_total_alt": Def(C.uint32, None, HR(4109), HR(4110)),
-        "e_battery_charge_total_alt": Def(C.uint32, None, HR(4111), HR(4112)),
-        "e_battery_discharge_today": Def(C.uint16, None, HR(4113)),
-        "e_battery_charge_today": Def(C.uint16, None, HR(4114)),
+        # DEAD: never polled. No read path in this repo or GivTCP requests HR>=4000
+        # (our max poll base is HR(240); GivTCP's add_regs detect-probe candidates top
+        # out at HR(300)). Defined for naming symmetry with the IR alt sources and as
+        # scaffold for a future #48 "does this block respond on real hardware?" probe;
+        # no model's _BATTERY_ENERGY_SOURCE routes here. The C.deci scaling diverges
+        # from GivTCP's raw (None) defs — moot while unpolled, reconcile under #48.
+        "e_battery_discharge_total_alt2": Def(C.uint32, C.deci, HR(4109), HR(4110)),
+        "e_battery_charge_total_alt2": Def(C.uint32, C.deci, HR(4111), HR(4112)),
+        "e_battery_discharge_today_alt3": Def(C.uint16, C.deci, HR(4113)),
+        "e_battery_charge_today_alt3": Def(C.uint16, C.deci, HR(4114)),
         #
         # Holding Registers, block 4140-4199
         #
@@ -609,8 +615,8 @@ class SinglePhaseInverterRegisterGetter(RegisterGetter):
         "e_grid_in_total": Def(C.uint32, C.deci, IR(32), IR(33)),
         # IR(34) unknown, skip
         "e_load_day": Def(C.deci, None, IR(35)),
-        "e_battery_charge_day": Def(C.deci, None, IR(36)),
-        "e_battery_discharge_day": Def(C.deci, None, IR(37)),
+        "e_battery_charge_today_alt1": Def(C.deci, None, IR(36)),
+        "e_battery_discharge_today_alt1": Def(C.deci, None, IR(37)),
         "countdown": Def(C.uint16, None, IR(38)),
         "fault_code": Def(C.uint32, (C.hex, 8), IR(39), IR(40)),
         "t_inverter_heatsink": Def(C.deci, None, IR(41), min=-40.0, max=100.0),
@@ -644,16 +650,38 @@ class SinglePhaseInverterRegisterGetter(RegisterGetter):
         #
         # Input Registers, block 180-239
         #
-        "e_battery_discharge_alt": Def(C.deci, None, IR(180)),
-        "e_battery_charge_alt": Def(C.deci, None, IR(181)),
-        "e_battery_discharge_day_alt": Def(C.deci, None, IR(182)),
-        "e_battery_charge_day_alt": Def(C.deci, None, IR(183)),
+        "e_battery_discharge_total_alt1": Def(C.deci, None, IR(180)),
+        "e_battery_charge_total_alt1": Def(C.deci, None, IR(181)),
+        "e_battery_discharge_today_alt2": Def(C.deci, None, IR(182)),
+        "e_battery_charge_today_alt2": Def(C.deci, None, IR(183)),
         #
         # Input Registers, block 240-300
         # Gen3
         #
         "p_combined_generation": Def(C.uint32, None, IR(247), IR(248), max=100000),
     }
+
+
+# Per-(specific-model, metric) authoritative battery-energy source, keyed on the
+# Model resolved by resolve_model() — NOT the coarse `self.model` family. Declared
+# only where a wire capture positively confirms it; an absent model or metric routes
+# to None (honest "no evidence yet" + a forcing function for which captures to chase).
+# "today"/"total" each map to an altN whose register name is built as
+# e_battery_{charge,discharge}_{metric}_{altN} (see _battery_energy / the LUT renames).
+#
+#   alt1 = IR(36/37) daily, IR(180/181) total   alt2 = IR(182/183) daily, HR total (dead)
+#   alt3 = HR(4113/4114) daily (dead, never polled — see #48)
+#
+# Evidence (tests/fixtures/captures/): GEN1 populates the alt2 daily registers as
+# authoritative (non-alt read 0 on some firmware) and IR alt1 totals (17526/14791).
+# AC/AIO populate alt1 daily; their IR totals read a real 0 and where the lifetime
+# total actually lives is unknown (the HR block is never polled by anyone) — so total
+# is deliberately left undeclared → None rather than reporting a misleading 0.
+_BATTERY_ENERGY_SOURCE: dict[Model, dict[str, str]] = {
+    Model.HYBRID_GEN1: {"today": "alt2", "total": "alt1"},
+    Model.AC: {"today": "alt1"},
+    Model.ALL_IN_ONE: {"today": "alt1"},
+}
 
 
 _SinglePhaseInverterBase = create_model(  # type: ignore[call-overload]
@@ -694,6 +722,53 @@ class SinglePhaseInverter(  # type: ignore[valid-type,misc]
         if self.e_pv1_day is None or self.e_pv2_day is None:  # type: ignore[attr-defined]
             return None
         return self.e_pv1_day + self.e_pv2_day  # type: ignore[attr-defined]
+
+    def _battery_energy(self, direction: str, metric: str) -> float | None:
+        """Route a battery-energy metric to this model's authoritative alt register.
+
+        Which register location a firmware populates is a *static* property of the
+        model, not something to infer from live values (the #119 lesson — see #76 /
+        Codex review on #150). `_BATTERY_ENERGY_SOURCE` declares, per specific model,
+        which `altN` source is authoritative for each metric; the value is returned
+        verbatim including a legitimate 0.0. Returns None when the model or metric is
+        undeclared (honest "no evidence yet") — no value inspection, no cross-source
+        fallback. Resolves the *specific* model the way `slot_map` does: `self.model`
+        decodes HR(0) alone and only yields the coarse family (e.g. HYBRID, not
+        HYBRID_GEN1), which would miss the models we special-case.
+        """
+        dtc = self.device_type_code  # type: ignore[attr-defined]
+        arm_fw = self.arm_firmware_version  # type: ignore[attr-defined]
+        if dtc is None or arm_fw is None:
+            return None
+        model = resolve_model(int(dtc, 16), int(arm_fw))
+        alt = _BATTERY_ENERGY_SOURCE.get(model, {}).get(metric)
+        if alt is None:
+            return None
+        return getattr(self, f"e_battery_{direction}_{metric}_{alt}")
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def e_battery_charge_today(self) -> float | None:
+        """Canonical daily battery charge energy (kWh), routed by model (see #76)."""
+        return self._battery_energy("charge", "today")
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def e_battery_discharge_today(self) -> float | None:
+        """Canonical daily battery discharge energy (kWh), routed by model (see #76)."""
+        return self._battery_energy("discharge", "today")
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def e_battery_charge_total(self) -> float | None:
+        """Canonical total battery charge energy (kWh), routed by model (see #76)."""
+        return self._battery_energy("charge", "total")
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def e_battery_discharge_total(self) -> float | None:
+        """Canonical total battery discharge energy (kWh), routed by model (see #76)."""
+        return self._battery_energy("discharge", "total")
 
     @property
     def slot_map(self) -> SlotMap:

--- a/tests/model/test_inverter.py
+++ b/tests/model/test_inverter.py
@@ -101,8 +101,8 @@ def test_inverter():
             "p_backup": None,
             "e_grid_in_total": None,
             "e_load_day": None,
-            "e_battery_charge_day": None,
-            "e_battery_discharge_day": None,
+            "e_battery_charge_today_alt1": None,
+            "e_battery_discharge_today_alt1": None,
             "countdown": None,
             "fault_code": None,
             "t_inverter_heatsink": None,
@@ -168,9 +168,13 @@ def test_inverter():
             "cmd_bms_flash_update": None,
             "enable_standard_self_consumption_logic": None,
             "e_battery_charge_today": None,
-            "e_battery_charge_total_alt": None,
+            "e_battery_charge_today_alt3": None,
+            "e_battery_charge_total": None,
+            "e_battery_charge_total_alt2": None,
             "e_battery_discharge_today": None,
-            "e_battery_discharge_total_alt": None,
+            "e_battery_discharge_today_alt3": None,
+            "e_battery_discharge_total": None,
+            "e_battery_discharge_total_alt2": None,
             "pv_power_setting": None,
             "e_inverter_export_total": None,
             "battery_voltage_adjust": None,
@@ -219,10 +223,10 @@ def test_inverter():
             "battery_discharge_limit_ac": None,
             "battery_pause_mode": None,
             "battery_pause_slot_1": None,
-            "e_battery_discharge_alt": None,
-            "e_battery_charge_alt": None,
-            "e_battery_discharge_day_alt": None,
-            "e_battery_charge_day_alt": None,
+            "e_battery_discharge_total_alt1": None,
+            "e_battery_charge_total_alt1": None,
+            "e_battery_discharge_today_alt2": None,
+            "e_battery_charge_today_alt2": None,
             "p_combined_generation": None,
         }
     )
@@ -262,16 +266,16 @@ def test_from_registers(register_cache):
         "debug_inverter": None,
         "discharge_soc_stop_1": None,
         "discharge_soc_stop_2": 0,
-        # 'e_battery_charge_day': 9.0,
-        # 'e_battery_charge_day_alt': 9.0,
-        "e_battery_charge_today": None,
-        # 'e_battery_charge_total': 174.4,
-        "e_battery_charge_total_alt": None,
-        # 'e_battery_discharge_day': 8.9,
-        # 'e_battery_discharge_day_alt': 8.9,
-        "e_battery_discharge_today": None,
-        # 'e_battery_discharge_total': 169.6,
-        "e_battery_discharge_total_alt": None,
+        # HYBRID_GEN1 (dtc 2001, arm 449): facade routes today→alt2, total→alt1 (#76).
+        # Raw IR alt1/alt2 sources are asserted in the IR-block sections below.
+        "e_battery_charge_today_alt3": None,  # HR(4114), dead/never polled
+        "e_battery_charge_today": 9.0,  # canonical: GEN1 today→alt2 (IR183)
+        "e_battery_charge_total_alt2": None,  # HR(4111-4112), dead/never polled
+        "e_battery_charge_total": 174.4,  # canonical: GEN1 total→alt1 (IR181)
+        "e_battery_discharge_today_alt3": None,  # HR(4113), dead/never polled
+        "e_battery_discharge_today": 8.9,  # canonical: GEN1 today→alt2 (IR182)
+        "e_battery_discharge_total_alt2": None,  # HR(4109-4110), dead/never polled
+        "e_battery_discharge_total": 169.6,  # canonical: GEN1 total→alt1 (IR180)
         # 'e_battery_throughput_total': 183.2,
         # 'e_discharge_year': 0.0,
         # 'e_grid_in_day': 20.9,
@@ -479,8 +483,8 @@ def test_from_registers(register_cache):
         "p_backup": 0,
         "e_grid_in_total": 365.3,
         "e_load_day": 9.3,
-        "e_battery_charge_day": 9.0,
-        "e_battery_discharge_day": 8.9,
+        "e_battery_charge_today_alt1": 9.0,  # IR(36)
+        "e_battery_discharge_today_alt1": 8.9,  # IR(37)
         "countdown": 30,
         "fault_code": "00000000",
         "t_inverter_heatsink": 22.2,
@@ -551,10 +555,10 @@ def test_from_registers(register_cache):
         "battery_discharge_limit_ac": None,
         "battery_pause_mode": None,
         "battery_pause_slot_1": None,
-        "e_battery_discharge_alt": 169.6,
-        "e_battery_charge_alt": 174.4,
-        "e_battery_discharge_day_alt": 8.9,
-        "e_battery_charge_day_alt": 9.0,
+        "e_battery_discharge_total_alt1": 169.6,  # IR(180)
+        "e_battery_charge_total_alt1": 174.4,  # IR(181)
+        "e_battery_discharge_today_alt2": 8.9,  # IR(182)
+        "e_battery_charge_today_alt2": 9.0,  # IR(183)
         "p_combined_generation": None,
     }
 
@@ -589,16 +593,16 @@ def test_from_registers_actual_data(register_cache_inverter_daytime_discharging_
         "debug_inverter": 0,
         "discharge_soc_stop_1": 0,
         "discharge_soc_stop_2": 0,
-        # 'e_battery_charge_day': 9.1,
-        # 'e_battery_charge_day_alt': 9.1,
-        "e_battery_charge_today": None,
-        # 'e_battery_charge_total': 183.5,
-        "e_battery_charge_total_alt": None,
-        # 'e_battery_discharge_day': 3.4,
-        # 'e_battery_discharge_day_alt': 3.4,
-        "e_battery_discharge_today": None,
-        # 'e_battery_discharge_total': 173.0,
-        "e_battery_discharge_total_alt": None,
+        # HYBRID_GEN1 (dtc 2001, arm 449): facade routes today→alt2, total→alt1 (#76).
+        # Raw IR alt1/alt2 sources are asserted in the IR-block sections below.
+        "e_battery_charge_today_alt3": None,  # HR(4114), dead/never polled
+        "e_battery_charge_today": 9.1,  # canonical: GEN1 today→alt2 (IR183)
+        "e_battery_charge_total_alt2": None,  # HR(4111-4112), dead/never polled
+        "e_battery_charge_total": 183.5,  # canonical: GEN1 total→alt1 (IR181)
+        "e_battery_discharge_today_alt3": None,  # HR(4113), dead/never polled
+        "e_battery_discharge_today": 3.4,  # canonical: GEN1 today→alt2 (IR182)
+        "e_battery_discharge_total_alt2": None,  # HR(4109-4110), dead/never polled
+        "e_battery_discharge_total": 173.0,  # canonical: GEN1 total→alt1 (IR180)
         # 'e_battery_throughput_total': 356.5,
         # 'e_discharge_year': 0.0,
         # 'e_grid_in_day': 19.8,
@@ -807,8 +811,8 @@ def test_from_registers_actual_data(register_cache_inverter_daytime_discharging_
         "p_backup": 0,
         "e_grid_in_total": 624.2,
         "e_load_day": 9.3,
-        "e_battery_charge_day": 9.1,
-        "e_battery_discharge_day": 3.4,
+        "e_battery_charge_today_alt1": 9.1,  # IR(36)
+        "e_battery_discharge_today_alt1": 3.4,  # IR(37)
         "countdown": 0,
         "fault_code": "00000000",
         "t_inverter_heatsink": 24.4,
@@ -879,10 +883,10 @@ def test_from_registers_actual_data(register_cache_inverter_daytime_discharging_
         "battery_discharge_limit_ac": None,
         "battery_pause_mode": None,
         "battery_pause_slot_1": None,
-        "e_battery_discharge_alt": 173.0,
-        "e_battery_charge_alt": 183.5,
-        "e_battery_discharge_day_alt": 3.4,
-        "e_battery_charge_day_alt": 9.1,
+        "e_battery_discharge_total_alt1": 173.0,  # IR(180)
+        "e_battery_charge_total_alt1": 183.5,  # IR(181)
+        "e_battery_discharge_today_alt2": 3.4,  # IR(182)
+        "e_battery_charge_today_alt2": 9.1,  # IR(183)
         "p_combined_generation": None,
     }
 
@@ -1130,3 +1134,90 @@ def test_work_time_total_hours_rename_and_deprecated_alias():
     dumped = inv.model_dump()
     assert "work_time_total_hours" in dumped
     assert "work_time_total" not in dumped
+
+
+def test_battery_energy_facade_routes_by_model():
+    """Battery-energy facade routes each metric to the model's declared altN (#76).
+
+    Which register a firmware populates is a static property of the model, declared in
+    _BATTERY_ENERGY_SOURCE — not inferred from live values (the #119 / #150-Codex
+    lesson). The declared source is returned verbatim, including a legitimate 0.0; an
+    undeclared model or metric returns None, with no value inspection and no
+    cross-source fallback. The specific model is resolved via DTC+arm_fw like slot_map,
+    so GEN1 is distinguished from the coarse HYBRID family.
+    """
+    from givenergy_modbus.model.register import HR, IR
+
+    # HYBRID_GEN1 (dtc 0x2001, arm 449): today→alt2 (IR182/183), total→alt1 (IR180/181).
+    # alt1 and alt2 daily are set to DIFFERENT values, so routing (not fallback) is what
+    # selects alt2 — a value-based picker could not tell them apart.
+    gen1 = SinglePhaseInverter.from_register_cache(
+        RegisterCache(
+            {
+                HR(0): 0x2001,
+                HR(21): 449,
+                IR(36): 110,  # charge today alt1 — ignored on GEN1
+                IR(183): 220,  # charge today alt2 — authoritative
+                IR(37): 330,  # discharge today alt1 — ignored
+                IR(182): 440,  # discharge today alt2 — authoritative
+                IR(181): 1000,  # charge total alt1 — authoritative
+                IR(180): 2000,  # discharge total alt1 — authoritative
+            }
+        )
+    )
+    assert gen1.e_battery_charge_today == 22.0  # alt2, not alt1's 11.0
+    assert gen1.e_battery_discharge_today == 44.0  # alt2, not alt1's 33.0
+    assert gen1.e_battery_charge_total == 100.0  # alt1
+    assert gen1.e_battery_discharge_total == 200.0  # alt1
+
+    # GEN1 declared source read as 0.0 is returned verbatim — NOT overridden by a
+    # non-zero in a different source (the Codex stale-zero case, now structurally
+    # impossible: alt2 is 0.0, alt1 is non-zero, the facade still returns 0.0).
+    gen1_zero = SinglePhaseInverter.from_register_cache(
+        RegisterCache({HR(0): 0x2001, HR(21): 449, IR(183): 0, IR(36): 910, IR(182): 0, IR(37): 870})
+    )
+    assert gen1_zero.e_battery_charge_today == 0.0
+    assert gen1_zero.e_battery_discharge_today == 0.0
+
+    # AC (dtc 0x3001): today→alt1 (IR36/37); total is undeclared → None even though
+    # IR180/181 read non-zero (their IR totals are a real 0 on hardware; where the
+    # lifetime total lives is unknown, so None beats a misleading value).
+    ac = SinglePhaseInverter.from_register_cache(
+        RegisterCache({HR(0): 0x3001, HR(21): 282, IR(36): 120, IR(37): 340, IR(181): 5000, IR(180): 6000})
+    )
+    assert ac.e_battery_charge_today == 12.0  # alt1
+    assert ac.e_battery_discharge_today == 34.0  # alt1
+    assert ac.e_battery_charge_total is None
+    assert ac.e_battery_discharge_total is None
+
+    # ALL_IN_ONE (dtc 0x8001): same routing as AC (today→alt1, total undeclared).
+    aio = SinglePhaseInverter.from_register_cache(RegisterCache({HR(0): 0x8001, HR(21): 612, IR(36): 150, IR(37): 250}))
+    assert aio.e_battery_charge_today == 15.0
+    assert aio.e_battery_discharge_today == 25.0
+    assert aio.e_battery_charge_total is None
+    assert aio.e_battery_discharge_total is None
+
+    # Undeclared model (HYBRID_GEN3, fw>302) → None for all four despite populated regs.
+    gen3 = SinglePhaseInverter.from_register_cache(
+        RegisterCache(
+            {
+                HR(0): 0x2003,
+                HR(21): 303,
+                IR(36): 111,
+                IR(37): 222,
+                IR(180): 333,
+                IR(181): 444,
+                IR(182): 555,
+                IR(183): 666,
+            }
+        )
+    )
+    assert gen3.e_battery_charge_today is None
+    assert gen3.e_battery_discharge_today is None
+    assert gen3.e_battery_charge_total is None
+    assert gen3.e_battery_discharge_total is None
+
+    # No model at all (DTC/arm unset) → None: can't resolve a specific model to route by.
+    bare = SinglePhaseInverter.from_register_cache(RegisterCache({IR(36): 110, IR(183): 220}))
+    assert bare.e_battery_charge_today is None
+    assert bare.e_battery_charge_total is None

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -1008,16 +1008,16 @@ def test_from_actual():
         "debug_inverter": 0,
         "discharge_soc_stop_1": 0,
         "discharge_soc_stop_2": 0,
-        # 'e_battery_charge_day': 5.7,
-        # 'e_battery_charge_day_alt': 5.7,
-        "e_battery_charge_today": None,
-        # 'e_battery_charge_total': 946.6,
-        "e_battery_charge_total_alt": None,
-        # 'e_battery_discharge_day': 5.9,
-        # 'e_battery_discharge_day_alt': 5.9,
-        "e_battery_discharge_today": None,
-        # 'e_battery_discharge_total': 906.1,
-        "e_battery_discharge_total_alt": None,
+        # HYBRID_GEN1 (dtc 0x2001, arm 449): facade routes today→alt2, total→alt1 (#76).
+        # Raw IR alt1/alt2 sources are asserted in the IR-block sections below.
+        "e_battery_charge_today_alt3": None,  # HR(4114), dead/never polled
+        "e_battery_charge_today": 5.7,  # canonical: GEN1 today→alt2 (IR183)
+        "e_battery_charge_total_alt2": None,  # HR(4111-4112), dead/never polled
+        "e_battery_charge_total": 946.6,  # canonical: GEN1 total→alt1 (IR181)
+        "e_battery_discharge_today_alt3": None,  # HR(4113), dead/never polled
+        "e_battery_discharge_today": 5.9,  # canonical: GEN1 today→alt2 (IR182)
+        "e_battery_discharge_total_alt2": None,  # HR(4109-4110), dead/never polled
+        "e_battery_discharge_total": 906.1,  # canonical: GEN1 total→alt1 (IR180)
         # 'e_battery_throughput_total': 1852.7,
         # 'e_discharge_year': 0.0,
         # 'e_grid_in_day': 12.3,
@@ -1225,8 +1225,8 @@ def test_from_actual():
         "p_backup": 0,
         "e_grid_in_total": 1978.3,
         "e_load_day": 4.3,
-        "e_battery_charge_day": 5.7,
-        "e_battery_discharge_day": 5.9,
+        "e_battery_charge_today_alt1": 5.7,  # IR(36)
+        "e_battery_discharge_today_alt1": 5.9,  # IR(37)
         "countdown": 0,
         "fault_code": "00000000",
         "t_inverter_heatsink": 32.2,
@@ -1297,10 +1297,10 @@ def test_from_actual():
         "battery_discharge_limit_ac": None,
         "battery_pause_mode": None,
         "battery_pause_slot_1": None,
-        "e_battery_discharge_alt": 906.1,
-        "e_battery_charge_alt": 946.6,
-        "e_battery_discharge_day_alt": 5.9,
-        "e_battery_charge_day_alt": 5.7,
+        "e_battery_discharge_total_alt1": 906.1,  # IR(180)
+        "e_battery_charge_total_alt1": 946.6,  # IR(181)
+        "e_battery_discharge_today_alt2": 5.9,  # IR(182)
+        "e_battery_charge_today_alt2": 5.7,  # IR(183)
         "p_combined_generation": None,
     }
 


### PR DESCRIPTION
Closes #76 — gives consumers a single canonical battery-energy attribute instead of forcing each to know the firmware-dependent register convention.

## What

The same metric appears in up to three register locations depending on firmware. The first cut (the commit this replaces) picked the live source **dynamically by value** (first-non-zero). Codex and Gemini both caught flaws in that — most sharply, a legitimate start-of-day daily `0.0` being overridden by a stale non-zero alt. The deeper issue: value-based inference is the same anti-pattern the #119 addressing arc taught us to drop — which register a firmware populates is a *static* property of the model, not something to infer at runtime.

So this reworks the approach:

- **Explicit `altN` register names.** The multi-source registers are renamed `alt1`/`alt2`/`alt3` (address order), dropping the false "primary" framing. `alt1` = IR(36/37) daily, IR(180/181) total; `alt2` = IR(182/183) daily, HR total; `alt3` = HR(4113/4114) daily.
- **Model-aware static facade.** `e_battery_{charge,discharge}_{today,total}` resolve the *specific* model (via the same `resolve_model` path `slot_map` uses — `self.model` only gives the coarse family) and return the source declared authoritative for that model in `_BATTERY_ENERGY_SOURCE`, verbatim, including a legitimate `0.0`. No value inspection, no cross-source fallback.
- **Declared only where a capture confirms it.** GEN1 → today=alt2, total=alt1 (capture-backed). AC/AIO → today=alt1; their total is deliberately left undeclared → `None`, because the IR total reads a real 0 and where the lifetime total actually lives is unknown. An undeclared model or metric returns `None` — an honest "no evidence yet", and a forcing function for which captures to chase.

## The HR(4080+) block is dead — and stays out of scope

While reworking this I confirmed the HR(4109-4114) totals block is never polled by anyone: no read path in this repo (max base HR(240)) or in GivTCP (its `add_regs` probe candidates top out at HR(300)) requests HR ≥ 4000. GivTCP defines the same registers and never reads them either, so there's no runtime evidence they respond on hardware — they can't be a declared source. I've kept the definitions (renamed to the `altN` tail) but flagged them dead in a comment; whether to add a deliberate live-hardware probe for that block belongs in #48, which also defers the deci-vs-raw scaling question there (it diverges from GivTCP's raw defs, but that's moot while unpolled).

## Breaking rename

This renames long-standing single-phase fields (`e_battery_charge_day`, `e_battery_*_alt`, …). Breaking for consumers reading the old names — acceptable in a v2.1 alpha, and the point of the change. The canonical facade names now match what `gateway.py` and `inverter_threephase.py` already expose, so naming is consistent across models.

Tests: a per-model routing test (GEN1 routes today→alt2 even when alt1 differs; a declared 0.0 returned verbatim — the Codex stale-zero case made structurally impossible; AC/AIO total→None; undeclared model→None) plus the migrated model_dump snapshots. Tox green (py314 + format + mypy + bandit + build + docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
