### PR TITLE
fix(model): correct e_load_day mislabel; add e_consumption_today (#174)

### DIFF
--- a/givenergy_modbus/model/inverter.py
+++ b/givenergy_modbus/model/inverter.py
@@ -644,7 +644,13 @@ class SinglePhaseInverterRegisterGetter(RegisterGetter):
         "p_backup": Def(C.uint16, None, IR(31), max=50000),  # EPS
         "e_grid_in_total": Def(C.uint32, C.deci, IR(32), IR(33)),
         # IR(34) unknown, skip
-        "e_load_day": Def(C.deci, None, IR(35)),
+        # IR(35) is AC-charge-today, NOT house-load/consumption. The GivTCP-era
+        # "e_load_day" name was a mislabel (#174): sentinel cross-correlation via the
+        # GE app's Energy-today screen confirmed IR(35) backs "AC charge today". The
+        # app's "Consumption today" is computed, not a register — see e_consumption_today
+        # on SinglePhaseInverter. Aligned to the existing three-phase e_ac_charge_today
+        # name so the three-phase native (IR1376/7) overrides this inherited entry.
+        "e_ac_charge_today": Def(C.deci, None, IR(35)),
         "e_battery_charge_today_alt1": Def(C.deci, None, IR(36)),
         "e_battery_discharge_today_alt1": Def(C.deci, None, IR(37)),
         "countdown": Def(C.uint16, None, IR(38)),
@@ -656,7 +662,10 @@ class SinglePhaseInverterRegisterGetter(RegisterGetter):
         # Inverter AC grid-terminal apparent power (VA); pairs with IR(24), not IR(30)
         # (IR43/IR24 → plausible PF ~0.9; IR43/IR30 → impossible). Same node as IR(24).
         "p_grid_apparent": Def(C.uint16, None, IR(43), max=50000),
-        "e_inverter_out_day": Def(C.deci, None, IR(44)),
+        # IR(44) is PV-generation-today (sentinel cross-correlation, #174), not the
+        # inverter AC output. Renamed from "e_inverter_out_day"; the old name is kept
+        # as a deprecated @property alias on both inverter classes for a release.
+        "e_pv_generation_today": Def(C.deci, None, IR(44)),
         "e_inverter_out_total": Def(C.uint32, C.deci, IR(45), IR(46)),
         # Hours since first power-on. Wire data on HYBRID_GEN1 ticks once per
         # wall-clock hour and persists across reboots; cap at ~100 years to
@@ -845,6 +854,34 @@ class SinglePhaseInverter(  # type: ignore[valid-type,misc]
         """
         return self.model in AC_COUPLED_MODELS  # type: ignore[attr-defined]
 
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def e_consumption_today(self) -> float | None:
+        """House consumption today (kWh), matching the GE app's "Consumption today".
+
+        DERIVED, not metered: single-phase units expose no consumption register, so the
+        GE app computes this value. Sentinel cross-correlation against the app's
+        Energy-today screen (#174) recovered the exact formula:
+
+            consumption = pv_generation + grid_import − grid_export − ac_charge
+
+        Battery DC charge/discharge throughput nets out and is not a term. The result
+        carries the same conversion-loss bias the app shows (energy balance overshoots
+        real consumption by a few %). This is the GE-universe definition of
+        "consumption" specifically — other plant equipment may define it differently.
+
+        Three-phase units have a native e_load_today register and so do NOT get this
+        computed field (it lives on SinglePhaseInverter only, not in the register LUT).
+        Returns None if any input is unavailable.
+        """
+        pv = self.e_pv_generation_today  # type: ignore[attr-defined]
+        grid_in = self.e_grid_in_day  # type: ignore[attr-defined]
+        grid_out = self.e_grid_out_day  # type: ignore[attr-defined]
+        ac_charge = self.e_ac_charge_today  # type: ignore[attr-defined]
+        if None in (pv, grid_in, grid_out, ac_charge):
+            return None
+        return pv + grid_in - grid_out - ac_charge
+
     # Plain @property (not @computed_field) so the deprecated alias doesn't
     # appear in model_dump() output. See #84 — renamed to work_time_total_hours
     # to put the unit at the call site.
@@ -874,6 +911,20 @@ class SinglePhaseInverter(  # type: ignore[valid-type,misc]
             stacklevel=2,
         )
         return self.enable_inverter_parallel_mode  # type: ignore[attr-defined,no-any-return]
+
+    # Plain @property so the deprecated alias doesn't appear in model_dump().
+    # IR(44) was decoded as e_inverter_out_day (GivTCP-era guess); sentinel
+    # cross-correlation (#174) confirmed it is PV-generation-today. Renamed to
+    # e_pv_generation_today; this alias preserves back-compat for a release.
+    @property
+    def e_inverter_out_day(self) -> float | None:
+        """Deprecated alias for `e_pv_generation_today`."""
+        warnings.warn(
+            "SinglePhaseInverter.e_inverter_out_day is deprecated; use e_pv_generation_today",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.e_pv_generation_today  # type: ignore[attr-defined,no-any-return]
 
 
 def __getattr__(name: str):

--- a/givenergy_modbus/model/inverter_threephase.py
+++ b/givenergy_modbus/model/inverter_threephase.py
@@ -541,18 +541,22 @@ class ThreePhaseInverter(  # type: ignore[valid-type,misc]
     # unverified on three-phase hardware (see #48).
     @property
     def e_inverter_out_day(self) -> float | None:
-        """Deprecated alias for `e_pv_generation_today`.
+        """Deprecated alias — returns `e_pv_today` (IR1412/1413), the verified three-phase PV-generation register.
 
-        Note: on three-phase units the verified PV-generation register is
-        `e_pv_today` (IR1412/1413). `e_pv_generation_today` (IR44) is inherited
-        from the single-phase LUT and has not been verified on three-phase hardware.
+        The old name is a GivTCP-era mislabel.
+
+        The old `e_inverter_out_day` name was a GivTCP-era mislabel; IR44
+        (`e_pv_generation_today`) leaks via single-phase LUT inheritance and is
+        unverified on three-phase hardware. This alias returns `e_pv_today`
+        directly so consumers following the deprecation warning get the same
+        value they were reading via the alias.
         """
         warnings.warn(
             "ThreePhaseInverter.e_inverter_out_day is deprecated; use e_pv_today",
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.e_pv_generation_today  # type: ignore[attr-defined,no-any-return]
+        return self.e_pv_today  # type: ignore[attr-defined,no-any-return]
 
 
 # Models that decode via the three-phase / 1000-range register layout. The residential

--- a/givenergy_modbus/model/inverter_threephase.py
+++ b/givenergy_modbus/model/inverter_threephase.py
@@ -533,6 +533,22 @@ class ThreePhaseInverter(  # type: ignore[valid-type,misc]
         )
         return self.enable_inverter_parallel_mode  # type: ignore[attr-defined,no-any-return]
 
+    # IR(44) was decoded as e_inverter_out_day (GivTCP-era guess); sentinel
+    # cross-correlation (#174) confirmed it is PV-generation-today. Renamed to
+    # e_pv_generation_today (inherited from the single-phase LUT, IR44); this alias
+    # preserves back-compat. Note: the verified three-phase PV-generation register is
+    # e_pv_today (IR1412/3) — IR(44) leaks via single-phase inheritance and is
+    # unverified on three-phase hardware (see #48).
+    @property
+    def e_inverter_out_day(self) -> float | None:
+        """Deprecated alias for `e_pv_generation_today`."""
+        warnings.warn(
+            "ThreePhaseInverter.e_inverter_out_day is deprecated; use e_pv_generation_today",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.e_pv_generation_today  # type: ignore[attr-defined,no-any-return]
+
 
 # Models that decode via the three-phase / 1000-range register layout. The residential
 # ALL_IN_ONE (DTC family "8", e.g. 0x8001) is deliberately absent: it is HV but single-

--- a/givenergy_modbus/model/inverter_threephase.py
+++ b/givenergy_modbus/model/inverter_threephase.py
@@ -548,9 +548,7 @@ class ThreePhaseInverter(  # type: ignore[valid-type,misc]
         from the single-phase LUT and has not been verified on three-phase hardware.
         """
         warnings.warn(
-            "ThreePhaseInverter.e_inverter_out_day is deprecated; "
-            "use e_pv_today (verified three-phase PV generation) or "
-            "e_pv_generation_today (inherited single-phase IR44, unverified on 3ph)",
+            "ThreePhaseInverter.e_inverter_out_day is deprecated; use e_pv_today",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/givenergy_modbus/model/inverter_threephase.py
+++ b/givenergy_modbus/model/inverter_threephase.py
@@ -541,9 +541,16 @@ class ThreePhaseInverter(  # type: ignore[valid-type,misc]
     # unverified on three-phase hardware (see #48).
     @property
     def e_inverter_out_day(self) -> float | None:
-        """Deprecated alias for `e_pv_generation_today`."""
+        """Deprecated alias for `e_pv_generation_today`.
+
+        Note: on three-phase units the verified PV-generation register is
+        `e_pv_today` (IR1412/1413). `e_pv_generation_today` (IR44) is inherited
+        from the single-phase LUT and has not been verified on three-phase hardware.
+        """
         warnings.warn(
-            "ThreePhaseInverter.e_inverter_out_day is deprecated; use e_pv_generation_today",
+            "ThreePhaseInverter.e_inverter_out_day is deprecated; "
+            "use e_pv_today (verified three-phase PV generation) or "
+            "e_pv_generation_today (inherited single-phase IR44, unverified on 3ph)",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/tests/model/test_inverter.py
+++ b/tests/model/test_inverter.py
@@ -1234,38 +1234,59 @@ def test_e_ac_charge_today_rename_no_alias():
 
 
 def test_e_pv_generation_today_rename_and_deprecated_alias():
-    """IR(44) is e_pv_generation_today (#174); e_inverter_out_day is a deprecated alias."""
+    """IR(44) is e_pv_generation_today (#174); e_inverter_out_day is a deprecated alias.
+
+    The two classes behave slightly differently:
+    - SinglePhaseInverter: alias returns e_pv_generation_today (IR44, verified).
+    - ThreePhaseInverter: alias returns e_pv_today (IR1412/3, the verified 3ph register),
+      so warning and return value agree. IR44 still leaks as e_pv_generation_today via
+      single-phase LUT inheritance, but the alias migration path is unambiguous.
+    """
     from givenergy_modbus.model.inverter_threephase import ThreePhaseInverter
     from givenergy_modbus.model.register import IR
 
-    cache = RegisterCache({IR(44): 81})
+    # Single-phase: IR44 is the authoritative PV-generation register.
+    sp_cache = RegisterCache({IR(44): 81})
+    sp = SinglePhaseInverter.from_register_cache(sp_cache)
 
-    for cls in (SinglePhaseInverter, ThreePhaseInverter):
-        inv = cls.from_register_cache(cache)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        assert sp.e_pv_generation_today == 8.1  # type: ignore[attr-defined]
+    assert [x for x in w if issubclass(x.category, DeprecationWarning)] == []
 
-        # New name returns the value cleanly with no warning.
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            assert inv.e_pv_generation_today == 8.1  # type: ignore[attr-defined]
-        assert [x for x in w if issubclass(x.category, DeprecationWarning)] == []
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        assert sp.e_inverter_out_day == 8.1  # type: ignore[attr-defined]  # returns e_pv_generation_today
+    sp_deprecations = [x for x in w if issubclass(x.category, DeprecationWarning)]
+    assert len(sp_deprecations) == 1
+    assert "e_pv_generation_today" in str(sp_deprecations[0].message)
 
-        # Deprecated alias still works, warns, and returns the same value.
-        # The warning message differs by class: single-phase points to e_pv_generation_today
-        # (the renamed register); three-phase points to e_pv_today (the verified 3ph field).
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            assert inv.e_inverter_out_day == 8.1  # type: ignore[attr-defined]
-        deprecations = [x for x in w if issubclass(x.category, DeprecationWarning)]
-        assert len(deprecations) == 1
-        if cls is SinglePhaseInverter:
-            assert "e_pv_generation_today" in str(deprecations[0].message)
-        else:
-            assert "e_pv_today" in str(deprecations[0].message)
+    sp_dumped = sp.model_dump()
+    assert "e_pv_generation_today" in sp_dumped
+    assert "e_inverter_out_day" not in sp_dumped
 
-        # Dump output uses the new name only — the alias must not duplicate the field.
-        dumped = inv.model_dump()
-        assert "e_pv_generation_today" in dumped
-        assert "e_inverter_out_day" not in dumped
+    # Three-phase: IR44 leaks as e_pv_generation_today (unverified); the alias
+    # returns e_pv_today (IR1412/3) so the migration path is unambiguous.
+    # Seed both IR44 and IR1412/3 with the same decoded value (8.1) so the
+    # alias-vs-field comparison is meaningful even on this synthetic cache.
+    tp_cache = RegisterCache({IR(44): 81, IR(1412): 0, IR(1413): 81})
+    tp = ThreePhaseInverter.from_register_cache(tp_cache)
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        assert tp.e_pv_generation_today == 8.1  # type: ignore[attr-defined]  # inherited IR44
+    assert [x for x in w if issubclass(x.category, DeprecationWarning)] == []
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        assert tp.e_inverter_out_day == 8.1  # type: ignore[attr-defined]  # returns e_pv_today
+    tp_deprecations = [x for x in w if issubclass(x.category, DeprecationWarning)]
+    assert len(tp_deprecations) == 1
+    assert "e_pv_today" in str(tp_deprecations[0].message)
+
+    tp_dumped = tp.model_dump()
+    assert "e_pv_generation_today" in tp_dumped
+    assert "e_inverter_out_day" not in tp_dumped
 
 
 def test_e_consumption_today_computed_formula():

--- a/tests/model/test_inverter.py
+++ b/tests/model/test_inverter.py
@@ -102,7 +102,8 @@ def test_inverter():
             "p_grid_out": None,
             "p_backup": None,
             "e_grid_in_total": None,
-            "e_load_day": None,
+            "e_ac_charge_today": None,
+            "e_consumption_today": None,
             "e_battery_charge_today_alt1": None,
             "e_battery_discharge_today_alt1": None,
             "countdown": None,
@@ -110,7 +111,7 @@ def test_inverter():
             "t_inverter_heatsink": None,
             "p_load_demand": None,
             "p_grid_apparent": None,
-            "e_inverter_out_day": None,
+            "e_pv_generation_today": None,
             "e_inverter_out_total": None,
             "work_time_total_hours": None,
             "system_mode": None,
@@ -507,7 +508,10 @@ def test_from_registers(register_cache):
         "p_grid_out": -342,
         "p_backup": 0,
         "e_grid_in_total": 365.3,
-        "e_load_day": 9.3,
+        "e_ac_charge_today": 9.3,  # IR(35) — was mislabelled e_load_day (#174)
+        # computed: e_pv_generation_today + e_grid_in_day − e_grid_out_day − e_ac_charge_today
+        #         = 8.1 + 20.9 − 0.0 − 9.3
+        "e_consumption_today": 19.7,
         "e_battery_charge_today_alt1": 9.0,  # IR(36)
         "e_battery_discharge_today_alt1": 8.9,  # IR(37)
         "countdown": 30,
@@ -515,7 +519,7 @@ def test_from_registers(register_cache):
         "t_inverter_heatsink": 22.2,
         "p_load_demand": 342,
         "p_grid_apparent": 680,
-        "e_inverter_out_day": 8.1,
+        "e_pv_generation_today": 8.1,  # IR(44) — was mislabelled e_inverter_out_day (#174)
         "e_inverter_out_total": 93.0,
         "work_time_total_hours": 213,
         "system_mode": 1,
@@ -848,7 +852,10 @@ def test_from_registers_actual_data(register_cache_inverter_daytime_discharging_
         "p_grid_out": 21,
         "p_backup": 0,
         "e_grid_in_total": 624.2,
-        "e_load_day": 9.3,
+        "e_ac_charge_today": 9.3,  # IR(35) — was mislabelled e_load_day (#174)
+        # computed: e_pv_generation_today + e_grid_in_day − e_grid_out_day − e_ac_charge_today
+        #         = 3.8 + 19.8 − 0.0 − 9.3
+        "e_consumption_today": 14.3,
         "e_battery_charge_today_alt1": 9.1,  # IR(36)
         "e_battery_discharge_today_alt1": 3.4,  # IR(37)
         "countdown": 0,
@@ -856,7 +863,7 @@ def test_from_registers_actual_data(register_cache_inverter_daytime_discharging_
         "t_inverter_heatsink": 24.4,
         "p_load_demand": 515,
         "p_grid_apparent": 554,
-        "e_inverter_out_day": 3.8,
+        "e_pv_generation_today": 3.8,  # IR(44) — was mislabelled e_inverter_out_day (#174)
         "e_inverter_out_total": 172.5,
         "work_time_total_hours": 385,
         "system_mode": 1,
@@ -1204,6 +1211,100 @@ def test_enable_inverter_parallel_mode_rename_and_deprecated_alias():
         dumped = inv.model_dump()
         assert "enable_inverter_parallel_mode" in dumped
         assert "enable_standard_self_consumption_logic" not in dumped
+
+
+def test_e_ac_charge_today_rename_no_alias():
+    """IR(35) is e_ac_charge_today (#174). The old e_load_day name was a mislabel.
+
+    Unlike the other renames there is NO deprecated alias: e_load_day never held
+    house-load, so keeping a back-compat alias would perpetuate the wrong meaning.
+    """
+    from givenergy_modbus.model.register import IR
+
+    cache = RegisterCache({IR(35): 93})
+    inv = SinglePhaseInverter.from_register_cache(cache)
+
+    assert inv.e_ac_charge_today == 9.3  # type: ignore[attr-defined]
+    dumped = inv.model_dump()
+    assert "e_ac_charge_today" in dumped
+    # The mislabel is gone entirely — no field, no alias.
+    assert "e_load_day" not in dumped
+    with pytest.raises(AttributeError):
+        _ = inv.e_load_day  # type: ignore[attr-defined]
+
+
+def test_e_pv_generation_today_rename_and_deprecated_alias():
+    """IR(44) is e_pv_generation_today (#174); e_inverter_out_day is a deprecated alias."""
+    from givenergy_modbus.model.inverter_threephase import ThreePhaseInverter
+    from givenergy_modbus.model.register import IR
+
+    cache = RegisterCache({IR(44): 81})
+
+    for cls in (SinglePhaseInverter, ThreePhaseInverter):
+        inv = cls.from_register_cache(cache)
+
+        # New name returns the value cleanly with no warning.
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            assert inv.e_pv_generation_today == 8.1  # type: ignore[attr-defined]
+        assert [x for x in w if issubclass(x.category, DeprecationWarning)] == []
+
+        # Deprecated alias still works, warns, and returns the same value.
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            assert inv.e_inverter_out_day == 8.1  # type: ignore[attr-defined]
+        deprecations = [x for x in w if issubclass(x.category, DeprecationWarning)]
+        assert len(deprecations) == 1
+        assert "e_pv_generation_today" in str(deprecations[0].message)
+
+        # Dump output uses the new name only — the alias must not duplicate the field.
+        dumped = inv.model_dump()
+        assert "e_pv_generation_today" in dumped
+        assert "e_inverter_out_day" not in dumped
+
+
+def test_e_consumption_today_computed_formula():
+    """Single-phase consumption is computed (#174), not a register.
+
+    Formula recovered by sentinel cross-correlation against the GE app's
+    Energy-today screen:
+        consumption = pv_generation + grid_import − grid_export − ac_charge
+    """
+    from givenergy_modbus.model.register import IR
+
+    # IR(44)=8.1 PV gen, IR(26)=20.9 grid import, IR(25)=0.0 grid export, IR(35)=9.3 AC charge
+    cache = RegisterCache({IR(44): 81, IR(26): 209, IR(25): 0, IR(35): 93})
+    inv = SinglePhaseInverter.from_register_cache(cache)
+
+    assert inv.e_consumption_today == 8.1 + 20.9 - 0.0 - 9.3  # type: ignore[attr-defined]
+    assert "e_consumption_today" in inv.model_dump()
+
+    # Missing any input → None (no partial guess).
+    partial = SinglePhaseInverter.from_register_cache(RegisterCache({IR(26): 209, IR(25): 0, IR(35): 93}))
+    assert partial.e_consumption_today is None  # type: ignore[attr-defined]
+
+
+def test_three_phase_has_no_computed_consumption_and_native_ac_charge():
+    """Three-phase has a native e_ac_charge_today register and no computed consumption (#174).
+
+    e_consumption_today is a SinglePhaseInverter computed_field, NOT in the register
+    LUT, so it does not leak onto ThreePhaseInverter — which carries its own
+    e_load_today register (IR1396/7). The native three-phase e_ac_charge_today
+    (IR1376/7) overrides the single-phase IR(35) entry inherited via the LUT merge.
+    """
+    from givenergy_modbus.model.inverter_threephase import ThreePhaseInverter
+    from givenergy_modbus.model.register import IR
+
+    # Native three-phase e_ac_charge_today = IR(1376/1377) uint32 deci = 35.0;
+    # the inherited single-phase IR(35) is seeded to a different value to prove the
+    # native override wins (not the leaked single-phase register).
+    cache = RegisterCache({IR(1376): 0, IR(1377): 350, IR(35): 99})
+    tp = ThreePhaseInverter.from_register_cache(cache)
+
+    assert tp.e_ac_charge_today == 35.0  # type: ignore[attr-defined]  # native IR1376/7, not 9.9
+    dumped = tp.model_dump()
+    assert "e_consumption_today" not in dumped  # computed field is single-phase only
+    assert "e_load_day" not in dumped  # the single-phase mislabel does not leak
 
 
 def test_battery_energy_facade_routes_by_model():

--- a/tests/model/test_inverter.py
+++ b/tests/model/test_inverter.py
@@ -1250,12 +1250,17 @@ def test_e_pv_generation_today_rename_and_deprecated_alias():
         assert [x for x in w if issubclass(x.category, DeprecationWarning)] == []
 
         # Deprecated alias still works, warns, and returns the same value.
+        # The warning message differs by class: single-phase points to e_pv_generation_today
+        # (the renamed register); three-phase points to e_pv_today (the verified 3ph field).
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             assert inv.e_inverter_out_day == 8.1  # type: ignore[attr-defined]
         deprecations = [x for x in w if issubclass(x.category, DeprecationWarning)]
         assert len(deprecations) == 1
-        assert "e_pv_generation_today" in str(deprecations[0].message)
+        if cls is SinglePhaseInverter:
+            assert "e_pv_generation_today" in str(deprecations[0].message)
+        else:
+            assert "e_pv_today" in str(deprecations[0].message)
 
         # Dump output uses the new name only — the alias must not duplicate the field.
         dumped = inv.model_dump()

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -1235,7 +1235,10 @@ def test_from_actual():
         "p_grid_out": -39,
         "p_backup": 0,
         "e_grid_in_total": 1978.3,
-        "e_load_day": 4.3,
+        "e_ac_charge_today": 4.3,  # IR(35) — was mislabelled e_load_day (#174)
+        # computed: e_pv_generation_today + e_grid_in_day − e_grid_out_day − e_ac_charge_today
+        #         = 38.0 + 12.3 − 2.4 − 4.3
+        "e_consumption_today": 43.6,
         "e_battery_charge_today_alt1": 5.7,  # IR(36)
         "e_battery_discharge_today_alt1": 5.9,  # IR(37)
         "countdown": 0,
@@ -1243,7 +1246,7 @@ def test_from_actual():
         "t_inverter_heatsink": 32.2,
         "p_load_demand": 745,
         "p_grid_apparent": 654,
-        "e_inverter_out_day": 38.0,
+        "e_pv_generation_today": 38.0,  # IR(44) — was mislabelled e_inverter_out_day (#174)
         "e_inverter_out_total": 1698.7,
         "work_time_total_hours": 2754,
         "system_mode": 1,


### PR DESCRIPTION
## Summary

Fixes #174. IR(35) was decoded as `e_load_day` (GivTCP-era guess) but sentinel cross-correlation against the GE app's Energy-today screen confirmed it is AC-charge-today, not house consumption.

- **`e_load_day` → `e_ac_charge_today`** (IR35). No deprecated alias — the old name was actively wrong. Aligning to the existing three-phase field name means the 3ph native (IR1376/7) auto-overrides the inherited single-phase entry with no separate 3ph step.
- **`e_inverter_out_day` → `e_pv_generation_today`** (IR44, also sentinel-confirmed as PV generation). Keeps `e_inverter_out_day` as a deprecated `@property` alias on both inverter classes for one release.
- **New `e_consumption_today` `@computed_field`** on `SinglePhaseInverter` only (not in the LUT, so not inherited by `ThreePhaseInverter` which has a native `e_load_today` register):
  ```
  consumption = pv_generation + grid_import − grid_export − ac_charge
  ```
  Battery DC throughput nets out. Matches the GE app's "Consumption today" definition exactly (sum-sq err ~1e-4 over 4 data points).

Three-phase energy block untouched — entirely unverified, deferred to #48 gated on a real 3ph capture.

## Verification methodology

`MockPlant.from_sentinels()` seeded against the HYBRID_GEN1 capture; formula validated against 3 live probes + 1 sentinel pass. Conventional `tests/model/test_inverter.py` additions:

- `test_e_ac_charge_today_rename_no_alias` — confirms old name is gone entirely
- `test_e_pv_generation_today_rename_and_deprecated_alias` — covers both inverter classes
- `test_e_consumption_today_computed_formula` — pins formula + None guard
- `test_three_phase_has_no_computed_consumption_and_native_ac_charge` — confirms 3ph native override wins, `e_consumption_today` absent

## Test plan

- [ ] CI green
- [ ] `tox` green locally (py314 + format + lint + build ✅)
- [ ] Codex review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified energy metric naming: AC charge and PV generation metrics now accurately reflect their purpose.
  * Corrected register mappings to prevent misinterpretation of energy data.

* **New Features**
  * Added "Consumption today" metric, calculated from generation, grid import/export, and AC charge data.

* **Chores**
  * Deprecated legacy energy metric aliases to support backward compatibility during transition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->