### PR TITLE
fix(model): treat residential All-in-One as single-phase (#105)

### DIFF
--- a/givenergy_modbus/model/inverter_threephase.py
+++ b/givenergy_modbus/model/inverter_threephase.py
@@ -523,12 +523,18 @@ class ThreePhaseInverter(  # type: ignore[valid-type,misc]
         return self.work_time_total_hours  # type: ignore[attr-defined,no-any-return]
 
 
+# Models that decode via the three-phase / 1000-range register layout. The residential
+# ALL_IN_ONE (DTC family "8", e.g. 0x8001) is deliberately absent: it is HV but single-
+# phase, and decoding it as ThreePhaseInverter shadows ~30 live fields (battery_soc, v_ac1,
+# f_ac1, firmware, charge slots, status…) to IR/HR(1000+) addresses it doesn't expose,
+# zeroing them. It carries its data in the single-phase IR(0)/IR(180) banks and so decodes
+# correctly as SinglePhaseInverter. Verified against real AIO register dumps (#105). HV
+# battery voltage, extended slots and is_hv stay model-keyed at the capabilities layer.
 THREE_PHASE_MODELS: frozenset[Model] = frozenset(
     {
         Model.HYBRID_3PH,
         Model.AC_3PH,
         Model.AIO_COMMERCIAL,
-        Model.ALL_IN_ONE,
         Model.HYBRID_HV_GEN3,
         Model.ALL_IN_ONE_HYBRID,
     }
@@ -538,8 +544,9 @@ THREE_PHASE_MODELS: frozenset[Model] = frozenset(
 def select_inverter(model: Model, register_cache) -> "SinglePhaseInverter | ThreePhaseInverter":
     """Return the appropriate inverter model instance for the given device model.
 
-    Three-phase and AIO/HV units use a different register address layout;
-    everything else uses the single-phase layout.
+    Genuinely three-phase and HV-hybrid units use the 1000-range register address layout;
+    everything else — including the residential single-phase ALL_IN_ONE — uses the
+    single-phase layout (see THREE_PHASE_MODELS for why the AIO is excluded).
     """
     if model in THREE_PHASE_MODELS:
         return ThreePhaseInverter.from_register_cache(register_cache)

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -45,13 +45,18 @@ _HV_MODELS: frozenset[Model] = frozenset(
     }
 )
 
-# Models with registers in the 1000-range (HR 1000–1124, IR 1000–1413).
+# Models with registers in the 1000-range (HR 1000–1124, IR 1000–1413), i.e. genuinely
+# three-phase units that expose the per-phase bank. NB: the residential ALL_IN_ONE (DTC
+# family "8", e.g. 0x8001) is HV but SINGLE-phase — it has no 1000-range bank (it error-
+# responds to those reads) and its data lives in the single-phase IR(0)/IR(180) banks. It
+# is intentionally excluded here (and from the decode-layout set in inverter_threephase.py)
+# while remaining in _HV_MODELS / _EXTENDED_SLOT_MODELS. Confirmed against real AIO hardware
+# (HR(0)=0x8001, owner-confirmed 1-phase) and the GE spec sheet (3.6 kW/16 A). See #105.
 _THREE_PHASE_MODELS: frozenset[Model] = frozenset(
     {
         Model.HYBRID_3PH,
         Model.AC_3PH,
         Model.AIO_COMMERCIAL,
-        Model.ALL_IN_ONE,
         Model.ALL_IN_ONE_HYBRID,
         Model.HYBRID_HV_GEN3,
     }

--- a/tests/client/test_load_refresh.py
+++ b/tests/client/test_load_refresh.py
@@ -94,6 +94,16 @@ async def test_load_config_extended_slots():
     ]
 
 
+async def test_load_config_residential_aio_no_1000_range():
+    """Residential ALL_IN_ONE: extended-slot blocks but no three-phase HR(1000+) bank (#105)."""
+    client = _client_with_caps(Model.ALL_IN_ONE)
+    with patch.object(client, "_execute_reads", new_callable=AsyncMock) as mock_exec:
+        await client.load_config()
+    reqs = _reqs(mock_exec)
+    assert reqs == [_hr(0, 60), _hr(60, 60), _hr(120, 60), _ir(120, 60), _hr(240, 60), _hr(300, 60)]
+    assert all(base < 1000 for _, _, base, _ in reqs), "AIO must not poll the 1000-range bank"
+
+
 async def test_load_config_ems():
     """EMS plant controllers expose HR(0,60) (identity/firmware/serial) and HR(2040,36) only.
 
@@ -161,6 +171,16 @@ async def test_refresh_three_phase():
         _ir(1360, 54),
     ]
     assert _reqs(mock_exec) == [_ir(0, 60), _ir(180, 60)] + expected_3ph
+
+
+async def test_refresh_residential_aio_no_1000_range():
+    """Residential ALL_IN_ONE refreshes from IR(0)/IR(180) only — no per-phase IR(1000+) (#105)."""
+    client = _client_with_caps(Model.ALL_IN_ONE)
+    with patch.object(client, "_execute_reads", new_callable=AsyncMock) as mock_exec:
+        await client.refresh()
+    reqs = _reqs(mock_exec)
+    assert reqs == [_ir(0, 60), _ir(180, 60)]
+    assert all(base < 1000 for _, _, base, _ in reqs), "AIO must not poll the 1000-range bank"
 
 
 async def test_refresh_ems():

--- a/tests/model/test_inverter_threephase.py
+++ b/tests/model/test_inverter_threephase.py
@@ -160,6 +160,17 @@ def test_select_inverter_single_phase():
     assert isinstance(result, SinglePhaseInverter)
 
 
+def test_select_inverter_residential_aio_is_single_phase():
+    """Residential ALL_IN_ONE (0x8001) decodes single-phase, not three-phase.
+
+    Decoding it as ThreePhaseInverter shadows ~30 live fields (battery_soc, v_ac1, f_ac1,
+    firmware, charge slots, status…) to the IR/HR(1000+) addresses the AIO doesn't expose,
+    zeroing them; its data actually lives in the single-phase IR(0)/IR(180) banks. Verified
+    against a real AIO register dump (#105).
+    """
+    assert isinstance(select_inverter(Model.ALL_IN_ONE, RegisterCache()), SinglePhaseInverter)
+
+
 def test_work_time_total_hours_rename_and_deprecated_alias():
     """ThreePhaseInverter inherits the rename via the merged LUT and exposes the same alias shim."""
     import warnings

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -1622,7 +1622,6 @@ class TestPlantCapabilitiesProperties:
             Model.HYBRID_3PH,
             Model.AC_3PH,
             Model.AIO_COMMERCIAL,
-            Model.ALL_IN_ONE,
             Model.ALL_IN_ONE_HYBRID,
             Model.HYBRID_HV_GEN3,
         )
@@ -1630,9 +1629,25 @@ class TestPlantCapabilitiesProperties:
             assert self._caps(m).is_three_phase, f"{m} should be three-phase"
 
     def test_is_three_phase_false(self):
-        """Single-phase and non-inverter models report is_three_phase False."""
-        for m in (Model.HYBRID, Model.AC, Model.EMS, Model.GATEWAY):
+        """Single-phase and non-inverter models report is_three_phase False.
+
+        The residential ALL_IN_ONE (DTC family "8", e.g. 0x8001) is HV but single-phase: it
+        has no 1000-range per-phase bank (it error-responds to those reads) and so must NOT
+        be polled there. Confirmed against real AIO hardware + owner confirmation (#105).
+        """
+        for m in (Model.HYBRID, Model.AC, Model.EMS, Model.GATEWAY, Model.ALL_IN_ONE):
             assert not self._caps(m).is_three_phase, f"{m} should not be three-phase"
+
+    def test_all_in_one_is_hv_and_extended_but_not_three_phase(self):
+        """The AIO keeps its HV + extended-slot capabilities while not being three-phase.
+
+        Guards the split: removing ALL_IN_ONE from the per-phase poll set must not regress
+        the capabilities that are correctly model-keyed (HV battery, 10-slot map).
+        """
+        caps = self._caps(Model.ALL_IN_ONE)
+        assert caps.is_hv is True
+        assert caps.has_extended_slots is True
+        assert caps.is_three_phase is False
 
     def test_has_extended_slots_true(self):
         """Models with 10-slot support report has_extended_slots True."""


### PR DESCRIPTION
## Summary

The residential All-in-One (DTC family "8", e.g. `0x8001`) was classified as three-phase. Two consequences, both broken:

1. **Polling** — `refresh()`/`load_config()` requested the per-phase `IR/HR(1000+)` bank the AIO doesn't expose. Every such read error-responds, so `refresh()` failed with `RefreshPartiallySucceeded` — the failure gaima8 hit in #105 once the b5 request-CRC fix got the unit talking.
2. **Decoding** — it was decoded as `ThreePhaseInverter`, whose layout shadows ~30 live fields (battery SoC, AC voltage/frequency, firmware, charge slots, status) onto those same absent 1000-range addresses, so they'd read `None` even if polling were fixed.

## Fix

Remove `Model.ALL_IN_ONE` from both three-phase sets:
- `_THREE_PHASE_MODELS` (`model/plant.py`) — the poll gate behind `is_three_phase`.
- `THREE_PHASE_MODELS` (`model/inverter_threephase.py`) — the decode-layout gate behind `select_inverter`.

The AIO now polls and decodes single-phase, reading its real data from the `IR(0)`/`IR(180)` banks it answers. Its HV battery voltage (307 V), extended 10-slot map and `is_hv` are keyed on the model at the capabilities layer, so they're unaffected by the inverter decode class.

## Evidence

Diagnosed against the reporter's real AIO (#105):
- `HR(0) = 0x8001` → `Model.ALL_IN_ONE` (residential family "8").
- GE spec sheet: 3.6 kW / 16 A continuous, 7.2 kW / 32 A peak — single-phase domestic ratings; owner confirmed 1-phase.
- Decoded the unit's actual register dump both ways: single-phase yields complete, sane values (SoC 4%, 246.1 V, 49.98 Hz, firmware D0.612-A0.612); three-phase yields ~30 nulls.

## Scope

Conservative — only `ALL_IN_ONE` is reclassified. `AIO_COMMERCIAL` stays three-phase. `HYBRID_HV_GEN3` and `ALL_IN_ONE_HYBRID` are suspected single-phase HV, but I've left them untouched pending hardware confirmation rather than guess.

## Tests

- `is_three_phase` true/false sets updated; a guard that the AIO keeps `is_hv` / extended slots while not being three-phase.
- `select_inverter(ALL_IN_ONE)` → `SinglePhaseInverter`.
- `load_config` / `refresh` request-list regressions asserting no `base >= 1000` reads for the AIO.

## One thing I'll close out with the reporter

The failing reads in the capture are all on non-60-aligned bases (1000, 1060…), so I've asked them to also probe the correctly page-aligned 1000-range (960, 1020…) — to be fully sure the bank is genuinely absent rather than just rejected for misalignment. The model-level evidence (single-phase spec + owner confirmation) makes that a formality, but it removes the last doubt, and it would flag a latent alignment issue on the same code path (the gateway poll shares the offset) if anything does come back.

Refs #105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected ALL_IN_ONE inverter classification to single-phase architecture, ensuring proper register polling and data decoding for this device model.

* **Tests**
  * Added test coverage to verify ALL_IN_ONE inverter decodes correctly as single-phase and prevents three-phase register polling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->