### PR TITLE
feat(testing): register cross-correlation helpers (sentinel_devices + identify)

### DIFF
--- a/docs/register-identification.md
+++ b/docs/register-identification.md
@@ -1,0 +1,142 @@
+# Register identification via sentinel cross-correlation
+
+The GivEnergy Android app's **Read Only** tab displays telemetry labels (e.g.
+"Grid voltage 242.7 V", "Battery temperature 25.0 °C") but does not show register
+numbers.  This document describes how to identify the register address backing each
+label using the `MockPlant` sentinel approach.
+
+## Principle
+
+Seed a `MockPlant` with *sentinel* values — raw register value = register address.
+When the app reads a register and applies its converter (e.g. divide by 10 for "deci"
+scale), it displays a value that encodes the address.  Reading that value off the
+screen and inverting the converter recovers the address.
+
+For a linear converter with scale `s`:
+
+```
+raw = address
+displayed = address × s
+```
+
+**Single-pass ambiguity:** the same displayed value can match multiple `(address, scale)` pairs.
+For example `24.2` matches both address 242 at scale 0.1 *and* address 2420 at scale 0.01.
+
+**Two-pass resolution:** run a second pass with `offset=K` (e.g. 1000):
+
+```
+pass 1:  d1 = address × s
+pass 2:  d2 = (address + K) × s
+
+s = (d2 − d1) / K          ← scale, uniquely determined
+address = d1 / s            ← address, uniquely determined
+```
+
+## Step-by-step procedure
+
+### 1. Choose the register banks to probe
+
+Decide which device address and register type to seed.  For inverter telemetry:
+
+| Bank | Device | Type |
+|---|---|---|
+| Standard inverter IR | 0x31 | IR |
+| Holding registers | 0x11 | HR |
+| Battery | 0x32–0x37 | IR |
+
+Seed ranges densely (e.g. `range(0, 240)`) so the app's read requests always find
+populated registers and don't time out.
+
+### 2. Run pass 1 (offset = 0)
+
+```bash
+# Using givenergy-cli (once the identify commands are implemented):
+givenergy-cli mock-plant \
+    --capture path/to/plant.log \
+    --sentinels \
+    --device 0x31 --type ir --base 0 --count 240 \
+    --offset 0 \
+    --host 0.0.0.0 --port 8899
+
+# Or directly in Python:
+from givenergy_modbus.testing import MockPlant
+from givenergy_modbus.model.register import IR
+
+mock = MockPlant.from_sentinels(
+    "path/to/plant.log",
+    spec=[(0x31, IR, range(0, 240))],
+    offset=0,
+)
+import asyncio
+asyncio.run(mock.serve_forever())
+```
+
+Connect the GivEnergy app to the mock's IP and port.  Navigate to
+**Direct Control → Read Only**.  For each displayed label, record the value as `d1`.
+
+### 3. Run pass 2 (offset = 1000)
+
+Stop the mock; re-start with `--offset 1000`.  Record each value as `d2`.
+
+> **Choosing K:** use K = 1000.  This is safe for all known GivEnergy register
+> addresses (max address ≈ 5014; 5014 + 1000 = 6014 ≪ 65535 uint16 max).
+
+### 4. Identify each register
+
+```bash
+# CLI:
+givenergy-cli identify 242.7 --second 342.7 --k 1000
+# → address=2427, scale=0.1 (deci), confidence=two-pass
+
+# Python:
+from givenergy_modbus.testing import identify
+candidates = identify(242.7, 342.7, k=1000)
+print(candidates)
+# → [Candidate(address=2427, scale=0.1, confidence='two-pass')]
+```
+
+### 5. Cross-check against the existing model
+
+Compare each `(address, scale)` against the existing register LUT
+(`SinglePhaseInverterRegisterGetter.REGISTER_LUT` in `model/inverter.py`).
+
+- **Address matches an existing Def** → confirm the app label is the human-readable
+  name for that field.  Update the field's comment/docstring if it differs.
+- **Address unknown** → record it as a new Def candidate for the #48 register audit.
+  Note the app label and inferred scale; submit a PR adding `Def(C.deci, None, IR(address))`
+  (or the appropriate converter) under the right field name.
+
+### 6. Handle clamping and non-linear registers
+
+Some fields are problematic for auto-identification:
+
+| Case | Symptom | Workaround |
+|---|---|---|
+| **Clamped field** (e.g. SOC %) | App shows 100.0 % even with sentinel=2427 | Use a sentinel value in the valid range; probe with a third pass using a smaller offset |
+| **Boolean/enum** | App shows only 0 or 1 | Use a non-zero in-range sentinel and check which field toggles |
+| **uint32 pair** | Two registers combine into one displayed value | Seed the two adjacent addresses and note which label changes when each changes |
+| **timeslot** | Two registers encode start/end time | Similar to uint32 |
+
+Non-linear registers cannot be uniquely identified by `identify()` — handle them manually.
+
+## Example mapping table
+
+After completing both passes, build a table like:
+
+| App label | address | type | scale | Existing field | Action |
+|---|---|---|---|---|---|
+| Grid voltage | 2427 | IR | 0.1 (deci) | `v_ac1` at IR(8) | **Mismatch** — re-probe, likely IR(8) not 2427 |
+| Battery temperature | 250 | IR | 0.1 (deci) | `t_battery` at IR(56) | — |
+| AC charge today | ? | IR | 0.1 (deci) | unmapped | Add `Def(C.deci, None, IR(?))` |
+
+> Note: the sentinel value is the *address*, not necessarily a realistic reading.
+> "Grid voltage 242.7 V" from a sentinel means address 2427, but the real v_ac1 at
+> address 8 would display 0.8 V in sentinel mode.  Use cross-referencing, not
+> absolute values, to confirm names.
+
+## Reference
+
+- `givenergy_modbus/testing/identify.py` — `sentinel_devices`, `identify`, `Candidate`
+- `givenergy_modbus/testing/mock_plant.py` — `MockPlant.from_sentinels`
+- `givenergy_modbus/model/inverter.py` — `SinglePhaseInverterRegisterGetter.REGISTER_LUT`
+- Issue #48 — register audit tracking confirmed and candidate fields

