### PR TITLE
fix(ems): surface per-slot inverter status as raw hex code (#108)

### DIFF
--- a/givenergy_modbus/model/ems.py
+++ b/givenergy_modbus/model/ems.py
@@ -1,5 +1,6 @@
 """GivEnergy EMS (Energy Management System) data model."""
 
+from enum import IntEnum
 from typing import ClassVar
 
 from pydantic import ConfigDict, computed_field, create_model
@@ -16,6 +17,36 @@ from givenergy_modbus.model.register import RegisterDefinition as Def
 # fields for slots 1..MAX_MANAGED_INVERTERS; slots beyond ``inverter_count``
 # are unpopulated and skipped by ``Ems.managed_inverters``.
 MAX_MANAGED_INVERTERS = 4
+
+
+class EmsInverterStatus(IntEnum):
+    """SUSPECTED labels for the EMS per-slot inverter status code (IR(2045), 3-bit).
+
+    These are a best-effort interpretation, exposed via ``inverter_N_suspected_status``
+    so the raw code (``inverter_N_status``, hex) becomes human-inspectable and users can
+    confirm or correct it (#108). Only ``ABSENT`` (0) and ``ONLINE`` (2) are verified —
+    against the committed EMS capture, where empty slots read 0 and present, idle
+    inverters read 2. The other 3-bit codes (1, 3–7) have never been observed; they
+    decode to ``None`` here rather than being guessed. If your inverter shows an
+    unexpected suspected status (or ``None``), that feedback is exactly what closes #108.
+    """
+
+    ABSENT = 0
+    ONLINE = 2
+
+
+def _ems_inverter_suspected_status(code: int | None) -> "EmsInverterStatus | None":
+    """Map a raw 3-bit EMS inverter status code to a SUSPECTED label, or None if unknown.
+
+    Lenient by design: only verified codes (0, 2) resolve; unobserved codes return None
+    rather than raising, so an unexpected firmware value can't break the whole decode.
+    """
+    if code is None:
+        return None
+    try:
+        return EmsInverterStatus(code)
+    except ValueError:
+        return None
 
 
 class EmsRegisterGetter(RegisterGetter):
@@ -84,6 +115,14 @@ class EmsRegisterGetter(RegisterGetter):
         "inverter_2_status": Def((C.bitfield, 10, 12), (C.hex, 1), IR(2045)),
         "inverter_3_status": Def((C.bitfield, 7, 9), (C.hex, 1), IR(2045)),
         "inverter_4_status": Def((C.bitfield, 4, 6), (C.hex, 1), IR(2045)),
+        # SUSPECTED human-readable interpretation of the same per-slot code, for user
+        # inspection/feedback (#108). Only 0=ABSENT and 2=ONLINE are verified; other
+        # codes decode to None pending real-world confirmation. The raw code stays
+        # authoritative on inverter_N_status above.
+        "inverter_1_suspected_status": Def((C.bitfield, 13, 15), _ems_inverter_suspected_status, IR(2045)),
+        "inverter_2_suspected_status": Def((C.bitfield, 10, 12), _ems_inverter_suspected_status, IR(2045)),
+        "inverter_3_suspected_status": Def((C.bitfield, 7, 9), _ems_inverter_suspected_status, IR(2045)),
+        "inverter_4_suspected_status": Def((C.bitfield, 4, 6), _ems_inverter_suspected_status, IR(2045)),
         "meter_1_power": Def(C.int16, None, IR(2046)),
         "meter_2_power": Def(C.int16, None, IR(2047)),
         "meter_3_power": Def(C.int16, None, IR(2048)),

--- a/givenergy_modbus/model/ems.py
+++ b/givenergy_modbus/model/ems.py
@@ -72,10 +72,18 @@ class EmsRegisterGetter(RegisterGetter):
         "inverter_count": Def(C.uint16, None, IR(2044)),
         # IR(2045) packs up to 4 inverter statuses as 3-bit fields, LSB-first (slot N
         # occupies bits [(3N-3):(3N-1)] from LSB). MSB-first indices: [16-3N : 18-3N].
-        "inverter_1_status": Def((C.bitfield, 13, 15), Status, IR(2045)),
-        "inverter_2_status": Def((C.bitfield, 10, 12), Status, IR(2045)),
-        "inverter_3_status": Def((C.bitfield, 7, 9), Status, IR(2045)),
-        "inverter_4_status": Def((C.bitfield, 4, 6), Status, IR(2045)),
+        # The per-slot status CODE is exposed as a hex string (the house idiom for raw,
+        # uninterpreted codes — cf. device_type_code / fault_code), NOT mapped through the
+        # inverter Status enum: that enum's values don't match this field's encoding
+        # (a present, idle inverter reads code 2 here, which Status would mislabel as
+        # WARNING). The only values verified against the committed EMS capture are
+        # 0 = empty slot and 2 = present/idle; the full code→meaning mapping isn't exposed
+        # by the GivEnergy app (which abstracts the EMS to one PCS object) and remains
+        # undocumented. Use `inverter_count` for how many inverters are present (#108).
+        "inverter_1_status": Def((C.bitfield, 13, 15), (C.hex, 1), IR(2045)),
+        "inverter_2_status": Def((C.bitfield, 10, 12), (C.hex, 1), IR(2045)),
+        "inverter_3_status": Def((C.bitfield, 7, 9), (C.hex, 1), IR(2045)),
+        "inverter_4_status": Def((C.bitfield, 4, 6), (C.hex, 1), IR(2045)),
         "meter_1_power": Def(C.int16, None, IR(2046)),
         "meter_2_power": Def(C.int16, None, IR(2047)),
         "meter_3_power": Def(C.int16, None, IR(2048)),

--- a/tests/model/test_devices.py
+++ b/tests/model/test_devices.py
@@ -198,7 +198,7 @@ def test_ems_managed_inverters_constructs_summaries_per_populated_slot():
         power=1800,
         soc=65,
         temp_deci=285,  # 28.5 °C (deci scaling)
-        status=Status.NORMAL.value,
+        status=2,  # per-slot EMS status code (2 = present/idle, the verified value)
     )
     _add_rollup_slot(
         values,
@@ -207,7 +207,7 @@ def test_ems_managed_inverters_constructs_summaries_per_populated_slot():
         power=2200,
         soc=78,
         temp_deci=312,
-        status=Status.NORMAL.value,
+        status=2,
     )
     ems = Ems.from_register_cache(RegisterCache(values))
 
