### PR TITLE
fix(pdu): include device address + byte-swap in request CRC (#105)

### DIFF
--- a/givenergy_modbus/pdu/read_registers.py
+++ b/givenergy_modbus/pdu/read_registers.py
@@ -56,11 +56,19 @@ class ReadRegistersRequest(ReadRegistersMessage, TransparentRequest, ABC):
         self._update_check_code()
 
     def _update_check_code(self):
+        # Request CRC covers the device-address byte and is byte-swapped on the wire.
+        # Confirmed against real GivTCP + GivEnergy-app frames for an All-in-One (#105):
+        # ReadHolding(device=0x11, base=0, count=60) → wire CRC 0x474b. Omitting the
+        # device byte (the old behaviour) produced frames a strict inverter silently
+        # dropped. This matches the FC 0x16 layout (ReadMeterProductRegistersRequest, #58)
+        # — all request types share it.
         crc_builder = PayloadEncoder()
+        crc_builder.add_8bit_uint(self.device_address)
         crc_builder.add_8bit_uint(self.transparent_function_code)
         crc_builder.add_16bit_uint(self.base_register)
         crc_builder.add_16bit_uint(self.register_count)
-        self.check = crc_builder.crc
+        raw = crc_builder.crc
+        self.check = ((raw & 0xFF) << 8) | ((raw >> 8) & 0xFF)
         self._builder.add_16bit_uint(self.check)
 
     def ensure_valid_state(self):

--- a/givenergy_modbus/pdu/read_registers.py
+++ b/givenergy_modbus/pdu/read_registers.py
@@ -60,8 +60,9 @@ class ReadRegistersRequest(ReadRegistersMessage, TransparentRequest, ABC):
         # Confirmed against real GivTCP + GivEnergy-app frames for an All-in-One (#105):
         # ReadHolding(device=0x11, base=0, count=60) → wire CRC 0x474b. Omitting the
         # device byte (the old behaviour) produced frames a strict inverter silently
-        # dropped. This matches the FC 0x16 layout (ReadMeterProductRegistersRequest, #58)
-        # — all request types share it.
+        # dropped. This is the same layout originally confirmed for FC 0x16 against a
+        # meter wire capture (device=0x01, base=0x3c, count=0x3c → 0x8814; see #58) —
+        # all request function codes (0x03/0x04/0x06/0x16) share it.
         crc_builder = PayloadEncoder()
         crc_builder.add_8bit_uint(self.device_address)
         crc_builder.add_8bit_uint(self.transparent_function_code)
@@ -214,18 +215,9 @@ class ReadMeterProductRegistersRequest(ReadMeterProductRegisters, ReadRegistersR
             base_register=self.base_register, register_count=self.register_count, device_address=self.device_address
         )
 
-    def _update_check_code(self):
-        # FC 0x16 uses a different CRC layout from FC 0x03/0x04 — it includes the device address
-        # in the hash input and byte-swaps the result. Confirmed against a wire capture
-        # (device=0x01, base=0x3c, count=0x3c → wire CRC 0x8814). See issue #58.
-        crc_builder = PayloadEncoder()
-        crc_builder.add_8bit_uint(self.device_address)
-        crc_builder.add_8bit_uint(self.transparent_function_code)
-        crc_builder.add_16bit_uint(self.base_register)
-        crc_builder.add_16bit_uint(self.register_count)
-        raw = crc_builder.crc
-        self.check = ((raw & 0xFF) << 8) | ((raw >> 8) & 0xFF)
-        self._builder.add_16bit_uint(self.check)
+    # No _update_check_code override: the base ReadRegistersRequest method now uses the
+    # device-address-prefixed, byte-swapped layout this FC 0x16 path originally proved
+    # (#58) — they're identical, so the override was removed (#105 / #157).
 
 
 class ReadMeterProductRegistersResponse(ReadMeterProductRegisters, ReadRegistersResponse):

--- a/givenergy_modbus/pdu/write_registers.py
+++ b/givenergy_modbus/pdu/write_registers.py
@@ -194,11 +194,15 @@ class WriteHoldingRegisterRequest(WriteHoldingRegister, TransparentRequest):
             raise InvalidPduState(f"HR({self.register}) is not safe to write to", self)
 
     def _update_check_code(self):
+        # Request CRC covers the device-address byte and is byte-swapped on the wire —
+        # same layout as reads and FC 0x16 (see read_registers.py / #105 / #58).
         crc_builder = PayloadEncoder()
+        crc_builder.add_8bit_uint(self.device_address)
         crc_builder.add_8bit_uint(self.transparent_function_code)
         crc_builder.add_16bit_uint(self.register)
         crc_builder.add_16bit_uint(self.value)
-        self.check = crc_builder.crc
+        raw = crc_builder.crc
+        self.check = ((raw & 0xFF) << 8) | ((raw >> 8) & 0xFF)
         self._builder.add_16bit_uint(self.check)
 
     def expected_response(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -189,14 +189,14 @@ _server_messages: PduTestCases = [
         {
             "base_register": 0x10,
             "register_count": 6,
-            "check": 0x0754,
+            "check": 0x740E,
             "data_adapter_serial_number": "AB1234G567",
             "error": False,
             "padding": 8,
             "device_address": 0x32,
         },
         b"YY\x00\x01\x00\x1c\x01\x02",  # 8 bytes
-        b"AB1234G567\x00\x00\x00\x00\x00\x00\x00\x08\x32\x04\x00\x10\x00\x06\x07\x54",  # 26 bytes
+        b"AB1234G567\x00\x00\x00\x00\x00\x00\x00\x08\x32\x04\x00\x10\x00\x06\x74\x0e",  # 26 bytes
         None,
     ),
     (
@@ -205,14 +205,14 @@ _server_messages: PduTestCases = [
         {
             "base_register": 0x5151,
             "register_count": 20,
-            "check": 0x2221,
+            "check": 0x012B,
             "data_adapter_serial_number": "AB1234G567",
             "error": False,
             "padding": 8,
             "device_address": 0x32,
         },
         b"YY\x00\x01\x00\x1c\x01\x02",
-        b"AB1234G567\x00\x00\x00\x00\x00\x00\x00\x08\x32\x03\x51\x51\x00\x14\x22\x21",
+        b"AB1234G567\x00\x00\x00\x00\x00\x00\x00\x08\x32\x03\x51\x51\x00\x14\x01\x2b",
         None,
     ),
     (
@@ -221,14 +221,14 @@ _server_messages: PduTestCases = [
         {
             "base_register": 0x5151,
             "register_count": 30,
-            "check": 0x25A1,
+            "check": 0x812C,
             "data_adapter_serial_number": "AB1234G567",
             "error": False,
             "padding": 8,
             "device_address": 0x32,
         },
         b"YY\x00\x01\x00\x1c\x01\x02",
-        b"AB1234G567\x00\x00\x00\x00\x00\x00\x00\x08\x32\x03\x51\x51\x00\x1e\x25\xa1",
+        b"AB1234G567\x00\x00\x00\x00\x00\x00\x00\x08\x32\x03\x51\x51\x00\x1e\x81\x2c",
         None,
     ),
     (
@@ -237,14 +237,14 @@ _server_messages: PduTestCases = [
         {
             "register": 179,
             "value": 2000,
-            "check": 0x81EE,
+            "check": 0x7E42,
             "data_adapter_serial_number": "AB1234G567",
             "error": False,
             "padding": 8,
             "device_address": 0x32,
         },
         b"YY\x00\x01\x00\x1c\x01\x02",
-        b"AB1234G567\x00\x00\x00\x00\x00\x00\x00\x08\x32\x06\x00\xb3\x07\xd0\x81\xee",
+        b"AB1234G567\x00\x00\x00\x00\x00\x00\x00\x08\x32\x06\x00\xb3\x07\xd0\x7e\x42",
         InvalidPduState(r"HR\(179\) is not safe to write to", None),
     ),
     (
@@ -253,14 +253,14 @@ _server_messages: PduTestCases = [
         {
             "register": 199,
             "value": 2000,
-            "check": 0x81EE,
+            "check": 0x3E58,
             "data_adapter_serial_number": "AB1234G567",
             "error": False,
             "padding": 8,
             "device_address": 0x32,
         },
         b"YY\x00\x01\x00\x1c\x01\x02",
-        b"AB1234G567\x00\x00\x00\x00\x00\x00\x00\x08\x32\x06\x00\xc7\x07\xd0\x81\xee",
+        b"AB1234G567\x00\x00\x00\x00\x00\x00\x00\x08\x32\x06\x00\xc7\x07\xd0\x3e\x58",
         InvalidPduState(r"HR\(199\) is not safe to write to", None),
     ),
     (
@@ -269,14 +269,14 @@ _server_messages: PduTestCases = [
         {
             "register": 0x14,
             "value": 1,
-            "check": 0xC42D,
+            "check": 0x0DCD,
             "data_adapter_serial_number": "AB1234G567",
             "error": False,
             "padding": 8,
             "device_address": 0x32,
         },
         b"YY\x00\x01\x00\x1c\x01\x02",
-        b"AB1234G567\x00\x00\x00\x00\x00\x00\x00\x08\x32\x06\x00\x14\x00\x01\xc4\x2d",
+        b"AB1234G567\x00\x00\x00\x00\x00\x00\x00\x08\x32\x06\x00\x14\x00\x01\x0d\xcd",
         None,
     ),
     (

--- a/tests/test_pdu.py
+++ b/tests/test_pdu.py
@@ -379,3 +379,41 @@ def test_read_registers_response_caps_decode_at_60():
     assert result.register_count == 100
     assert len(result.register_values) == 60
     assert result.register_values == list(range(60))
+
+
+def test_request_crc_includes_device_address_matches_real_wire():
+    """Request CRC must cover the device-address byte — pinned to a real GivTCP frame (#105).
+
+    GivTCP and the GivEnergy app both compute the request check code over
+    device_address + function_code + base + count; omitting the device byte produces a
+    frame a strict inverter (All-in-One) silently drops. This value (0x474b) is the exact
+    CRC GivTCP put on the wire for ReadHoldingRegisters(device=0x11, base=0, count=60),
+    captured during the #105 investigation — external ground truth, not just internal
+    consistency.
+    """
+    req = ReadHoldingRegistersRequest(device_address=0x11, base_register=0, register_count=60)
+    raw = req.encode()
+    # 0x474b is both the stored check and the on-wire trailing bytes (the CRC is
+    # byte-swapped on emit, matching GivTCP/app frames — the old code emitted 0x1160).
+    assert req.check == 0x474B
+    assert raw[-2:] == b"\x47\x4b"
+    # Same logical read at a different device address must produce a different CRC —
+    # proving the device byte actually participates (regression guard for the old bug).
+    other = ReadHoldingRegistersRequest(device_address=0x32, base_register=0, register_count=60)
+    other.encode()
+    assert other.check != req.check
+
+
+def test_write_request_crc_includes_device_address():
+    """Write request CRC also covers the device byte (#105).
+
+    Uses a write-safe register so ensure_valid_state() doesn't reject the encode.
+    """
+    from givenergy_modbus.client.commands import RegisterMap
+
+    # ENABLE_CHARGE (96) is in WRITE_SAFE_REGISTERS.
+    req = WriteHoldingRegisterRequest(register=RegisterMap.ENABLE_CHARGE, value=1, device_address=0x11)
+    req.encode()
+    at_other = WriteHoldingRegisterRequest(register=RegisterMap.ENABLE_CHARGE, value=1, device_address=0x32)
+    at_other.encode()
+    assert req.check != at_other.check, "device address must participate in the write CRC"


### PR DESCRIPTION
Root-cause fix for #105 — an All-in-One that timed out on **every** read/write, even after the #119/#121/#156 addressing fixes.

## Root cause (triple-confirmed)

Our outgoing **request** frames computed the trailing CRC16/Modbus check code incorrectly in **two** ways:
1. Over `function_code + fields` — **omitting the leading device-address byte**.
2. Emitted **big-endian** — but the wire format is **byte-swapped**.

Real GivEnergy hardware, GivTCP, and the GivEnergy Android app all compute it over `device_address + function_code + fields` and emit it byte-swapped. A **strict** inverter (the AIO) validates the request CRC and silently drops our wrong-CRC frames → every poll times out. **Lenient** hybrid/AC firmware never validated it, which is why this latent bug hid for years until an AIO owner hit it.

Confirmed three independent ways:
- **GivTCP wire frames** — captured this session; its `ReadHolding(0x11,0,60)` carries CRC `0x474b`, ours carried `0x1160`.
- **GivEnergy Android app wire frames** — same `0x474b` (also device-byte + byte-swap; sends an all-zero serial, so serial content is irrelevant — the CRC is the gate).
- **GivTCP source** — `add_8bit_uint(self.slave_address)` first.

And corroborated internally: our own `ReadMeterProductRegistersRequest` (#58) **already** did device-byte + byte-swap. The base read-request and write-request CRCs simply never got the same treatment.

## Change

- `pdu/read_registers.py` `ReadRegistersRequest._update_check_code` and `pdu/write_registers.py` `WriteHoldingRegisterRequest._update_check_code`: add the device-address byte to the CRC input and byte-swap the result — matching the FC 0x16 layout.
- `tests/conftest.py`: recompute the 6 request fixtures' CRC (`check` kwarg + `inner_frame` trailing bytes).
- `tests/test_pdu.py`: new ground-truth test pinning `ReadHolding(0x11,0,60)` to GivTCP's real wire CRC `0x474b`, plus a guard that the device address participates in the write CRC.

## Safety

CRC-only change: `WRITE_SAFE_REGISTERS`, `ensure_valid_state()`, and the register/value bytes on the wire are all untouched — only the trailing 2-byte checksum changes. **Register-safety reviewed: PASS.** The fix makes our frames *match* what hardware expects; it corrects wire-correctness rather than introducing it.

`tox` green (py314 + format + mypy + bandit + build + docs); 683 tests pass.

## Verification status

This is the first fix in the #105 arc backed by **externally-verified evidence** (GivTCP + app wire frames + GivTCP source) rather than inference — but a real AIO is the final word. Ship in 2.1.0b5; gaima8 to retest.

## Follow-up (separate)

Investigation surfaced a related issue: `client.redact()` mutates serials length-preservingly without recomputing the (response) CRC, leaving redacted capture fixtures CRC-invalid; and the library never validates/computes response CRCs at all. Filed separately as a tracking issue (response-CRC algorithm + redaction integrity + a faithful replay mock).

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)
