### PR TITLE
feat(model): add is_ac_coupled topology discriminator

### DIFF
--- a/givenergy_modbus/client/commands.py
+++ b/givenergy_modbus/client/commands.py
@@ -652,8 +652,12 @@ class _InverterCommands:
         def slot_map(self) -> SlotMap: ...
 
     # Universally-applicable subset of pdu.write_registers.WRITE_SAFE_REGISTERS.
-    # Excludes 313/314 (BATTERY_*_LIMIT_AC — ambiguous), 318-320 (pause mode),
-    # 1112/1122/1123 (three-phase), and 2040/2062-2069 (EMS).
+    # Excludes 318-320 (pause mode), 1112/1122/1123 (three-phase), and
+    # 2040/2062-2069 (EMS). Also excludes 313/314 (BATTERY_*_LIMIT_AC): these are
+    # the *single-phase* AC charge/discharge limits, but ThreePhaseInverter remaps
+    # the read-backs to HR1110/1108, so read != write on three-phase AC. A correct
+    # three-phase write needs per-model command-register selection (#75); until that
+    # lands they stay out of the universal write-safe set.
     WRITE_SAFE_REGISTERS: ClassVar[frozenset[int]] = frozenset(
         {
             20,  # ENABLE_CHARGE_TARGET

--- a/givenergy_modbus/model/inverter.py
+++ b/givenergy_modbus/model/inverter.py
@@ -87,6 +87,13 @@ _DTC_PREFIX_TO_MODEL: dict[str, Model] = {
     "83": Model.HYBRID_GEN4,
 }
 
+# AC-coupled inverters: no integrated DC battery, so they expose dedicated AC
+# charge/discharge limit registers (HR313/314) that DC-coupled models don't.
+# Both are coarse families with no specific sub-variants, so the set is complete
+# (an AC DTC like 0x3001 resolves to Model.AC via Model._missing_). Consumers gate
+# AC-only controls on this rather than re-deriving the model set themselves.
+AC_COUPLED_MODELS: frozenset[Model] = frozenset({Model.AC, Model.AC_3PH})
+
 # Rated AC output power in watts, keyed by 4-char hex device type code.
 # Sourced from britkat1980/giv_tcp:dev3; likely not exhaustive for all variants.
 _DTC_RATED_POWER: dict[str, int] = {
@@ -803,6 +810,17 @@ class SinglePhaseInverter(  # type: ignore[valid-type,misc]
     def inverter_max_power(self) -> int | None:
         """Returns the rated inverter power in watts, derived from the device type code."""
         return _DTC_RATED_POWER.get(self.device_type_code)  # type: ignore[attr-defined]
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def is_ac_coupled(self) -> bool:
+        """True for AC-coupled inverters (no integrated DC battery).
+
+        Coarse-family resolution is correct here: AC DTCs resolve to Model.AC /
+        Model.AC_3PH and neither has specific sub-variants. False when the model is
+        unknown (DTC unread).
+        """
+        return self.model in AC_COUPLED_MODELS  # type: ignore[attr-defined]
 
     # Plain @property (not @computed_field) so the deprecated alias doesn't
     # appear in model_dump() output. See #84 — renamed to work_time_total_hours

--- a/givenergy_modbus/model/inverter_threephase.py
+++ b/givenergy_modbus/model/inverter_threephase.py
@@ -9,6 +9,7 @@ from givenergy_modbus.client.commands import _InverterCommands
 from givenergy_modbus.model.battery import BatteryMaintenance
 from givenergy_modbus.model.inverter import (
     _DTC_RATED_POWER,
+    AC_COUPLED_MODELS,
     BatteryType,
     Model,
     PowerFactorFunctionModel,
@@ -491,6 +492,17 @@ class ThreePhaseInverter(  # type: ignore[valid-type,misc]
     def inverter_max_power(self) -> int | None:
         """Returns the rated inverter power in watts, derived from the device type code."""
         return _DTC_RATED_POWER.get(self.device_type_code)  # type: ignore[attr-defined]
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def is_ac_coupled(self) -> bool:
+        """True for AC-coupled inverters (no integrated DC battery).
+
+        True for Model.AC_3PH on three-phase; False when the model is unknown.
+        Mirrors the field on SinglePhaseInverter (not inherited — the two inverter
+        classes are parallel, like battery_max_power / inverter_max_power above).
+        """
+        return self.model in AC_COUPLED_MODELS  # type: ignore[attr-defined]
 
     @property
     def slot_map(self) -> SlotMap:

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -11,6 +11,7 @@ from givenergy_modbus.model.ems import Ems
 from givenergy_modbus.model.gateway import GatewayV1, GatewayV2, select_gateway
 from givenergy_modbus.model.hv_bcu import Bcu, BcuRegisterGetter, Bmu, HvStack
 from givenergy_modbus.model.inverter import (
+    AC_COUPLED_MODELS,
     Model,
     SinglePhaseInverter,
     SinglePhaseInverterRegisterGetter,
@@ -377,6 +378,11 @@ class PlantCapabilities(BaseModel):
     def is_three_phase(self) -> bool:
         """Return True if this system uses three-phase registers (HR/IR 1000-range)."""
         return self.device_type in _THREE_PHASE_MODELS
+
+    @property
+    def is_ac_coupled(self) -> bool:
+        """Return True if this system is AC-coupled (no integrated DC battery)."""
+        return self.device_type in AC_COUPLED_MODELS
 
     @property
     def has_extended_slots(self) -> bool:

--- a/tests/client/test_commands.py
+++ b/tests/client/test_commands.py
@@ -364,6 +364,53 @@ async def test_set_battery_discharge_limit_ac():
         commands.set_battery_discharge_limit_ac(101)
 
 
+def test_battery_ac_limit_single_phase_read_write_register_consistency():
+    """Single-phase AC limit read-back reads the same register the write command targets.
+
+    Pins read==write on single-phase so the model LUT and the command can't silently
+    drift to different registers. The write target (RegisterMap) is the source of truth;
+    reading that exact register back must surface on the model field.
+    """
+    from givenergy_modbus.model.inverter import SinglePhaseInverter
+    from givenergy_modbus.model.register import HR
+    from givenergy_modbus.model.register_cache import RegisterCache
+
+    charge_reg = int(RegisterMap.BATTERY_CHARGE_LIMIT_AC)
+    discharge_reg = int(RegisterMap.BATTERY_DISCHARGE_LIMIT_AC)
+    inv = SinglePhaseInverter.from_register_cache(RegisterCache({HR(charge_reg): 55, HR(discharge_reg): 80}))
+    assert inv.battery_charge_limit_ac == 55
+    assert inv.battery_discharge_limit_ac == 80
+
+
+def test_battery_ac_limit_three_phase_readback_diverges_from_write():
+    """Pin the known three-phase read != write gap (#75): the divergence is intentional.
+
+    The write command targets the single-phase HR313/314, but ThreePhaseInverter remaps
+    the read-backs to HR1110/1108. Asserting both sides keeps the gap explicit and
+    flagged until per-model command-register selection lands (#75).
+    """
+    from givenergy_modbus.model.inverter_threephase import ThreePhaseInverter
+    from givenergy_modbus.model.register import HR
+    from givenergy_modbus.model.register_cache import RegisterCache
+
+    charge_reg = int(RegisterMap.BATTERY_CHARGE_LIMIT_AC)  # 313
+    discharge_reg = int(RegisterMap.BATTERY_DISCHARGE_LIMIT_AC)  # 314
+    # Single-phase write registers and the three-phase read-backs hold different values.
+    tp = ThreePhaseInverter.from_register_cache(
+        RegisterCache({HR(charge_reg): 11, HR(1110): 99, HR(discharge_reg): 22, HR(1108): 88})
+    )
+    # Three-phase reads its remapped registers, NOT the single-phase write target.
+    assert tp.battery_charge_limit_ac == 99  # HR(1110), not HR(313)=11
+    assert tp.battery_discharge_limit_ac == 88  # HR(1108), not HR(314)=22
+    # Meanwhile the write command still targets the single-phase registers — the gap.
+    assert commands.set_battery_charge_limit_ac(50) == [
+        WriteHoldingRegisterRequest(RegisterMap.BATTERY_CHARGE_LIMIT_AC, 50)
+    ]
+    assert commands.set_battery_discharge_limit_ac(50) == [
+        WriteHoldingRegisterRequest(RegisterMap.BATTERY_DISCHARGE_LIMIT_AC, 50)
+    ]
+
+
 async def test_set_battery_pause_mode():
     assert commands.set_battery_pause_mode(BatteryPauseMode.DISABLED) == [
         WriteHoldingRegisterRequest(RegisterMap.BATTERY_PAUSE_MODE, BatteryPauseMode.DISABLED)

--- a/tests/model/test_inverter.py
+++ b/tests/model/test_inverter.py
@@ -5,6 +5,7 @@ import pytest
 
 from givenergy_modbus.model import TimeSlot
 from givenergy_modbus.model.inverter import (
+    AC_COUPLED_MODELS,
     BatteryCalibrationStage,
     BatteryPowerMode,
     BatteryType,
@@ -63,6 +64,7 @@ def test_inverter():
             "modbus_version": None,
             "model": None,
             "inverter_max_power": None,
+            "is_ac_coupled": False,
             "module": None,
             "num_mppt": None,
             "num_phases": None,
@@ -446,6 +448,7 @@ def test_from_registers(register_cache):
         "modbus_version": "1.40",
         "model": Model.HYBRID,
         "inverter_max_power": 5000,
+        "is_ac_coupled": False,
         "module": "00030832",
         "num_mppt": 2,
         "num_phases": 1,
@@ -774,6 +777,7 @@ def test_from_registers_actual_data(register_cache_inverter_daytime_discharging_
         "modbus_version": "1.40",
         "model": Model.HYBRID,
         "inverter_max_power": 5000,
+        "is_ac_coupled": False,
         "module": "00030832",
         "num_mppt": 2,
         "num_phases": 1,
@@ -1221,3 +1225,33 @@ def test_battery_energy_facade_routes_by_model():
     bare = SinglePhaseInverter.from_register_cache(RegisterCache({IR(36): 110, IR(183): 220}))
     assert bare.e_battery_charge_today is None
     assert bare.e_battery_charge_total is None
+
+
+def test_ac_coupled_models_constant():
+    """AC_COUPLED_MODELS is exactly the two AC coarse families (no DC-coupled models)."""
+    assert AC_COUPLED_MODELS == frozenset({Model.AC, Model.AC_3PH})
+
+
+def test_single_phase_inverter_is_ac_coupled():
+    """is_ac_coupled is True only for AC-coupled models, via coarse-family resolution.
+
+    An AC DTC (0x3001) resolves to Model.AC, so the computed field reads True; DC-coupled
+    families and an unread model read False.
+    """
+    from givenergy_modbus.model.register import HR
+
+    # AC single-phase (dtc prefix 3) → True
+    ac = SinglePhaseInverter.from_register_cache(RegisterCache({HR(0): 0x3001}))
+    assert ac.model is Model.AC
+    assert ac.is_ac_coupled is True
+
+    # DC-coupled families → False
+    for dtc in (0x2001, 0x2003, 0x8001, 0x5001):  # HYBRID, HYBRID(gen3), ALL_IN_ONE, EMS
+        inv = SinglePhaseInverter.from_register_cache(RegisterCache({HR(0): dtc}))
+        assert inv.is_ac_coupled is False, f"{inv.model} should not be AC-coupled"
+
+    # Unknown model (DTC unread) → False, and the field is in the dump.
+    bare = SinglePhaseInverter.from_register_cache(RegisterCache())
+    assert bare.model is None
+    assert bare.is_ac_coupled is False
+    assert bare.model_dump()["is_ac_coupled"] is False

--- a/tests/model/test_inverter_threephase.py
+++ b/tests/model/test_inverter_threephase.py
@@ -182,3 +182,20 @@ def test_work_time_total_hours_rename_and_deprecated_alias():
     dumped = tph.model_dump()
     assert "work_time_total_hours" in dumped
     assert "work_time_total" not in dumped
+
+
+def test_three_phase_inverter_is_ac_coupled():
+    """is_ac_coupled is True for the AC three-phase model, False for DC-coupled 3ph.
+
+    This is the case PlantCapabilities.is_three_phase deliberately excludes downstream,
+    but the inverter field must still report topology correctly (the field is duplicated
+    onto ThreePhaseInverter, not inherited from SinglePhaseInverter).
+    """
+    ac3 = ThreePhaseInverter.from_register_cache(_cache({HR(0): 0x6001}))
+    assert ac3.model is Model.AC_3PH
+    assert ac3.is_ac_coupled is True
+    assert ac3.model_dump()["is_ac_coupled"] is True
+
+    for dtc in (0x4001, 0x8001):  # HYBRID_3PH, ALL_IN_ONE
+        inv = ThreePhaseInverter.from_register_cache(_cache({HR(0): dtc}))
+        assert inv.is_ac_coupled is False, f"{inv.model} should not be AC-coupled"

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -1188,6 +1188,7 @@ def test_from_actual():
         "modbus_version": "1.40",
         "model": Model.HYBRID,
         "inverter_max_power": 5000,
+        "is_ac_coupled": False,
         "module": "00030832",
         "num_mppt": 2,
         "num_phases": 1,
@@ -1661,3 +1662,22 @@ class TestPlantCapabilitiesProperties:
         """GATEWAY reports is_gateway True; other models False."""
         assert self._caps(Model.GATEWAY).is_gateway
         assert not self._caps(Model.HYBRID).is_gateway
+
+
+def test_plant_capabilities_is_ac_coupled():
+    """PlantCapabilities.is_ac_coupled gates AC-only controls without a hardcoded model set.
+
+    This is the surface the givenergy-hass consumer relies on (composed with
+    `not is_three_phase` to scope single-phase AC). True for both AC families,
+    False for DC-coupled systems.
+    """
+    assert PlantCapabilities(device_type=Model.AC).is_ac_coupled is True
+    assert PlantCapabilities(device_type=Model.AC_3PH).is_ac_coupled is True
+    for model in (Model.HYBRID, Model.HYBRID_3PH, Model.ALL_IN_ONE, Model.EMS, Model.GATEWAY):
+        assert PlantCapabilities(device_type=model).is_ac_coupled is False, f"{model} not AC-coupled"
+
+    # The consumer's composition: single-phase AC is AC-coupled and not three-phase.
+    ac = PlantCapabilities(device_type=Model.AC)
+    assert (ac.is_ac_coupled and not ac.is_three_phase) is True
+    ac3 = PlantCapabilities(device_type=Model.AC_3PH)
+    assert (ac3.is_ac_coupled and not ac3.is_three_phase) is False


### PR DESCRIPTION
Adds an `is_ac_coupled` topology discriminator so downstream consumers can gate AC-coupled-only controls without hardcoding the model set. Requested by `givenergy-hass`, which wants to expose the AC charge/discharge limit controls only on AC-coupled inverters.

## What

- **`AC_COUPLED_MODELS`** (`frozenset({Model.AC, Model.AC_3PH})`) — exported module-level constant in `inverter.py`. Complete as-is: both are coarse families with no specific sub-variants, so an AC DTC like `0x3001` resolves to `Model.AC` via `Model._missing_`.
- **`PlantCapabilities.is_ac_coupled`** — the surface hass gates on (`caps.is_ac_coupled and not caps.is_three_phase` scopes single-phase AC). Mirrors the existing `is_three_phase`.
- **`is_ac_coupled` computed field** on `SinglePhaseInverter` *and* `ThreePhaseInverter`. Duplicated onto the three-phase class rather than inherited — the two inverter classes are parallel (same pattern as `battery_max_power` / `inverter_max_power`), and this is what makes `AC_3PH` correctly read `True`.

## Register hygiene (the `#75` divergence, made explicit)

The `WRITE_SAFE_REGISTERS` comment previously called HR313/314 "ambiguous". Reworded to state the real reason: they're the *single-phase* AC limit registers, but `ThreePhaseInverter` remaps the read-backs to HR1110/1108, so read ≠ write on three-phase AC. A correct three-phase write needs per-model command-register selection (#75) — out of scope here; the consumer excludes three-phase AC via `not is_three_phase`. **No behavioural change** — the write-safe set is byte-identical.

Tests pin this both ways: single-phase read==write (the model read-back reads the same register the command writes), and the deliberate three-phase divergence, so the gap stays explicit rather than drifting silently.

## Tests

`is_ac_coupled` true/false matrix on `PlantCapabilities` and both inverter classes; single-phase register-consistency pin; three-phase divergence pin; updated `model_dump` snapshots. Tox green (py314 + format + mypy + bandit + build + docs).

## Not in scope (deferred)

Three-phase AC limit *writes* — tracked in #75. The consumer scopes to single-phase AC, so this isn't a blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
