### PR TITLE
fix(client): probe all LV battery slots; continue past absent/invalid slots

### DIFF
--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -636,6 +636,10 @@ class Client:
         # 0x33–0x37 (the inverter itself now lives at 0x11/0x31, not 0x32 — issue #119). All
         # slots are validated via Battery.is_valid(). Skipped for HV systems (handled at step 2)
         # and EMS plant controllers (don't expose IR at the inverter address — see #86).
+        # Per-slot (not break-on-fail) for the same reasons as the meter sweep above: battery
+        # addresses can be non-contiguous (DIP-switch misconfiguration) and a transient BMS
+        # timeout on pack N must not silently drop pack N+1 onward. Cold detect is affordable
+        # since the probe budget only applies on cold sweeps; warm/hinted starts skip this.
         if not caps.is_hv and not caps.is_ems:
             await self.send_request_and_await_response(
                 ReadInputRegistersRequest(base_register=60, register_count=60, device_address=0x32),
@@ -650,14 +654,18 @@ class Client:
                         timeout=probe_timeout,
                         retries=probe_retries,
                     ):
-                        break
+                        continue
                     if not self.plant.register_caches.get(batt_addr):
-                        break
+                        continue
                 try:
                     if not Battery.from_register_cache(self.plant.register_caches[batt_addr]).is_valid():
-                        break
+                        _logger.debug(
+                            "detect: battery probe responded at 0x%02x but is_valid()=False — skipping",
+                            batt_addr,
+                        )
+                        continue
                 except KeyError, ValueError:
