### PR TITLE
fix(client): refuse to poll without capabilities instead of guessing 0x32 (#105)

### DIFF
--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -8,10 +8,10 @@ from asyncio import Future, Queue, StreamReader, StreamWriter, Task
 from collections.abc import Callable
 from typing import Literal
 
-from givenergy_modbus.client import commands
 from givenergy_modbus.exceptions import (
     CommunicationError,
     ExceptionBase,
+    PlantNotDetected,
     PlantTopologyMismatch,
     ReadFailure,
     RefreshFailed,
@@ -691,20 +691,6 @@ class Client:
             cause=group,
         )
 
-    async def _refresh_no_caps(
-        self,
-        *,
-        full_refresh: bool,
-        max_batteries: int,
-        timeout: float,
-        retries: int,
-        retry_delay: float,
-    ) -> Plant:
-        """Legacy capability-free refresh — the pre-detect fallback shape."""
-        reqs = commands.refresh_plant_data(full_refresh, self.plant.number_batteries, max_batteries)
-        await self._execute_reads(reqs, timeout=timeout, retries=retries, retry_delay=retry_delay)
-        return self.plant
-
     async def load_config(self, timeout: float = 2.0, retries: int = 3, retry_delay: float = 0.5) -> Plant:
         """Read HR configuration blocks for the inverter.
 
@@ -712,8 +698,13 @@ class Client:
         failure raises ``RefreshPartiallySucceeded`` / ``RefreshFailed``.
         """
         caps = self.plant.capabilities
-        inverter = caps.inverter_address if caps else 0x32
-        is_ems = bool(caps and caps.is_ems)
+        if caps is None:
+            raise PlantNotDetected(
+                "load_config() requires plant capabilities — call detect() once first, "
+                "or restore a persisted PlantCapabilities onto client.plant.capabilities."
+            )
+        inverter = caps.inverter_address
+        is_ems = caps.is_ems
         # HR(0,60) is the identity/firmware/serial bank that every device type — including EMS —
         # answers; it's the same bank detect() reads to identify the device. The HR(60,60),
         # HR(120,60) and IR(120,60) banks are inverter-specific; EMS plant controllers don't
@@ -729,23 +720,22 @@ class Client:
                 ReadHoldingRegistersRequest(base_register=120, register_count=60, device_address=inverter),
                 ReadInputRegistersRequest(base_register=120, register_count=60, device_address=inverter),
             ]
-        if caps:
-            if caps.is_three_phase:
-                reqs += [
-                    ReadHoldingRegistersRequest(base_register=1000, register_count=60, device_address=inverter),
-                    ReadHoldingRegistersRequest(base_register=1060, register_count=60, device_address=inverter),
-                    ReadHoldingRegistersRequest(base_register=1120, register_count=5, device_address=inverter),
-                ]
-            if caps.has_extended_slots:
-                reqs.append(ReadHoldingRegistersRequest(base_register=240, register_count=60, device_address=inverter))
-            if not caps.is_ems and not caps.is_gateway:
-                # HR(300-359) — Single Phase New registers: export_priority (HR311),
-                # battery_*_limit_ac (HR313/314), enable_eps (HR317), pause mode/slot
-                # (HR318-320). Polled for all non-EMS / non-gateway models; confirmed
-                # present on Model.AC via hass#52 portal write observations.
-                reqs.append(ReadHoldingRegistersRequest(base_register=300, register_count=60, device_address=inverter))
-            if caps.is_ems:
-                reqs.append(ReadHoldingRegistersRequest(base_register=2040, register_count=36, device_address=inverter))
+        if caps.is_three_phase:
+            reqs += [
+                ReadHoldingRegistersRequest(base_register=1000, register_count=60, device_address=inverter),
+                ReadHoldingRegistersRequest(base_register=1060, register_count=60, device_address=inverter),
+                ReadHoldingRegistersRequest(base_register=1120, register_count=5, device_address=inverter),
+            ]
+        if caps.has_extended_slots:
+            reqs.append(ReadHoldingRegistersRequest(base_register=240, register_count=60, device_address=inverter))
+        if not caps.is_ems and not caps.is_gateway:
+            # HR(300-359) — Single Phase New registers: export_priority (HR311),
+            # battery_*_limit_ac (HR313/314), enable_eps (HR317), pause mode/slot
+            # (HR318-320). Polled for all non-EMS / non-gateway models; confirmed
+            # present on Model.AC via hass#52 portal write observations.
+            reqs.append(ReadHoldingRegistersRequest(base_register=300, register_count=60, device_address=inverter))
+        if caps.is_ems:
+            reqs.append(ReadHoldingRegistersRequest(base_register=2040, register_count=36, device_address=inverter))
         await self._execute_reads(reqs, timeout=timeout, retries=retries, retry_delay=retry_delay)
         return self.plant
 