@@ -218,12 +218,13 @@ def test_ems_managed_inverters_constructs_summaries_per_populated_slot():
     # encode/decode contract — the bit positions for the per-slot status
     # fields are MSB-first (see ``Converter.bitfield``), so a regression in
     # the encoder shift direction or in the decoder slice would surface here.
-    assert managed[0].status == Status.NORMAL
+    # The per-slot status is an uninterpreted hex code (#108), so code 2 → "2".
+    assert managed[0].status == "2"
     assert managed[0].p_inverter_out == 1800
     assert managed[0].battery_soc == 65
     assert managed[0].t_inverter_heatsink == 28.5
     assert managed[1].serial_number == "ZZ9876B543"
-    assert managed[1].status == Status.NORMAL
+    assert managed[1].status == "2"
     assert managed[1].p_inverter_out == 2200
 
 

--- a/tests/model/test_ems.py
+++ b/tests/model/test_ems.py
@@ -93,13 +93,15 @@ def test_meter_status_bitfield():
 def test_inverter_status_bitfield():
     # IR(2045) packs 4 × 3-bit inverter statuses, LSB-first: slot N occupies bits [3N-3:3N-1].
     # C.bitfield uses MSB-first indices, so slot N = bitfield(16-3N, 18-3N).
-    # inverter_1 (bits[2:0] → 0b001 = NORMAL=1 → 0x0001)
-    # inverter_2 (bits[5:3] → 0b011 = FAULT=3 → 0b011<<3 = 0x0018)
+    # The 3-bit code is surfaced as a hex string (uninterpreted raw code, #108) — NOT the
+    # inverter Status enum, whose values don't match this field's encoding.
+    # inverter_1 (bits[2:0] → 0b001 = code 1 → "1")
+    # inverter_2 (bits[5:3] → 0b011 = code 3 → "3")
     packed = 0b001 | (0b011 << 3)  # = 0x0019
     cache = _cache({IR(2045): packed})
     ems = Ems.from_register_cache(cache)
