### PR TITLE
fix(model): clamp zero month/day in to_datetime to prevent crash

### DIFF
--- a/givenergy_modbus/model/register_cache.py
+++ b/givenergy_modbus/model/register_cache.py
@@ -79,7 +79,7 @@ class RegisterCache(defaultdict[Register, int]):
 
     def to_datetime(self, y: Register, m: Register, d: Register, h: Register, min: Register, s: Register):
         """Combine 6 registers into a datetime, with safe defaults for zeroes."""
-        return datetime.datetime(self[y] + 2000, self.get(m, 1), self.get(d, 1), self[h], self[min], self[s])
+        return datetime.datetime(self[y] + 2000, self.get(m, 1) or 1, self.get(d, 1) or 1, self[h], self[min], self[s])
 
     def to_timeslot(self, start: Register, end: Register) -> "TimeSlot | None":
         """Combine two registers into a time slot, or None if either is unset.

--- a/tests/model/test_register_cache.py
+++ b/tests/model/test_register_cache.py
@@ -116,6 +116,26 @@ def test_to_datetime():
     assert datetime.datetime(2000, 1, 1, 0, 0, 0) == rc.to_datetime(IR(22), IR(23), IR(24), IR(25), IR(26), IR(27))
 
 
+def test_to_datetime_zero_month_and_day():
+    """Month or day register reading 0 must clamp to 1, not crash.
+
+    Real hardware: Nick's AC captures (hass#52) show HR(41)=0 on all 3 devices.
+    Previously raised 'month must be in 1..12, not 0'.
+    """
+    rc = RegisterCache(
+        registers={
+            HR(0): 24,  # year → 2024
+            HR(1): 0,  # month register present but reads 0
+            HR(2): 0,  # day register present but reads 0
+            HR(3): 12,
+            HR(4): 0,
+            HR(5): 0,
+        }
+    )
+    result = rc.to_datetime(HR(0), HR(1), HR(2), HR(3), HR(4), HR(5))
+    assert result == datetime.datetime(2024, 1, 1, 12, 0, 0)
+
+
 def test_to_timeslot():
     rc = RegisterCache(
         registers={


### PR DESCRIPTION
## Summary

- `RegisterCache.to_datetime` called `self.get(m, 1)` to default a missing month register to 1, but the fallback only fires when the key is **absent** — not when it's present with value 0.
- On real AC hardware (confirmed across 3 devices in hass#52: 2× AC inverter + 1× EMS), HR(41) is populated but reads 0, so `datetime.datetime(..., 0, ...)` raises `ValueError: month must be in 1..12, not 0` and crashes the coordinator on every refresh cycle.
- Fix: `self.get(m, 1) or 1` and `self.get(d, 1) or 1` — clamps both month and day to 1 when the register is present but zero, matching the intent of the existing `"safe defaults for zeroes"` docstring.

## Test plan

- [ ] New regression test `test_to_datetime_zero_month_and_day`: builds a `RegisterCache` with month=0 and day=0, asserts the call returns `datetime(2024, 1, 1, 12, 0, 0)` without raising.
- [ ] All 677 existing tests continue to pass.
- [ ] `tox` (py314 + format + lint + build) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)