--- a/givenergy_modbus/testing/__init__.py
+++ b/givenergy_modbus/testing/__init__.py
@@ -3,8 +3,21 @@
 `MockPlant` is a TCP server that seeds per-device register state from a recorded wire
 capture and serves synthesized, correct-CRC responses to register reads — so this
 library's `Client`, GivTCP, or the vendor app can be driven end-to-end without hardware.
+
+`sentinel_devices`, `identify`, and `Candidate` support register cross-correlation:
+seed a MockPlant with sentinel values (raw = register address), read displayed values
+off the app's Read Only tab, and invert the converter to identify which register backs
+each label.
 """
 
+from givenergy_modbus.testing.identify import Candidate, SentinelSpec, identify, sentinel_devices
 from givenergy_modbus.testing.mock_plant import MockPlant, plant_from_capture
 
-__all__ = ["MockPlant", "plant_from_capture"]
+__all__ = [
+    "Candidate",
+    "MockPlant",
+    "SentinelSpec",
+    "identify",
+    "plant_from_capture",
+    "sentinel_devices",
+]

--- a/givenergy_modbus/testing/identify.py
+++ b/givenergy_modbus/testing/identify.py
@@ -174,6 +174,8 @@ def identify(
         For single-pass: one entry per scale factor whose inverse is an integer
         address (possibly multiple candidates — use two-pass to disambiguate).
     """
+    if k <= 0:
+        raise ValueError(f"k must be a positive integer (got {k})")
     if d2 is not None:
         return _identify_two_pass(d1, d2, k=k, reg_range=reg_range, tolerance=tolerance)
     return _identify_single_pass(d1, reg_range=reg_range, tolerance=tolerance)