-    assert ems.inverter_1_status == Status.NORMAL  # type: ignore[attr-defined]
-    assert ems.inverter_2_status == Status.FAULT  # type: ignore[attr-defined]
+    assert ems.inverter_1_status == "1"  # type: ignore[attr-defined]
+    assert ems.inverter_2_status == "3"  # type: ignore[attr-defined]
 
 
 def test_bitfield_decode_matches_fixture():
@@ -107,26 +109,31 @@ def test_bitfield_decode_matches_fixture():
 
     Pinned to the committed ems_2_inv_3_bat_a fixture where:
     - IR(2043)=17 (0b10001): bits[1:0]=01=ONLINE (meter_1 −94 W), bits[5:4]=01=ONLINE
-      (meter_3 583 W), everything else DISABLED
-    - IR(2045)=18 (0b10010): bits[2:0]=010=WARNING (inv_1), bits[5:3]=010=WARNING (inv_2)
+      (meter_3 583 W), everything else DISABLED — verified against the meter power regs.
+    - IR(2045)=18 (0b10010): bits[2:0]=010=code 2 (inv_1 present), bits[5:3]=010=code 2
+      (inv_2 present), inv_3/inv_4 = code 0 (empty). Per-slot inverter status is an
+      uninterpreted hex code (the GivEnergy app doesn't expose it); only 0=empty and
+      2=present/idle are verified. Presence is authoritatively given by `inverter_count`.
     """
     fixture = Path(__file__).parent.parent / "fixtures/captures/ems_2_inv_3_bat_a/ems_arm1036_30min.log"
     plant = plant_from_capture(str(fixture))
     cache = plant.register_caches[0x11]
     ems = Ems.from_register_cache(cache)
 
-    # Meter statuses — only meters with power should be ONLINE
+    # Meter statuses — only meters with power should be ONLINE (verified vs power regs)
     assert ems.meter_1_status == MeterStatus.ONLINE  # type: ignore[attr-defined]  # -94 W
     assert ems.meter_2_status == MeterStatus.DISABLED  # type: ignore[attr-defined]  # 0 W
     assert ems.meter_3_status == MeterStatus.ONLINE  # type: ignore[attr-defined]  # +583 W
     for n in range(4, 9):
         assert getattr(ems, f"meter_{n}_status") == MeterStatus.DISABLED  # type: ignore[attr-defined]
 
-    # Inverter statuses — inv_1/inv_2 are present and active; inv_3/inv_4 absent
-    assert ems.inverter_1_status in (Status.NORMAL, Status.WARNING)  # type: ignore[attr-defined]
-    assert ems.inverter_2_status in (Status.NORMAL, Status.WARNING)  # type: ignore[attr-defined]
-    assert ems.inverter_3_status == Status.WAITING  # type: ignore[attr-defined]  # no physical inverter
-    assert ems.inverter_4_status == Status.WAITING  # type: ignore[attr-defined]  # no physical inverter
+    # Inverter statuses — raw hex codes: inv_1/inv_2 present (code 2), inv_3/inv_4 empty (0)
+    assert ems.inverter_1_status == "2"  # type: ignore[attr-defined]
+    assert ems.inverter_2_status == "2"  # type: ignore[attr-defined]
+    assert ems.inverter_3_status == "0"  # type: ignore[attr-defined]
+    assert ems.inverter_4_status == "0"  # type: ignore[attr-defined]
+    # inverter_count is the authoritative presence signal (#108)
+    assert ems.inverter_count == 2  # type: ignore[attr-defined]
 
 
 def test_per_inverter_data():

--- a/tests/model/test_ems.py
+++ b/tests/model/test_ems.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from givenergy_modbus.model.ems import Ems
+from givenergy_modbus.model.ems import Ems, EmsInverterStatus
 from givenergy_modbus.model.inverter import Status
 from givenergy_modbus.model.meter import MeterStatus
 from givenergy_modbus.model.register import HR, IR
@@ -102,6 +102,9 @@ def test_inverter_status_bitfield():
     ems = Ems.from_register_cache(cache)
     assert ems.inverter_1_status == "1"  # type: ignore[attr-defined]
     assert ems.inverter_2_status == "3"  # type: ignore[attr-defined]
+    # codes 1 and 3 are unverified → suspected_status is None (not guessed)
+    assert ems.inverter_1_suspected_status is None  # type: ignore[attr-defined]
+    assert ems.inverter_2_suspected_status is None  # type: ignore[attr-defined]
 
 
 def test_bitfield_decode_matches_fixture():
@@ -132,6 +135,11 @@ def test_bitfield_decode_matches_fixture():
     assert ems.inverter_2_status == "2"  # type: ignore[attr-defined]
     assert ems.inverter_3_status == "0"  # type: ignore[attr-defined]
     assert ems.inverter_4_status == "0"  # type: ignore[attr-defined]
+    # ...and the SUSPECTED interpretation (verified codes only): 2→ONLINE, 0→ABSENT
+    assert ems.inverter_1_suspected_status == EmsInverterStatus.ONLINE  # type: ignore[attr-defined]
+    assert ems.inverter_2_suspected_status == EmsInverterStatus.ONLINE  # type: ignore[attr-defined]
+    assert ems.inverter_3_suspected_status == EmsInverterStatus.ABSENT  # type: ignore[attr-defined]
+    assert ems.inverter_4_suspected_status == EmsInverterStatus.ABSENT  # type: ignore[attr-defined]
     # inverter_count is the authoritative presence signal (#108)
     assert ems.inverter_count == 2  # type: ignore[attr-defined]
 

--- a/tests/model/test_ems.py
+++ b/tests/model/test_ems.py
@@ -90,6 +90,16 @@ def test_meter_status_bitfield():
     assert ems.meter_3_status == MeterStatus.DISABLED  # type: ignore[attr-defined]
 
 
+def test_ems_inverter_suspected_status_converter():
+    """The lenient converter resolves verified codes, returns None otherwise."""
+    from givenergy_modbus.model.ems import _ems_inverter_suspected_status
+
+    assert _ems_inverter_suspected_status(0) == EmsInverterStatus.ABSENT
+    assert _ems_inverter_suspected_status(2) == EmsInverterStatus.ONLINE
+    assert _ems_inverter_suspected_status(3) is None  # unobserved code → not guessed
+    assert _ems_inverter_suspected_status(None) is None  # absent register → None
+
+
 def test_inverter_status_bitfield():
     # IR(2045) packs 4 × 3-bit inverter statuses, LSB-first: slot N occupies bits [3N-3:3N-1].
     # C.bitfield uses MSB-first indices, so slot N = bitfield(16-3N, 18-3N).


### PR DESCRIPTION
## Summary

Fixes #108 (the known issue called out in the 2.1.0 release notes). Targets a **2.1.1 patch**.

The EMS rollup's per-slot **inverter** status (`IR(2045)`, 4×3-bit) was decoded through the main inverter `Status` enum, whose values don't match this field's encoding — so a *present, idle* inverter (code `2`) read as "WARNING" and an *empty* slot (code `0`) as "WAITING". The bit extraction was already correct; only the interpretation was wrong.

### What changed

- **Inverter status → hex string.** Surface the raw 3-bit code as a hex string — the house idiom for uninterpreted codes (cf. `device_type_code`, `fault_code`) — rather than mis-applying `Status`. Verified codes: `0` = empty slot, `2` = present/idle (against the committed EMS capture's SoC/power registers). `inverter_count` remains the authoritative presence signal.
- **Meter status unchanged** — it was already correct (`MeterStatus`, verified against the meter power registers); now pinned by the fixture regression test.

### Why hex rather than a new enum

The GivEnergy app abstracts the whole EMS into a single "EMS-PCS" object and never exposes per-slot inverter status, so there's no authoritative label for the codes. A speculative enum would either invent GE's wording or `ValueError` on an unseen code. Hex is honest and robust.

### Verification

- App session (against an EMS-seeded MockPlant) independently confirmed the broad EMS rollup decode — solar 583 W, grid 94 W exporting, battery idle/45%, energies, voltages, temps all matched — and plant status NORMAL. It just doesn't surface per-slot inverter status.
- `tox` green (py314 + format + lint + build).
- `test_ems.py` / `test_devices.py` updated to assert the hex codes; meter statuses still pinned against the capture's power readings.
- Decode-only change — no register-safety review needed.

Refs #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Inverter per-slot status codes are now returned as raw hexadecimal values instead of parsed enum states, as the firmware encoding does not match expected Status values. Affects all four inverter slots in EMS monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->