@@ -763,8 +753,9 @@ class Client:
         """
         caps = self.plant.capabilities
         if caps is None:
-            return await self._refresh_no_caps(
-                full_refresh=False, max_batteries=5, timeout=timeout, retries=retries, retry_delay=retry_delay
+            raise PlantNotDetected(
+                "refresh() requires plant capabilities — call detect() once first, "
+                "or restore a persisted PlantCapabilities onto client.plant.capabilities."
             )
         inverter = caps.inverter_address
         reqs: list[TransparentRequest] = []
@@ -814,12 +805,19 @@ class Client:
         """Deprecated orchestrator — run ``detect()`` once, then drive your own loop.
 
         .. deprecated::
-            Will be removed in 3.0. This composes ``load_config()`` + ``refresh()``,
-            which is trivial to do in the consumer where the partial-failure policy
-            belongs. It now also propagates ``RefreshPartiallySucceeded`` /
-            ``RefreshFailed`` like the primitives — note that on a full refresh a
-            partial failure in ``load_config()`` short-circuits before ``refresh()``
-            runs; call the primitives directly for full control.
+            Will be removed in 3.0 (soon). This composes ``detect()`` (when needed) +
+            ``load_config()`` + ``refresh()``, which is trivial to do in the consumer
+            where the partial-failure policy belongs. It propagates
+            ``RefreshPartiallySucceeded`` / ``RefreshFailed`` like the primitives —
+            note that on a full refresh a partial failure in ``load_config()``
+            short-circuits before ``refresh()`` runs; call the primitives directly for
+            full control.
+
+            Unlike the primitives, this wrapper runs ``detect()`` for you if
+            capabilities are absent (preserving the legacy connect-then-refresh shape).
+            New code should call ``detect()`` then ``load_config()`` / ``refresh()``
+            directly — the primitives raise ``PlantNotDetected`` rather than guessing
+            an address.
         """
         warnings.warn(
             "Client.refresh_plant() is deprecated and will be removed in 3.0. Run detect() once, then "
@@ -828,18 +826,16 @@ class Client:
             DeprecationWarning,
             stacklevel=2,
         )
-        if self.plant.capabilities:
-            if full_refresh:
-                await self.load_config(timeout=timeout, retries=retries, retry_delay=retry_delay)
-            await self.refresh(timeout=timeout, retries=retries, retry_delay=retry_delay)
-            return self.plant
-        return await self._refresh_no_caps(
-            full_refresh=full_refresh,
-            max_batteries=max_batteries,
-            timeout=timeout,
-            retries=retries,
-            retry_delay=retry_delay,
-        )
+        # The primitives require capabilities; as the legacy one-call wrapper, detect
+        # them here if the caller hasn't, so connect()-then-refresh_plant() still works
+        # (it now addresses correctly per model — issue #105, where an AIO answering at
+        # 0x11 timed out under the old 0x32 fallback).
+        if self.plant.capabilities is None:
+            self.plant.capabilities = await self.detect(timeout=timeout, retries=retries)
+        if full_refresh:
+            await self.load_config(timeout=timeout, retries=retries, retry_delay=retry_delay)
+        await self.refresh(timeout=timeout, retries=retries, retry_delay=retry_delay)
+        return self.plant
 
     async def watch_plant(
         self,

--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -826,6 +826,16 @@ class Client:
             DeprecationWarning,
             stacklevel=2,
         )
+        if max_batteries != 5:
+            # Battery addresses now come from detect()/capabilities, so this argument
+            # no longer does anything — warn rather than silently ignore a custom value.
+            warnings.warn(
+                "The max_batteries argument to refresh_plant() is ignored — battery "
+                "addresses are now discovered by detect(). It will be removed with "
+                "refresh_plant() in 3.0.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         # The primitives require capabilities; as the legacy one-call wrapper, detect
         # them here if the caller hasn't, so connect()-then-refresh_plant() still works
         # (it now addresses correctly per model — issue #105, where an AIO answering at

--- a/givenergy_modbus/client/commands.py
+++ b/givenergy_modbus/client/commands.py
@@ -9,8 +9,6 @@ from givenergy_modbus.model import TimeSlot
 from givenergy_modbus.model.battery import BatteryPauseMode, ExportPriority
 from givenergy_modbus.model.slot_map import EMS_SLOTS, SINGLE_PHASE_SLOTS, SlotMap
 from givenergy_modbus.pdu import (
-    ReadHoldingRegistersRequest,
-    ReadInputRegistersRequest,
     TransparentRequest,
     WriteHoldingRegisterRequest,
 )
@@ -108,23 +106,6 @@ class RegisterMap:
     EXPORT_SLOT_3_END = 2069
     EMS_EXPORT_TARGET_SOC_3 = 2070
     EMS_EXPORT_POWER_LIMIT = 2071
-
-
-def refresh_plant_data(complete: bool, number_batteries: int = 1, max_batteries: int = 5) -> list[TransparentRequest]:
-    """Refresh plant data."""
-    requests: list[TransparentRequest] = [
-        ReadInputRegistersRequest(base_register=0, register_count=60, device_address=0x32),
-        ReadInputRegistersRequest(base_register=180, register_count=60, device_address=0x32),
-    ]
-    if complete:
-        requests.append(ReadHoldingRegistersRequest(base_register=0, register_count=60, device_address=0x32))
-        requests.append(ReadHoldingRegistersRequest(base_register=60, register_count=60, device_address=0x32))
-        requests.append(ReadHoldingRegistersRequest(base_register=120, register_count=60, device_address=0x32))
-        requests.append(ReadInputRegistersRequest(base_register=120, register_count=60, device_address=0x32))
-        number_batteries = max_batteries
-    for i in range(number_batteries):
-        requests.append(ReadInputRegistersRequest(base_register=60, register_count=60, device_address=0x32 + i))
-    return requests
 
 
 def disable_charge_target() -> list[TransparentRequest]:

--- a/givenergy_modbus/client/commands.py
+++ b/givenergy_modbus/client/commands.py
@@ -5,6 +5,7 @@ from datetime import time as dt_time
 from typing import TYPE_CHECKING, ClassVar
 from warnings import deprecated  # type: ignore[attr-defined]
 
+from givenergy_modbus.exceptions import PlantNotDetected
 from givenergy_modbus.model import TimeSlot
 from givenergy_modbus.model.battery import BatteryPauseMode, ExportPriority
 from givenergy_modbus.model.slot_map import EMS_SLOTS, SINGLE_PHASE_SLOTS, SlotMap
@@ -106,6 +107,26 @@ class RegisterMap:
     EXPORT_SLOT_3_END = 2069
     EMS_EXPORT_TARGET_SOC_3 = 2070
     EMS_EXPORT_POWER_LIMIT = 2071
+
+
+@deprecated("Call Client.detect() then load_config()/refresh() instead — see PlantNotDetected.")
+def refresh_plant_data(complete: bool, number_batteries: int = 1, max_batteries: int = 5) -> list[TransparentRequest]:
+    """Removed: built a fixed 0x32-addressed poll that timed out on non-0x32 models.
+
+    This helper hardcoded ``device_address=0x32`` for every read, which silently
+    failed on models answering elsewhere (e.g. an All-in-One at 0x11 — issue #105).
+    Capability-aware polling — ``Client.detect()`` then ``Client.load_config()`` /
+    ``Client.refresh()`` — replaces it and addresses each device correctly.
+
+    Kept as an import-compatible stub so existing imports don't break with an
+    ``ImportError``; it raises ``PlantNotDetected`` to signpost the migration rather
+    than rebuild the unsafe blind poll.
+    """
+    raise PlantNotDetected(
+        "commands.refresh_plant_data() has been removed — it built a fixed 0x32 poll "
+        "that timed out on models answering at other addresses (e.g. All-in-One at 0x11). "
+        "Call Client.detect() once, then Client.load_config() / Client.refresh()."
+    )
 
 
 def disable_charge_target() -> list[TransparentRequest]:

--- a/givenergy_modbus/exceptions.py
+++ b/givenergy_modbus/exceptions.py
@@ -38,6 +38,18 @@ class CommunicationError(ExceptionBase):
     """Exception to indicate a communication error."""
 
 
+class PlantNotDetected(CommunicationError):
+    """Raised when a capability-aware poll is attempted before ``detect()`` has run.
+
+    ``load_config()`` / ``refresh()`` route by ``plant.capabilities`` (device kind,
+    inverter address, slot layout). With no capabilities there is no safe default —
+    guessing an inverter address (historically ``0x32``) silently times out on models
+    that answer elsewhere (e.g. an All-in-One at ``0x11``). Rather than guess, the poll
+    refuses: call ``detect()`` once first, or restore a persisted ``PlantCapabilities``
+    onto ``client.plant.capabilities`` before polling.
+    """
+
+
 class PlantTopologyMismatch(CommunicationError):
     """Raised when detect(prior=...) finds the plant doesn't match the supplied prior.
 

--- a/tests/client/test_commands.py
+++ b/tests/client/test_commands.py
@@ -669,3 +669,17 @@ def test_ems_commands_are_write_safe():
     for r in reqs:
         assert r.register in WRITE_SAFE_REGISTERS, f"register {r.register} not write-safe"
         assert r.device_address == 0x11, f"EMS write to {r.register} should target 0x11"
+
+
+def test_refresh_plant_data_is_a_raising_stub():
+    """The removed 0x32-poll builder is import-compatible but raises on call (#105/#156).
+
+    Kept so external `from ...commands import refresh_plant_data` doesn't ImportError,
+    but raises PlantNotDetected pointing at detect()/load_config()/refresh() rather
+    than rebuilding the unsafe fixed-0x32 poll.
+    """
+    from givenergy_modbus.exceptions import PlantNotDetected
+
+    with pytest.warns(DeprecationWarning):
+        with pytest.raises(PlantNotDetected, match="detect()"):
+            commands.refresh_plant_data(True)

--- a/tests/client/test_load_refresh.py
+++ b/tests/client/test_load_refresh.py
@@ -39,19 +39,6 @@ def _reqs(mock_execute) -> list[tuple]:
 # ---------------------------------------------------------------------------
 
 
-async def test_load_config_no_caps():
-    """Without capabilities, only the four base blocks are requested, at the legacy 0x32."""
-    client = Client("localhost", 8899)
-    with patch.object(client, "_execute_reads", new_callable=AsyncMock) as mock_exec:
-        await client.load_config()
-    assert _reqs(mock_exec) == [
-        _hr(0, 60, device=0x32),
-        _hr(60, 60, device=0x32),
-        _hr(120, 60, device=0x32),
-        _ir(120, 60, device=0x32),
-    ]
-
-
 async def test_load_config_single_phase():
     """Standard single-phase HYBRID requests the four base blocks plus HR(300-359), at 0x11."""
     client = _client_with_caps(Model.HYBRID)
@@ -124,17 +111,31 @@ async def test_load_config_ems():
 # ---------------------------------------------------------------------------
 
 
-async def test_refresh_no_caps_runs_legacy_path():
-    """Without capabilities, refresh() runs the legacy capability-free fallback.
+async def test_refresh_without_caps_raises_plant_not_detected():
+    """refresh() refuses to guess an address when detect() hasn't run (#105).
 
-    It must NOT route through the deprecated refresh_plant() (that would warn);
-    _refresh_no_caps() builds the legacy request list and dispatches it.
+    Previously it fell back to a hardcoded 0x32 poll, which silently timed out on
+    models answering elsewhere (e.g. an All-in-One at 0x11). It now raises
+    PlantNotDetected rather than dispatching a blind request.
     """
+    from givenergy_modbus.exceptions import PlantNotDetected
+
     client = Client("localhost", 8899)
     with patch.object(client, "_execute_reads", new_callable=AsyncMock) as mock_exec:
-        plant = await client.refresh()
-    assert plant is client.plant
-    mock_exec.assert_awaited_once()
+        with pytest.raises(PlantNotDetected, match="detect()"):
+            await client.refresh()
+    mock_exec.assert_not_awaited()
+
+
+async def test_load_config_without_caps_raises_plant_not_detected():
+    """load_config() likewise refuses without capabilities (#105)."""
+    from givenergy_modbus.exceptions import PlantNotDetected
+
+    client = Client("localhost", 8899)
+    with patch.object(client, "_execute_reads", new_callable=AsyncMock) as mock_exec:
+        with pytest.raises(PlantNotDetected, match="detect()"):
+            await client.load_config()
+    mock_exec.assert_not_awaited()
 
 
 async def test_refresh_single_phase_no_peripherals():

--- a/tests/client/test_refresh_resilience.py
+++ b/tests/client/test_refresh_resilience.py
@@ -186,13 +186,27 @@ async def test_refresh_plant_propagates_partial():
             await client.refresh_plant()
 
 
-async def test_refresh_plant_no_caps_uses_legacy_path():
-    """refresh_plant() without capabilities routes to the legacy fallback (and warns)."""
-    client = Client("localhost", 8899)
-    with patch.object(client, "_refresh_no_caps", new_callable=AsyncMock) as mock_legacy:
+async def test_refresh_plant_no_caps_detects_first():
+    """refresh_plant() without capabilities runs detect() first, then polls (#105).
+
+    The deprecated wrapper keeps the legacy connect()-then-refresh_plant() shape
+    working — but by detecting (so the inverter address is model-correct, e.g. 0x11
+    for an AIO) rather than the old blind 0x32 fallback that timed out.
+    """
+    client = _client_with_caps(Model.HYBRID)
+    client.plant.capabilities = None  # simulate no prior detect()
+    detected = PlantCapabilities(device_type=Model.HYBRID)
+    with (
+        patch.object(client, "detect", new_callable=AsyncMock, return_value=detected) as mock_detect,
+        patch.object(client, "load_config", new_callable=AsyncMock) as mock_load,
+        patch.object(client, "refresh", new_callable=AsyncMock) as mock_refresh,
+    ):
         with pytest.warns(DeprecationWarning):
             await client.refresh_plant()
-    mock_legacy.assert_awaited_once()
+    mock_detect.assert_awaited_once()
+    assert client.plant.capabilities is detected
+    mock_load.assert_awaited_once()
+    mock_refresh.assert_awaited_once()
 
 
 async def test_watch_plant_deprecated():

--- a/tests/client/test_refresh_resilience.py
+++ b/tests/client/test_refresh_resilience.py
@@ -196,13 +196,26 @@ async def test_refresh_plant_no_caps_detects_first():
     client = _client_with_caps(Model.HYBRID)
     client.plant.capabilities = None  # simulate no prior detect()
     detected = PlantCapabilities(device_type=Model.HYBRID)
+    # Record call order — detecting *before* polling is the whole regression (#105),
+    # so pin the sequence rather than just asserting each was awaited.
+    calls: list[str] = []
     with (
-        patch.object(client, "detect", new_callable=AsyncMock, return_value=detected) as mock_detect,
-        patch.object(client, "load_config", new_callable=AsyncMock) as mock_load,
-        patch.object(client, "refresh", new_callable=AsyncMock) as mock_refresh,
+        patch.object(
+            client,
+            "detect",
+            new_callable=AsyncMock,
+            side_effect=lambda *a, **k: calls.append("detect") or detected,
+        ) as mock_detect,
+        patch.object(
+            client, "load_config", new_callable=AsyncMock, side_effect=lambda *a, **k: calls.append("load_config")
+        ) as mock_load,
+        patch.object(
+            client, "refresh", new_callable=AsyncMock, side_effect=lambda *a, **k: calls.append("refresh")
+        ) as mock_refresh,
     ):
         with pytest.warns(DeprecationWarning):
             await client.refresh_plant()
+    assert calls == ["detect", "load_config", "refresh"]
     mock_detect.assert_awaited_once()
     assert client.plant.capabilities is detected
     mock_load.assert_awaited_once()

--- a/tests/client/test_refresh_resilience.py
+++ b/tests/client/test_refresh_resilience.py
@@ -209,6 +209,20 @@ async def test_refresh_plant_no_caps_detects_first():
     mock_refresh.assert_awaited_once()
 
 
+async def test_refresh_plant_warns_on_ignored_max_batteries():
+    """refresh_plant(max_batteries=...) now no-ops that arg — warn rather than silently ignore.
+
+    Battery addresses come from detect()/capabilities; the old fixed-count poll is gone.
+    """
+    client = _client_with_caps(Model.HYBRID)
+    with (
+        patch.object(client, "load_config", new_callable=AsyncMock),
+        patch.object(client, "refresh", new_callable=AsyncMock),
+    ):
+        with pytest.warns(DeprecationWarning, match="max_batteries"):
+            await client.refresh_plant(max_batteries=3)
+
+
 async def test_watch_plant_deprecated():
     """watch_plant() warns on entry (before doing any work)."""
     client = Client("localhost", 8899)


### PR DESCRIPTION
Closes the real gap behind #105: an All-in-One still timed out under the latest betas when polled via the legacy entrypoint.

## Root cause
`load_config()` / `refresh()` resolved the inverter address as `caps.inverter_address if caps else 0x32`. With no capabilities cached (i.e. `detect()` hadn't run), they fell back to a hardcoded **0x32** — which is wrong for several models. An AIO answers at **0x11** and exposes nothing at 0x32, so every poll went into silence.

The #119/#121 addressing fix only takes effect *after* `detect()` populates `capabilities.inverter_address`. The #105 reporter calls `refresh_plant(full_refresh=True)` straight after `connect()` with no detection, so their code never reached the fix and still saw identical `0x32` timeouts on 2.1.0b2/b3.

## Change
- **Primitives refuse to guess.** `load_config()` / `refresh()` now raise a new **`PlantNotDetected`** (`CommunicationError` subclass) when capabilities are absent, pointing at `detect()`. "No capabilities" means detection hasn't run (or no prior was restored) — addressing blind is worse than refusing.
- **`refresh_plant()` detects first.** The deprecated one-call wrapper runs `detect()` itself when caps are absent, then `load_config()` + `refresh()` — preserving the legacy `connect()`-then-`refresh_plant()` shape but now addressing per model (0x11 for AIO). The reporter's exact original script works again. Deprecation language strengthened ("removed in 3.0 (soon)").
- Removes the dead `_refresh_no_caps()` / 0x32 fallback and its now-unused `commands` import.

## Tests
- `refresh()` / `load_config()` without caps → assert `PlantNotDetected` (and that no request is dispatched).
- `refresh_plant()` without caps → asserts it calls `detect()` first, then polls.
- Capability-driven addressing (HYBRID→0x11, AC/GEN1→0x31) already covered; AIO→0x11 asserted in `test_addressing_from_captures.py` from the `aio_a` fixture.

`tox` green (py314 + format + mypy + bandit + build + docs).

## Note
This is a behaviour change: code calling `refresh()`/`load_config()` without a prior `detect()` now raises instead of silently polling 0x32. That path only ever *worked* for models that happen to answer at 0x32, and silently timed out for the rest — so raising is strictly more honest. Acceptable in a v2.1 beta, and `refresh_plant()` shields the legacy shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * `load_config()` now requires prior device capability detection; raises an exception if capabilities are missing instead of using fallback values.

* **New Features**
  * Added a new exception type to provide clearer error messaging for capability detection scenarios.

* **Chores**
  * Removed legacy helper function; updated deprecated refresh method behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->