-                    break
+                    continue
                 caps.lv_battery_addresses.append(batt_addr)
             _logger.info(
                 "detect: lv_battery_addresses=[%s]",

--- a/tests/client/test_detect.py
+++ b/tests/client/test_detect.py
@@ -876,3 +876,77 @@ async def test_detect_hinted_raises_on_bcu_module_count_drift():
 
     assert exc_info.value.prior.bcu_stacks == [(0, 3), (1, 2)]
     assert exc_info.value.actual.bcu_stacks == [(0, 2), (1, 2)]
+
+
+@pytest.mark.asyncio
+async def test_detect_lv_batteries_non_contiguous():
+    """Non-contiguous battery addresses (e.g. 0x32 + 0x34, gap at 0x33) are all detected.
+
+    Regression for break-on-first-absent: a gap at 0x33 must not prevent 0x34 from
+    being found. Mirrors the meter sweep which already uses per-slot continue (#95).
+    """
+    client = _make_client()
+    _prime_cache(client, 0x11, {HR(0): 0x2001, HR(21): 0})
+    _prime_battery_serial(client, 0x32)
+    # 0x33 is absent; 0x34 is present and valid.
+    _prime_battery_serial(client, 0x34)
+
+    async def _probe_side_effect(request, *, timeout, retries):
+        return request.device_address in {0x34}  # 0x33 absent, 0x34 present
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
+        with patch.object(client, "_probe", side_effect=_probe_side_effect):
+            caps = await client.detect()
+
+    assert 0x32 in caps.lv_battery_addresses
+    assert 0x33 not in caps.lv_battery_addresses
+    assert 0x34 in caps.lv_battery_addresses
+
+
+@pytest.mark.asyncio
+async def test_detect_lv_batteries_transient_failure_mid_range():
+    """A transient probe failure on one battery slot does not drop all subsequent slots."""
+    client = _make_client()
+    _prime_cache(client, 0x11, {HR(0): 0x2001, HR(21): 0})
+    _prime_battery_serial(client, 0x32)
+    # 0x33 times out transiently; 0x34 is present and valid.
+    _prime_battery_serial(client, 0x34)
+
+    call_count = {}
+
+    async def _probe_side_effect(request, *, timeout, retries):
+        addr = request.device_address
+        call_count[addr] = call_count.get(addr, 0) + 1
+        return addr == 0x34  # 0x33 fails, 0x34 succeeds
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
+        with patch.object(client, "_probe", side_effect=_probe_side_effect):
+            caps = await client.detect()
+
+    assert 0x32 in caps.lv_battery_addresses
+    assert 0x33 not in caps.lv_battery_addresses
+    assert 0x34 in caps.lv_battery_addresses
+    # 0x34 must have been probed (not short-circuited after 0x33 failed)
+    assert call_count.get(0x34, 0) >= 1
+
+
+@pytest.mark.asyncio
+async def test_detect_lv_batteries_invalid_slot_skipped_not_aborted():
+    """A ghost slot that ACKs but fails Battery.is_valid() is skipped; later slots still found."""
+    client = _make_client()
+    _prime_cache(client, 0x11, {HR(0): 0x2001, HR(21): 0})
+    _prime_battery_serial(client, 0x32)
+    # 0x33 responds but has no valid serial → is_valid()=False (ghost).
+    _prime_cache(client, 0x33, {})  # no serial registers → is_valid False
+    _prime_battery_serial(client, 0x34)
+
+    async def _probe_side_effect(request, *, timeout, retries):
+        return request.device_address in {0x33, 0x34}
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
+        with patch.object(client, "_probe", side_effect=_probe_side_effect):
+            caps = await client.detect()
+
+    assert 0x32 in caps.lv_battery_addresses
+    assert 0x33 not in caps.lv_battery_addresses  # ghost — skipped
+    assert 0x34 in caps.lv_battery_addresses

--- a/tests/client/test_detect.py
+++ b/tests/client/test_detect.py
@@ -894,9 +894,11 @@ async def test_detect_lv_batteries_non_contiguous():
     async def _probe_side_effect(request, *, timeout, retries):
         return request.device_address in {0x34}  # 0x33 absent, 0x34 present
 
-    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
-        with patch.object(client, "_probe", side_effect=_probe_side_effect):
-            caps = await client.detect()
+    with (
+        patch.object(client, "send_request_and_await_response", new_callable=AsyncMock),
+        patch.object(client, "_probe", side_effect=_probe_side_effect),
+    ):
+        caps = await client.detect()
 
     assert 0x32 in caps.lv_battery_addresses
     assert 0x33 not in caps.lv_battery_addresses
@@ -919,9 +921,11 @@ async def test_detect_lv_batteries_transient_failure_mid_range():
         call_count[addr] = call_count.get(addr, 0) + 1
         return addr == 0x34  # 0x33 fails, 0x34 succeeds
 
-    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
-        with patch.object(client, "_probe", side_effect=_probe_side_effect):
-            caps = await client.detect()
+    with (
+        patch.object(client, "send_request_and_await_response", new_callable=AsyncMock),
+        patch.object(client, "_probe", side_effect=_probe_side_effect),
+    ):
+        caps = await client.detect()
 
     assert 0x32 in caps.lv_battery_addresses
     assert 0x33 not in caps.lv_battery_addresses
@@ -943,9 +947,11 @@ async def test_detect_lv_batteries_invalid_slot_skipped_not_aborted():
     async def _probe_side_effect(request, *, timeout, retries):
         return request.device_address in {0x33, 0x34}
 
-    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
-        with patch.object(client, "_probe", side_effect=_probe_side_effect):
-            caps = await client.detect()
+    with (
+        patch.object(client, "send_request_and_await_response", new_callable=AsyncMock),
+        patch.object(client, "_probe", side_effect=_probe_side_effect),
+    ):
+        caps = await client.detect()
 
     assert 0x32 in caps.lv_battery_addresses
     assert 0x33 not in caps.lv_battery_addresses  # ghost — skipped


### PR DESCRIPTION
## Summary

- The battery sweep in `detect()` used `break` on the first absent or invalid slot, silently dropping all subsequent batteries.
- Changed to `continue` per slot, matching the meter sweep which has carried the same rationale since #95.
- Three regression tests: non-contiguous addresses (gap at 0x33 doesn't hide 0x34), transient probe failure mid-range, and ghost slot with `is_valid()=False`.

## Motivation

From givenergy-hass: a second battery (0x33) vanished after an update's reconnect and stayed gone until a forced re-detect. Plants with DIP-switch-misconfigured battery IDs (non-contiguous) were also under-reported.

## Test plan

- [ ] `pytest tests/client/test_detect.py` — 39 tests pass
- [ ] Full tox green (lint failures in `tests/debug/probe_ems_write.py` are pre-existing on baseline)
- [ ] @coderabbitai review

🤖 Generated with [Claude Code](https://claude.com/claude-code)