--- a/givenergy_modbus/testing/identify.py
+++ b/givenergy_modbus/testing/identify.py
@@ -126,7 +126,14 @@ def sentinel_devices(
             devices[device_address] = RegisterCache()
         cache = devices[device_address]
         for a in reg_range:
-            cache[reg_cls(a)] = a + offset
+            val = a + offset
+            if not (0 <= val <= 65535):
+                raise ValueError(
+                    f"Sentinel value {val} at address {a} with offset {offset} "
+                    "is out of the valid 16-bit unsigned integer range (0–65535). "
+                    "Choose a smaller offset or a narrower address range."
+                )
+            cache[reg_cls(a)] = val
     return devices
 
 
@@ -183,8 +190,15 @@ def _identify_two_pass(
     diff = d2 - d1
     if abs(diff) < 1e-9:
         return []
-    scale = diff / k
-    if scale <= 0:
+    scale_raw = diff / k
+    if scale_raw <= 0:
+        return []
+    # Snap to the nearest known scale to handle minor app display rounding.
+    # If the computed scale doesn't match any known converter, the identification
+    # is unreliable — return empty rather than a spurious result.
+    known = list(CONVERTER_SCALES.values())
+    scale = min(known, key=lambda s: abs(scale_raw - s))
+    if abs(scale_raw - scale) > tolerance:
         return []
     address_float = d1 / scale
     address = round(address_float)
@@ -209,7 +223,7 @@ def _identify_single_pass(
         address = round(address_float)
         if abs(address_float - address) > tolerance:
             continue
-        if not (0 < address <= 65535):
+        if not (0 <= address <= 65535):
             continue
         if reg_range is not None and address not in reg_range:
             continue

--- a/givenergy_modbus/testing/identify.py
+++ b/givenergy_modbus/testing/identify.py
@@ -1,0 +1,220 @@
+"""Register-identification helpers for cross-correlating app display values to addresses.
+
+The GivEnergy Android app's *Read Only* tab shows human-readable telemetry (e.g.
+"Grid voltage 242.7 V") but hides register addresses.  These helpers let you figure
+out which IR/HR address backs each label by seeding a :class:`MockPlant` with
+*sentinel* values — raw register value = register address — then reading the
+displayed value off the app and inverting the converter.
+
+Workflow::
+
+    # 1. Build a sentinel-overlaid mock from a real capture
+    mock = MockPlant.from_sentinels(
+        "path/to/plant.log",
+        spec=[(0x31, IR, range(0, 240))],   # seed IR(0-239) with value = address
+        offset=0,
+    )
+    await mock.start("0.0.0.0", 8899)
+
+    # 2. Point the app at the mock, note each displayed value on the Read Only tab.
+    #    e.g. app shows "Grid voltage  24.2 V"
+
+    # 3. Identify the address
+    candidates = identify(24.2)
+    # → [Candidate(address=242, scale=0.1, confidence='single-pass'), ...]
+
+    # 4. Run a second pass (offset=1000) to resolve ambiguity
+    mock2 = MockPlant.from_sentinels(..., spec=..., offset=1000)
+    # app now shows "Grid voltage 124.2 V"   (= (242+1000)/10)
+    candidates = identify(24.2, 124.2, k=1000)
+    # → [Candidate(address=242, scale=0.1, confidence='two-pass')]
+
+Two-pass principle
+------------------
+For any *linear* converter with scale ``s`` (deci: 0.1, centi: 0.01, …):
+
+    d1 = A * s          (offset=0)
+    d2 = (A + K) * s    (offset=K)
+
+    s = (d2 - d1) / K
+    A = d1 / s
+
+This uniquely recovers both the address and the scale without knowing the converter
+up front.  Non-linear registers (uint32 pairs, timeslots, enums, bitfields) are not
+auto-identifiable; those need a manual third-pass or direct probing.
+
+Caveats
+-------
+- Choose K so that ``address + K ≤ 65535`` for all seeded addresses.  K=1000 is safe
+  for addresses up to 64535, which covers every known GivEnergy register range.
+- SoC-% and other clamped fields may clip implausible sentinel values; handle those
+  with a third in-range pass or identify them manually.
+- The displayed value may be rounded by the app; use a generous *tolerance*.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from givenergy_modbus.model.register import Register
+from givenergy_modbus.model.register_cache import RegisterCache
+
+# Type alias for the sentinel specification:
+# list of (device_address, register_class, address_range)
+SentinelSpec = list[tuple[int, type[Register], range]]
+
+# Linear converter scale factors: raw → displayed value.
+# Non-linear converters (uint32, timeslot, datetime, string/serial, bitfield, enum)
+# are not included — they can't be auto-identified by this method.
+CONVERTER_SCALES: dict[str, float] = {
+    "uint16": 1.0,
+    "int16": 1.0,  # positive values behave identically to uint16
+    "deci": 0.1,
+    "centi": 0.01,
+    "milli": 0.001,
+}
+
+
+@dataclass
+class Candidate:
+    """A candidate register address inferred from a displayed app value.
+
+    Attributes:
+        address: The inferred raw register address (integer, 0–65535).
+        scale:   The inferred converter scale (1.0 = uint16, 0.1 = deci, …).
+        confidence: ``"two-pass"`` when ``d2`` was provided (unique solution);
+                    ``"single-pass"`` when only ``d1`` was given (may have duplicates).
+    """
+
+    address: int
+    scale: float
+    confidence: str  # "two-pass" | "single-pass"
+
+
+def sentinel_devices(
+    base: dict[int, RegisterCache],
+    spec: SentinelSpec,
+    *,
+    offset: int = 0,
+) -> dict[int, RegisterCache]:
+    """Clone *base* and overlay sentinel values (raw = address + offset).
+
+    Parameters
+    ----------
+    base:
+        Per-device register caches, typically from
+        ``plant_from_capture(...).register_caches``.  The returned dict is a
+        *deep copy* — the original is not modified.
+    spec:
+        Sequence of ``(device_address, register_class, address_range)`` triples.
+        For each triple, every address in ``address_range`` is written to the
+        cache for ``device_address`` as ``register_class(addr): addr + offset``.
+        Device addresses not present in *base* are created as empty caches.
+    offset:
+        Added to every sentinel value.  Pass 1 uses ``offset=0``; pass 2 uses
+        ``offset=K`` (e.g. 1000).  Keep K small enough that
+        ``max(address_range) + K ≤ 65535``.
+
+    Returns:
+    -------
+    dict[int, RegisterCache]
+        A fresh dict ready to pass to ``MockPlant(devices=...)``.
+    """
+    devices: dict[int, RegisterCache] = {addr: RegisterCache(dict(cache)) for addr, cache in base.items()}
+    for device_address, reg_cls, reg_range in spec:
+        if device_address not in devices:
+            devices[device_address] = RegisterCache()
+        cache = devices[device_address]
+        for a in reg_range:
+            cache[reg_cls(a)] = a + offset
+    return devices
+
+
+def identify(
+    d1: float,
+    d2: float | None = None,
+    *,
+    k: int = 1000,
+    reg_range: range | None = None,
+    tolerance: float = 1e-3,
+) -> list[Candidate]:
+    """Infer register address(es) from an app-displayed value.
+
+    Parameters
+    ----------
+    d1:
+        Value the app displayed for pass 1 (sentinel ``offset=0``).
+    d2:
+        Value the app displayed for pass 2 (sentinel ``offset=k``).
+        When provided, the result is a unique two-pass identification.
+        When ``None``, all single-pass candidates are returned.
+    k:
+        The offset used between the two sentinel passes.  Must match the
+        ``offset`` argument passed to :func:`sentinel_devices` for pass 2.
+    reg_range:
+        Optional filter: only return candidates whose address falls in this
+        range.  Useful when you know which bank was seeded.
+    tolerance:
+        Maximum deviation from an integer when checking whether the inferred
+        address is a whole number.  Default 0.001 accommodates minor floating-
+        point rounding in the app display.
+
+    Returns:
+    -------
+    list[Candidate]
+        For two-pass: at most one entry (empty if the maths doesn't resolve to
+        a plausible integer address).
+        For single-pass: one entry per scale factor whose inverse is an integer
+        address (possibly multiple candidates — use two-pass to disambiguate).
+    """
+    if d2 is not None:
+        return _identify_two_pass(d1, d2, k=k, reg_range=reg_range, tolerance=tolerance)
+    return _identify_single_pass(d1, reg_range=reg_range, tolerance=tolerance)
+
+
+def _identify_two_pass(
+    d1: float,
+    d2: float,
+    *,
+    k: int,
+    reg_range: range | None,
+    tolerance: float,
+) -> list[Candidate]:
+    diff = d2 - d1
+    if abs(diff) < 1e-9:
+        return []
+    scale = diff / k
+    if scale <= 0:
+        return []
+    address_float = d1 / scale
+    address = round(address_float)
+    if abs(address_float - address) > tolerance:
+        return []
+    if not (0 <= address <= 65535):
+        return []
+    if reg_range is not None and address not in reg_range:
+        return []
+    return [Candidate(address=address, scale=scale, confidence="two-pass")]
+
+
+def _identify_single_pass(
+    d1: float,
+    *,
+    reg_range: range | None,
+    tolerance: float,
+) -> list[Candidate]:
+    candidates: list[Candidate] = []
+    for scale in CONVERTER_SCALES.values():
+        address_float = d1 / scale
+        address = round(address_float)
+        if abs(address_float - address) > tolerance:
+            continue
+        if not (0 < address <= 65535):
+            continue
+        if reg_range is not None and address not in reg_range:
+            continue
+        # Deduplicate: uint16 and int16 have the same scale (1.0), skip second.
+        if any(abs(c.scale - scale) < 1e-9 and c.address == address for c in candidates):
+            continue
+        candidates.append(Candidate(address=address, scale=scale, confidence="single-pass"))
+    return candidates

--- a/givenergy_modbus/testing/mock_plant.py
+++ b/givenergy_modbus/testing/mock_plant.py
@@ -133,6 +133,42 @@ class MockPlant:
             adapter_serial=plant.data_adapter_serial_number,
         )
 
+    @classmethod
+    def from_sentinels(
+        cls,
+        *paths: str | Path,
+        spec: "list[tuple[int, type, range]]",
+        offset: int = 0,
+    ) -> "MockPlant":
+        """Build a sentinel-overlaid mock for register cross-correlation.
+
+        Loads a base plant from *paths* (same as :meth:`from_capture`), then
+        overlays *spec* with sentinel values ``raw = address + offset``.  Run the
+        app against the resulting mock and call :func:`.identify` on each displayed
+        value to recover the backing register address.
+
+        Parameters
+        ----------
+        *paths:
+            One or more capture ``.log`` files to seed the base state.
+        spec:
+            Sentinel overlay: list of ``(device_address, HR|IR|MR, address_range)``
+            triples.  Every address in ``address_range`` is written as
+            ``register_class(addr) → addr + offset``.
+        offset:
+            Added to every sentinel value.  Use ``offset=0`` for pass 1,
+            ``offset=K`` (e.g. 1000) for pass 2.
+        """
+        from givenergy_modbus.testing.identify import sentinel_devices
+
+        plant = plant_from_capture(*paths)
+        devices = sentinel_devices(plant.register_caches, spec, offset=offset)
+        return cls(
+            devices,
+            inverter_serial=plant.inverter_serial_number,
+            adapter_serial=plant.data_adapter_serial_number,
+        )
+
     # -- serving ---------------------------------------------------------------
 
     async def start(self, host: str = "127.0.0.1", port: int = 0) -> tuple[str, int]:

--- a/tests/testing/test_identify.py
+++ b/tests/testing/test_identify.py
@@ -1,5 +1,7 @@
 """Tests for register cross-correlation helpers (identify.py)."""
 
+import pytest
+
 from givenergy_modbus.model.register import HR, IR
 from givenergy_modbus.model.register_cache import RegisterCache
 from givenergy_modbus.testing.identify import (
@@ -92,10 +94,14 @@ def test_identify_single_pass_range_filter():
 
 
 def test_identify_single_pass_non_integer_address_excluded():
-    """Values that don't invert to an integer address for any scale are excluded."""
-    # 0.37 → uint16: 0.37 (not int), deci: 3.7 (not int), centi: 37 (int! address=37)
+    """Non-integer inverses at a given scale are excluded; only integer-address scales returned."""
+    # 0.37 → uint16: 0.37 (not int, excluded), deci: 3.7 (not int, excluded),
+    #         centi: 37.0 (int, included), milli: 370 (int, included)
     candidates = identify(0.37)
-    assert all(c.address == round(c.address) for c in candidates)
+    scales = {c.scale for c in candidates}
+    assert 0.01 in scales  # centi: 0.37/0.01 = 37 ✓
+    assert 1.0 not in scales  # uint16: 0.37 not an integer
+    assert 0.1 not in scales  # deci: 3.7 not an integer
 
 
 def test_identify_single_pass_returns_all_candidates():
@@ -212,3 +218,87 @@ def test_sentinel_identify_round_trip_uint16():
     candidates = identify(d1, d2, k=k, reg_range=range(95, 110))
     assert len(candidates) == 1
     assert candidates[0].address == address
+
+
+# ---------------------------------------------------------------------------
+# sentinel_devices — validation
+# ---------------------------------------------------------------------------
+
+
+def test_sentinel_devices_overflow_raises():
+    """sentinel_devices raises ValueError when address + offset exceeds uint16 max."""
+    base: dict[int, RegisterCache] = {0x31: RegisterCache()}
+    spec = [(0x31, IR, range(65530, 65540))]
+    with pytest.raises(ValueError, match="is out of the valid 16-bit unsigned integer range"):
+        sentinel_devices(base, spec, offset=10)
+
+
+def test_sentinel_devices_max_valid_address():
+    """Address + offset = 65535 is accepted."""
+    base: dict[int, RegisterCache] = {0x31: RegisterCache()}
+    spec = [(0x31, IR, range(65535, 65536))]
+    devices = sentinel_devices(base, spec, offset=0)
+    assert devices[0x31][IR(65535)] == 65535
+
+
+def test_sentinel_devices_address_zero():
+    """Register address 0 is valid and correctly seeded."""
+    base: dict[int, RegisterCache] = {0x11: RegisterCache()}
+    spec = [(0x11, HR, range(0, 3))]
+    devices = sentinel_devices(base, spec)
+    assert devices[0x11][HR(0)] == 0
+
+
+# ---------------------------------------------------------------------------
+# identify — address 0 and two-pass scale snapping
+# ---------------------------------------------------------------------------
+
+
+def test_identify_single_pass_address_zero():
+    """Register 0 at uint16 scale (displayed 0.0) should be a candidate."""
+    # Seeded value = 0 → displayed 0.0 at scale 1.0 → address = 0
+    candidates = identify(0.0, reg_range=range(0, 5))
+    # address=0 at scale=1.0 should be included
+    assert any(c.address == 0 and abs(c.scale - 1.0) < 1e-9 for c in candidates)
+
+
+def test_identify_two_pass_snaps_to_known_scale():
+    """Two-pass result uses the snapped known scale even with minor rounding."""
+    # Simulate app rounding: true deci scale 0.1, displayed values rounded to 1dp
+    # d1 = 24.2 (true: 242 * 0.1), d2 = 124.2 (true: (242+1000) * 0.1)
+    # diff / k = 100.0 / 1000 = 0.1 exactly — scale snaps to 0.1
+    candidates = identify(24.2, 124.2, k=1000)
+    assert len(candidates) == 1
+    assert abs(candidates[0].scale - 0.1) < 1e-9
+    assert candidates[0].address == 242
+
+
+def test_identify_two_pass_unknown_scale_returns_empty():
+    """Two-pass returns empty if computed scale doesn't match any known converter."""
+    # d2 - d1 = 3 with k=1000 → scale = 0.003 — not in CONVERTER_SCALES
+    candidates = identify(1.0, 4.0, k=1000)
+    assert candidates == []
+
+
+# ---------------------------------------------------------------------------
+# MockPlant.from_sentinels integration
+# ---------------------------------------------------------------------------
+
+
+def test_mock_plant_from_sentinels_overlays_values():
+    """from_sentinels seeds sentinel values on top of the base capture."""
+    from pathlib import Path
+
+    from givenergy_modbus.testing import MockPlant
+
+    fixture = (
+        Path(__file__).parent.parent
+        / "fixtures/captures/hybrid_2_bat_a/hybrid_gen1_arm449_givbat82_givbat95gen3_60min.log"
+    )
+    if not fixture.exists():
+        pytest.skip("fixture not available")
+
+    spec = [(0x31, IR, range(100, 105))]
+    mock = MockPlant.from_sentinels(fixture, spec=spec, offset=500)
+    # Sentinel: IR(100) should be 600 (= 100 + 500)
+    assert mock.devices[0x31][IR(100)] == 600

--- a/tests/testing/test_identify.py
+++ b/tests/testing/test_identify.py
@@ -152,6 +152,14 @@ def test_identify_two_pass_centi():
     assert abs(candidates[0].scale - 0.01) < 1e-9
 
 
+def test_identify_invalid_k_raises():
+    """identify() raises ValueError for non-positive k."""
+    with pytest.raises(ValueError, match="k must be a positive integer"):
+        identify(100.0, 200.0, k=0)
+    with pytest.raises(ValueError, match="k must be a positive integer"):
+        identify(100.0, 200.0, k=-1)
+
+
 def test_identify_two_pass_equal_values_returns_empty():
     """If both passes show the same value (zero diff), return empty."""
     assert identify(100.0, 100.0, k=1000) == []

--- a/tests/testing/test_identify.py
+++ b/tests/testing/test_identify.py
@@ -1,0 +1,214 @@
+"""Tests for register cross-correlation helpers (identify.py)."""
+
+from givenergy_modbus.model.register import HR, IR
+from givenergy_modbus.model.register_cache import RegisterCache
+from givenergy_modbus.testing.identify import (
+    identify,
+    sentinel_devices,
+)
+
+# ---------------------------------------------------------------------------
+# sentinel_devices
+# ---------------------------------------------------------------------------
+
+
+def test_sentinel_devices_overlays_values():
+    """Sentinel value at each address equals address + offset."""
+    base: dict[int, RegisterCache] = {0x31: RegisterCache()}
+    spec = [(0x31, IR, range(10, 15))]
+    devices = sentinel_devices(base, spec, offset=0)
+    for addr in range(10, 15):
+        assert devices[0x31][IR(addr)] == addr
+
+
+def test_sentinel_devices_offset():
+    """offset=K shifts every sentinel value by K."""
+    base: dict[int, RegisterCache] = {0x31: RegisterCache()}
+    spec = [(0x31, IR, range(50, 55))]
+    devices = sentinel_devices(base, spec, offset=1000)
+    for addr in range(50, 55):
+        assert devices[0x31][IR(addr)] == addr + 1000
+
+
+def test_sentinel_devices_creates_new_device():
+    """A device_address not in base is created automatically."""
+    base: dict[int, RegisterCache] = {}
+    spec = [(0x11, HR, range(0, 5))]
+    devices = sentinel_devices(base, spec)
+    assert 0x11 in devices
+    assert devices[0x11][HR(3)] == 3
+
+
+def test_sentinel_devices_does_not_mutate_base():
+    """Base caches are not modified."""
+    cache = RegisterCache({IR(10): 999})
+    base = {0x31: cache}
+    sentinel_devices(base, [(0x31, IR, range(10, 12))])
+    assert cache[IR(10)] == 999  # original untouched
+
+
+def test_sentinel_devices_preserves_non_overlaid_registers():
+    """Registers outside the spec range keep their base values."""
+    base = {0x31: RegisterCache({IR(5): 42})}
+    spec = [(0x31, IR, range(10, 15))]
+    devices = sentinel_devices(base, spec)
+    assert devices[0x31][IR(5)] == 42
+
+
+# ---------------------------------------------------------------------------
+# identify — single-pass
+# ---------------------------------------------------------------------------
+
+
+def test_identify_single_pass_deci():
+    """Deci register: displayed = address * 0.1 → candidate address recovered."""
+    # Address 2427 at deci scale → displayed 242.7
+    candidates = identify(242.7)
+    addrs_at_deci = [c.address for c in candidates if abs(c.scale - 0.1) < 1e-9]
+    assert 2427 in addrs_at_deci
+
+
+def test_identify_single_pass_uint16():
+    """uint16 register: displayed = address (scale 1.0)."""
+    # Address 100 at scale 1.0 → displayed 100.0
+    candidates = identify(100.0)
+    addrs_at_unit = [c.address for c in candidates if abs(c.scale - 1.0) < 1e-9]
+    assert 100 in addrs_at_unit
+
+
+def test_identify_single_pass_centi():
+    """Centi register: displayed = address * 0.01."""
+    # Address 4998 at centi scale → displayed 49.98
+    candidates = identify(49.98)
+    addrs_at_centi = [c.address for c in candidates if abs(c.scale - 0.01) < 1e-9]
+    assert 4998 in addrs_at_centi
+
+
+def test_identify_single_pass_range_filter():
+    """reg_range filters candidates to those whose address falls in the range."""
+    candidates = identify(242.7, reg_range=range(2400, 2500))
+    assert all(2400 <= c.address < 2500 for c in candidates)
+    assert any(c.address == 2427 for c in candidates)
+
+
+def test_identify_single_pass_non_integer_address_excluded():
+    """Values that don't invert to an integer address for any scale are excluded."""
+    # 0.37 → uint16: 0.37 (not int), deci: 3.7 (not int), centi: 37 (int! address=37)
+    candidates = identify(0.37)
+    assert all(c.address == round(c.address) for c in candidates)
+
+
+def test_identify_single_pass_returns_all_candidates():
+    """Single-pass may return multiple candidates (one per matching scale)."""
+    # 10.0 → uint16: 10, deci: 100, centi: 1000, milli: 10000 — all valid integers
+    candidates = identify(10.0)
+    assert len(candidates) >= 2  # at least uint16 + deci match
+
+
+def test_identify_single_pass_no_duplicates():
+    """No duplicate (address, scale) pairs even when multiple scale names match."""
+    candidates = identify(100.0)
+    seen = [(c.address, c.scale) for c in candidates]
+    assert len(seen) == len(set(seen))
+
+
+# ---------------------------------------------------------------------------
+# identify — two-pass
+# ---------------------------------------------------------------------------
+
+
+def test_identify_two_pass_deci():
+    """Two-pass uniquely recovers address and scale for a deci register."""
+    # Address 2427, deci (0.1): pass1=242.7, pass2=(2427+1000)/10=342.7
+    candidates = identify(242.7, 342.7, k=1000)
+    assert len(candidates) == 1
+    c = candidates[0]
+    assert c.address == 2427
+    assert abs(c.scale - 0.1) < 1e-9
+    assert c.confidence == "two-pass"
+
+
+def test_identify_two_pass_uint16():
+    """Two-pass for a uint16 register (scale=1.0)."""
+    # Address 100, scale 1.0: pass1=100, pass2=100+1000=1100
+    candidates = identify(100.0, 1100.0, k=1000)
+    assert len(candidates) == 1
+    assert candidates[0].address == 100
+    assert abs(candidates[0].scale - 1.0) < 1e-9
+
+
+def test_identify_two_pass_centi():
+    """Two-pass for a centi register."""
+    # Address 4998, centi (0.01): pass1=49.98, pass2=(4998+1000)*0.01=59.98
+    candidates = identify(49.98, 59.98, k=1000)
+    assert len(candidates) == 1
+    assert candidates[0].address == 4998
+    assert abs(candidates[0].scale - 0.01) < 1e-9
+
+
+def test_identify_two_pass_equal_values_returns_empty():
+    """If both passes show the same value (zero diff), return empty."""
+    assert identify(100.0, 100.0, k=1000) == []
+
+
+def test_identify_two_pass_negative_diff_returns_empty():
+    """Negative scale is physically meaningless."""
+    # d2 < d1 → negative scale
+    assert identify(342.7, 242.7, k=1000) == []
+
+
+def test_identify_two_pass_range_filter():
+    """reg_range filter applies to two-pass results."""
+    candidates = identify(242.7, 342.7, k=1000, reg_range=range(2000, 2500))
+    assert len(candidates) == 1
+    assert candidates[0].address == 2427
+
+    # Exclude the address
+    candidates_filtered = identify(242.7, 342.7, k=1000, reg_range=range(3000, 4000))
+    assert candidates_filtered == []
+
+
+# ---------------------------------------------------------------------------
+# sentinel_devices + identify round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_sentinel_identify_round_trip_deci():
+    """End-to-end: seed a deci register, read the forward value, recover address."""
+    address = 377  # hypothetical temperature register
+    scale = 0.1  # C.deci
+    base = {0x31: RegisterCache()}
+
+    # Pass 1: seed value = address
+    devices1 = sentinel_devices(base, [(0x31, IR, range(370, 385))], offset=0)
+    raw1 = devices1[0x31][IR(address)]
+    d1 = raw1 * scale  # simulate app displaying the value
+
+    # Pass 2: seed value = address + K
+    k = 1000
+    devices2 = sentinel_devices(base, [(0x31, IR, range(370, 385))], offset=k)
+    raw2 = devices2[0x31][IR(address)]
+    d2 = raw2 * scale
+
+    candidates = identify(d1, d2, k=k)
+    assert len(candidates) == 1
+    assert candidates[0].address == address
+    assert abs(candidates[0].scale - scale) < 1e-9
+    assert candidates[0].confidence == "two-pass"
+
+
+def test_sentinel_identify_round_trip_uint16():
+    """uint16 registers round-trip through sentinel_devices + identify."""
+    address = 100  # battery SOC
+    base = {0x11: RegisterCache()}
+    k = 1000
+
+    devices1 = sentinel_devices(base, [(0x11, HR, range(95, 110))], offset=0)
+    d1 = float(devices1[0x11][HR(address)])
+
+    devices2 = sentinel_devices(base, [(0x11, HR, range(95, 110))], offset=k)
+    d2 = float(devices2[0x11][HR(address)])
+
+    candidates = identify(d1, d2, k=k, reg_range=range(95, 110))
+    assert len(candidates) == 1
+    assert candidates[0].address == address


### PR DESCRIPTION
## Summary

Adds `givenergy_modbus/testing/identify.py` — tools to identify which register backs each label on the GivEnergy app's Read Only tab, where register numbers are hidden.

**Principle.** Seed a `MockPlant` with *sentinel* values (raw = address), point the app at it, read the displayed values off the Read Only tab, and call `identify()` to invert the converter and recover the address.

### New API

```python
from givenergy_modbus.testing import sentinel_devices, identify, Candidate, MockPlant

# Pass 1: seed IR(0-239) at device 0x31 with raw = address
mock = MockPlant.from_sentinels("plant.log", spec=[(0x31, IR, range(0, 240))], offset=0)

# Pass 2: same spec, offset=1000
mock2 = MockPlant.from_sentinels("plant.log", spec=[(0x31, IR, range(0, 240))], offset=1000)

# App shows "Grid voltage 242.7 V" on pass 1, "342.7 V" on pass 2
candidates = identify(242.7, 342.7, k=1000)
# → [Candidate(address=2427, scale=0.1, confidence='two-pass')]
```

**Two-pass principle:** for any linear converter with scale `s`:
- `d1 = A * s` (offset=0), `d2 = (A+K) * s` (offset=K)
- `s = (d2 - d1) / K`, `A = d1 / s` — uniquely recovers address and scale

Single-pass returns all scale-consistent candidates; two-pass gives a unique solution.

### New items

| Symbol | Description |
|---|---|
| `sentinel_devices(base, spec, *, offset)` | Deep-clone register caches + overlay sentinels |
| `identify(d1, d2, *, k, reg_range, tolerance)` | Invert displayed value → address + scale |
| `Candidate` | Dataclass: `address`, `scale`, `confidence` |
| `CONVERTER_SCALES` | The four linear scale factors (uint16, deci, centi, milli) |
| `MockPlant.from_sentinels(...)` | One-call setup for a cross-correlation run |

## Test plan

- [x] 20 unit tests: overlay correctness, offset, mutation safety, single/two-pass identify for deci/uint16/centi, range filtering, deduplication, full round-trip
- [x] `tox` green (py314, format, lint, build, 737+ tests)
- [ ] @coderabbitai review
- [ ] Codex review gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added diagnostic utilities to identify Modbus register addresses from displayed telemetry values
  * Added method to construct mock plants using sentinel register definitions
  * Expanded testing module exports with register identification helpers

* **Tests**
  * Added comprehensive test suite covering register identification and sentinel device functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->