### PR TITLE
fix(client): redact serials split across capture-frame boundaries (#117)

### DIFF
--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -106,6 +106,72 @@ def redact(frame: bytes) -> bytes:
     return frame
 
 
+# Longest token redact() matches is a 10-char serial; an IPv4 dotted-quad can be
+# up to 15. Holding back the last 14 bytes guarantees any identifier straddling a
+# chunk boundary is reassembled before the boundary is emitted.
+_REDACT_LOOKBACK = 14
+
+
+class StreamRedactor:
+    """Stateful redactor for a chunked byte stream (e.g. raw socket reads).
+
+    ``redact()`` is per-buffer, so an identifier split across two chunks — the
+    prefix in one, the unit-bearing continuation in the next — is seen by neither
+    pass and leaks on reassembly (#117; observed in the EMS rollup at IR(2066+)).
+
+    This wrapper carries the trailing ``_REDACT_LOOKBACK`` bytes of each chunk over
+    to the next, redacts across the join, and only emits bytes once they're far
+    enough from the frontier that no further identifier can overlap them. Byte
+    count and offsets are preserved exactly (same guarantee as ``redact()``), so
+    the reassembled stream is identical-length to the raw one. Call ``flush()`` at
+    end-of-stream to emit the final held tail.
+
+    Not thread-safe; use one instance per capture stream (per direction).
+    """
+
+    def __init__(self) -> None:
+        # Raw bytes seen but whose redaction isn't yet settled, plus how many of
+        # them we've already emitted. We keep the *raw* prefix (not the redacted
+        # output) so each pass re-redacts with full left-context, and a match
+        # straddling a previous cut is never double-processed.
+        self._buffer = b""
+        self._emitted = 0
+
+    def feed(self, chunk: bytes) -> bytes:
+        """Absorb a chunk; return the bytes that are now safe to emit, redacted.
+
+        Bytes within ``_REDACT_LOOKBACK`` of the buffer end are held back — an
+        identifier could still extend into the next chunk — so they aren't emitted
+        until enough following bytes arrive (or ``flush()`` is called).
+        """
+        self._buffer += chunk
+        stable_end = len(self._buffer) - _REDACT_LOOKBACK
+        if stable_end <= self._emitted:
+            return b""
+        # Redact the whole buffer for full left-context (offset-preserving), then
+        # slice out only the newly-settled span [already-emitted, stable_end).
+        redacted = redact(self._buffer)
+        out = redacted[self._emitted : stable_end]
+        self._emitted = stable_end
+        # Prune the settled prefix so a long capture doesn't grow the buffer
+        # unbounded. Keep a lookback-sized margin behind the emit frontier as
+        # left-context (a match can span at most _REDACT_LOOKBACK bytes), so
+        # dropping bytes older than that can't change any future redaction.
+        if self._emitted > _REDACT_LOOKBACK:
+            drop = self._emitted - _REDACT_LOOKBACK
+            self._buffer = self._buffer[drop:]
+            self._emitted -= drop
+        return out
+
+    def flush(self) -> bytes:
+        """Emit the remaining held bytes, redacted. Call once at end of stream."""
+        redacted = redact(self._buffer)
+        out = redacted[self._emitted :]
+        self._buffer = b""
+        self._emitted = 0
+        return out
+
+
 class Client:
     """Asynchronous client for talking to a GivEnergy inverter over Modbus TCP.
 
@@ -162,6 +228,11 @@ class Client:
     connected = False
     _shutting_down = False
     _capture_sink: Callable[[Direction, bytes], None] | None = None
+    # Per-direction stream redactors for an active capture — carry a small tail
+    # across socket-read chunks so a serial split across a boundary is still
+    # redacted (#117). Created in capture_frames(), None when no capture runs.
+    _capture_redactor_rx: "StreamRedactor | None" = None
+    _capture_redactor_tx: "StreamRedactor | None" = None
     reader: StreamReader
     writer: StreamWriter
     network_consumer_task: Task | None
@@ -818,6 +889,22 @@ class Client:
         """Execute a set of requests. Caller is responsible for connecting first."""
         await self.execute(requests, timeout=timeout, retries=retries, retry_delay=retry_delay)
 
+    def _emit_to_sink(self, direction: "Direction", data: bytes) -> None:
+        """Hand redacted bytes to the active capture sink, swallowing sink errors.
+
+        The sink is a user-supplied callback. It runs inside the long-lived network
+        consumer/producer tasks (and the capture-close flush), so an exception it
+        raises would otherwise crash that background task and break the client. A
+        capture is a diagnostic tee, never load-bearing — log and carry on.
+        """
+        sink = self._capture_sink
+        if sink is None or not data:
+            return
+        try:
+            sink(direction, data)
+        except Exception:  # noqa: BLE001 — a capture sink must never break the client
+            _logger.exception("capture sink raised on %s frame; dropping it and continuing", direction)
+
     async def capture_frames(
         self,
         sink: Callable[[Direction, bytes], None],
@@ -825,10 +912,18 @@ class Client:
     ) -> None:
         """Tee redacted TX/RX wire frames to *sink* for *duration* seconds.
 
-        *sink* is called once per frame with the direction ('rx' or 'tx') and
-        the *redacted* bytes. The library always redacts before invoking the
-        sink so callers can't accidentally see raw hardware identifiers;
-        persistence, formatting and forwarding are the caller's choice.
+        *sink* is called with the direction ('rx' or 'tx') and the *redacted*
+        bytes. The library always redacts before invoking the sink so callers
+        can't accidentally see raw hardware identifiers; persistence, formatting
+        and forwarding are the caller's choice.
+
+        Redaction is cross-chunk-aware: a serial split across two socket reads is
+        still caught (#117), at the cost of the sink seeing the stream re-chunked
+        (a small trailing tail of each read is deferred to the next sink call, and
+        flushed when the capture ends). The reassembled byte stream is identical
+        in length and offsets to the raw one. Sinks must not assume one call maps
+        to one decodable frame — that was never guaranteed (reads tee raw socket
+        buffers, not framer output).
 
         Runs alongside the normal refresh loop — does not suspend reads or
         writes, just tees a copy of each frame to *sink*. Only one capture
@@ -838,17 +933,25 @@ class Client:
         if self._capture_sink is not None:
             raise RuntimeError("a frame capture is already running on this client")
         self._capture_sink = sink
+        self._capture_redactor_rx = StreamRedactor()
+        self._capture_redactor_tx = StreamRedactor()
         try:
             await asyncio.sleep(duration)
         finally:
+            # Flush each direction's held tail so the final bytes aren't lost.
+            for direction, redactor in (("rx", self._capture_redactor_rx), ("tx", self._capture_redactor_tx)):
+                if redactor is not None:
+                    self._emit_to_sink(direction, redactor.flush())  # type: ignore[arg-type]
             self._capture_sink = None
+            self._capture_redactor_rx = None
+            self._capture_redactor_tx = None
 
     async def _task_network_consumer(self):
         """Task for orchestrating incoming data."""
         while hasattr(self, "reader") and self.reader and not self.reader.at_eof():
             frame = await self.reader.read(300)
-            if self._capture_sink is not None and frame:
-                self._capture_sink("rx", redact(frame))
+            if self._capture_sink is not None and frame and self._capture_redactor_rx is not None:
+                self._emit_to_sink("rx", self._capture_redactor_rx.feed(frame))
             async for message in self.framer.decode(frame):
                 _logger.debug(f"Processing {message}")
                 if isinstance(message, ExceptionBase):
@@ -905,8 +1008,8 @@ class Client:
                     frame_sent.set_result(True)
                 continue
             self.writer.write(message)
-            if self._capture_sink is not None:
-                self._capture_sink("tx", redact(message))
+            if self._capture_sink is not None and self._capture_redactor_tx is not None:
+                self._emit_to_sink("tx", self._capture_redactor_tx.feed(message))
             await self.writer.drain()
             self.tx_queue.task_done()
             if frame_sent and not frame_sent.done():

--- a/tests/client/test_capture.py
+++ b/tests/client/test_capture.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from givenergy_modbus.client.client import Client, redact
+from givenergy_modbus.client.client import Client, StreamRedactor, redact
 
 # ---------------------------------------------------------------------------
 # redact()
@@ -164,7 +164,12 @@ async def test_capture_frames_tees_tx_to_sink_redacted():
         except asyncio.CancelledError:
             pass
 
-    assert captured == [("tx", b"hello SA1234B000 frame")]
+    # The stream redactor may re-chunk the output (holds a trailing tail across
+    # feeds, flushed at close), so reassemble before asserting. The joined stream
+    # is identical-length to the raw frame with the serial's unit digits zeroed.
+    assert all(d == "tx" for d, _ in captured)
+    reassembled = b"".join(f for _, f in captured)
+    assert reassembled == b"hello SA1234B000 frame"
     # Sink is detached after the capture completes.
     assert client._capture_sink is None
 
@@ -189,3 +194,81 @@ async def test_capture_frames_releases_sink_on_cancellation():
     except asyncio.CancelledError:
         pass
     assert client._capture_sink is None
+
+
+# ---------------------------------------------------------------------------
+# StreamRedactor — cross-chunk redaction (#117)
+# ---------------------------------------------------------------------------
+
+
+def _stream(chunks: list[bytes]) -> bytes:
+    """Feed chunks through a StreamRedactor and reassemble the emitted output."""
+    r = StreamRedactor()
+    return b"".join(r.feed(c) for c in chunks) + r.flush()
+
+
+def test_stream_redactor_catches_serial_split_across_chunks():
+    """A serial split across two chunks is redacted (the leak the per-frame redact misses)."""
+    # 'CE2242G612' split mid-serial: prefix in chunk 1, unit-bearing tail in chunk 2.
+    out = _stream([b"pad CE22", b"42G612 pad"])
+    assert b"CE2242G612" not in out
+    assert b"CE2242G000" in out  # date kept, unit digits zeroed (#113)
+
+
+def test_stream_redactor_reassembles_identically_to_whole_redact():
+    """However the stream is chunked, the reassembled output equals redact(whole)."""
+    whole = b"xx CE2242G612 yy EMS2522018 zz ,192.168.1.100, end"
+    expected = redact(whole)
+    for split in range(1, len(whole)):
+        assert _stream([whole[:split], whole[split:]]) == expected
+    # also multi-chunk
+    assert _stream([whole[i : i + 3] for i in range(0, len(whole), 3)]) == expected
+
+
+def test_stream_redactor_preserves_length_and_offsets():
+    """The reassembled stream is byte-identical in length to the raw input."""
+    raw = b"abc SA1234B567 def XY9876Z543 ghi"
+    assert len(_stream([raw[:7], raw[7:20], raw[20:]])) == len(raw)
+
+
+def test_stream_redactor_buffer_stays_bounded():
+    """A long stream doesn't grow the internal buffer unbounded (prefix pruning)."""
+    r = StreamRedactor()
+    for _ in range(1000):
+        r.feed(b"AB1234C567 some filler bytes ")
+        assert len(r._buffer) < 100  # prunes to ~lookback regardless of stream length
+    r.flush()
+
+
+def test_stream_redactor_no_identifiers_passthrough():
+    """Plain bytes with no identifiers reassemble unchanged."""
+    raw = b"just some plain frame bytes with no serials at all"
+    assert _stream([raw[:10], raw[10:]]) == raw
+
+
+def test_emit_to_sink_swallows_sink_exceptions(caplog):
+    """A sink callback that raises must not propagate out of the network tasks (#117 review)."""
+    import logging
+
+    client = Client(host="foo", port=4321)
+
+    def boom(_direction, _data):
+        raise RuntimeError("sink blew up")
+
+    client._capture_sink = boom
+    with caplog.at_level(logging.ERROR, logger="givenergy_modbus.client.client"):
+        # Must not raise — the capture is a diagnostic tee, never load-bearing.
+        client._emit_to_sink("rx", b"some redacted bytes")
+    assert any("capture sink raised" in r.message for r in caplog.records)
+
+
+def test_emit_to_sink_noops_without_sink_or_data():
+    """No active sink, or empty data, is a silent no-op (doesn't call the sink)."""
+    client = Client(host="foo", port=4321)
+    calls = []
+    # No sink installed → nothing happens even with data.
+    client._emit_to_sink("rx", b"data")
+    # Sink installed but empty data → not called (avoids spurious empty sink calls).
+    client._capture_sink = lambda d, f: calls.append((d, f))
+    client._emit_to_sink("tx", b"")
+    assert calls == []


### PR DESCRIPTION
Closes #117 — fixes the cross-frame serial leak in the live capture redactor.

## The leak

`redact()` runs per socket-read chunk (`reader.read(300)` tees raw buffers to the sink *before* the framer reassembles them). A GE serial split across two reads — prefix in one, unit-bearing continuation in the next — is seen as a complete serial by neither chunk's redaction pass, so the unit digits leak when the capture is reassembled. Not hypothetical: it occurs in the EMS rollup at IR(2066+), where consecutive inverter serials straddle a frame boundary (e.g. `CE2242` | `G612` → reconstructable `CE2242G612`). #116 fixed the *fixture tool* (`_redact_extra.py`) to be reassembly-aware, but the live `redact()` had no cross-chunk view.

## Fix — `StreamRedactor`

A stateful wrapper for the chunked stream: carries a small raw tail across chunks, redacts the buffer with full left-context, and emits only bytes settled ≥ lookback from the frontier (so no identifier can still overlap them). `flush()` emits the final tail at capture close. `capture_frames()` holds one per direction.

- **Offset-preserving:** reassembled output is byte-identical in length to the raw stream (same guarantee as `redact()`), so CRC/length fields stay consistent.
- **Bounded memory:** the settled prefix is pruned (keeping a lookback margin), so a long capture holds ~lookback bytes regardless of length.
- **Verified:** 1500-trial fuzz across random chunkings/serials/IPs/EMS-serials — reassembled output equals `redact(whole)` every time. (The fuzz caught and killed a double-processing bug in my first cut.)

## Contract note

The sink now sees the stream **re-chunked** — a trailing tail is deferred to the next call, flushed at close. This was never a one-call-per-frame contract (reads tee raw socket buffers, not framer output), and the replay framer reassembles by concatenation regardless, so replay is unaffected. givenergy-cli's capture writes one `ts dir hex` line per sink call, so its output gains more (shorter) lines — purely cosmetic, replay-transparent; worth a doc note on the cli side but no functional change.

Tox green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
