### PR TITLE
fix(model): rename e_inverter_out_total → e_pv_generation_total + battery_max_power None for unmapped DTC

### DIFF
--- a/givenergy_modbus/model/inverter.py
+++ b/givenergy_modbus/model/inverter.py
@@ -662,11 +662,15 @@ class SinglePhaseInverterRegisterGetter(RegisterGetter):
         # Inverter AC grid-terminal apparent power (VA); pairs with IR(24), not IR(30)
         # (IR43/IR24 → plausible PF ~0.9; IR43/IR30 → impossible). Same node as IR(24).
         "p_grid_apparent": Def(C.uint16, None, IR(43), max=50000),
-        # IR(44) is PV-generation-today (sentinel cross-correlation, #174), not the
-        # inverter AC output. Renamed from "e_inverter_out_day"; the old name is kept
-        # as a deprecated @property alias on both inverter classes for a release.
+        # IR(44) is PV-generation-today and IR(45/46) is PV-generation-total (both
+        # sentinel cross-correlation, #174), not the inverter AC output. Renamed from
+        # "e_inverter_out_day" / "e_inverter_out_total"; the old names are kept as
+        # deprecated @property aliases for a release.
+        # NB: this rename is single-phase only. ThreePhaseInverter has its OWN native
+        # e_inverter_out_total (IR1362/3) — a genuine, distinct register from its PV
+        # total (e_pv_total, IR1374/5) — so the 3ph field is left untouched.
         "e_pv_generation_today": Def(C.deci, None, IR(44)),
-        "e_inverter_out_total": Def(C.uint32, C.deci, IR(45), IR(46)),
+        "e_pv_generation_total": Def(C.uint32, C.deci, IR(45), IR(46)),
         # Hours since first power-on. Wire data on HYBRID_GEN1 ticks once per
         # wall-clock hour and persists across reboots; cap at ~100 years to
         # reject obviously-garbage uint32 values. The `_hours` suffix carries
@@ -925,6 +929,21 @@ class SinglePhaseInverter(  # type: ignore[valid-type,misc]
             stacklevel=2,
         )
         return self.e_pv_generation_today  # type: ignore[attr-defined,no-any-return]
+
+    # IR(45/46) was decoded as e_inverter_out_total (GivTCP-era guess); the same
+    # sentinel cross-correlation (#174) confirmed it is PV-generation-total. Renamed
+    # to e_pv_generation_total; this alias preserves back-compat for a release.
+    # Single-phase only: ThreePhaseInverter keeps its native e_inverter_out_total
+    # (IR1362/3), which is a genuine register there, so no alias is defined on 3ph.
+    @property
+    def e_inverter_out_total(self) -> float | None:
+        """Deprecated alias for `e_pv_generation_total`."""
+        warnings.warn(
+            "SinglePhaseInverter.e_inverter_out_total is deprecated; use e_pv_generation_total",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.e_pv_generation_total  # type: ignore[attr-defined,no-any-return]
 
 
 def __getattr__(name: str):

--- a/givenergy_modbus/model/inverter.py
+++ b/givenergy_modbus/model/inverter.py
@@ -151,12 +151,18 @@ _DTC_BATPOWER: dict[str, int] = {
 
 
 def _battery_max_power(dtc_str: str, fw: int) -> int | None:
-    """Map DTC hex string + ARM firmware to rated battery charge/discharge power in watts."""
+    """Map DTC hex string + ARM firmware to rated battery charge/discharge power in watts.
+
+    Returns None for an unmapped DTC — the table is incomplete and unverified against
+    hardware docs, so an unknown model is an honest "unknown", not 0 W. Consumers must
+    treat None as "rated power unavailable" rather than "no capacity" (the latter is what
+    a 0 would have implied to e.g. a watt↔percent conversion or a dispatch coordinator).
+    """
     if dtc_str is None or fw is None:
         return None
     if dtc_str[:2] == "20":
         return 3600 if math.floor(int(fw) / 100) in (3, 8, 9) else 2600
-    return _DTC_BATPOWER.get(dtc_str, 0)
+    return _DTC_BATPOWER.get(dtc_str)
 
 
 def _inverter_fault_code(val: int) -> list[str] | None:

--- a/tests/model/test_inverter.py
+++ b/tests/model/test_inverter.py
@@ -112,7 +112,7 @@ def test_inverter():
             "p_load_demand": None,
             "p_grid_apparent": None,
             "e_pv_generation_today": None,
-            "e_inverter_out_total": None,
+            "e_pv_generation_total": None,
             "work_time_total_hours": None,
             "system_mode": None,
             "v_battery": None,
@@ -520,7 +520,7 @@ def test_from_registers(register_cache):
         "p_load_demand": 342,
         "p_grid_apparent": 680,
         "e_pv_generation_today": 8.1,  # IR(44) — was mislabelled e_inverter_out_day (#174)
-        "e_inverter_out_total": 93.0,
+        "e_pv_generation_total": 93.0,
         "work_time_total_hours": 213,
         "system_mode": 1,
         "v_battery": 49.91,
@@ -864,7 +864,7 @@ def test_from_registers_actual_data(register_cache_inverter_daytime_discharging_
         "p_load_demand": 515,
         "p_grid_apparent": 554,
         "e_pv_generation_today": 3.8,  # IR(44) — was mislabelled e_inverter_out_day (#174)
-        "e_inverter_out_total": 172.5,
+        "e_pv_generation_total": 172.5,
         "work_time_total_hours": 385,
         "system_mode": 1,
         "v_battery": 51.73,
@@ -1287,6 +1287,58 @@ def test_e_pv_generation_today_rename_and_deprecated_alias():
     tp_dumped = tp.model_dump()
     assert "e_pv_generation_today" in tp_dumped
     assert "e_inverter_out_day" not in tp_dumped
+
+
+def test_e_pv_generation_total_rename_and_deprecated_alias():
+    """IR(45/46) is e_pv_generation_total (#174); e_inverter_out_total is a deprecated alias.
+
+    Unlike the day field, three-phase is NOT symmetric here:
+    - SinglePhaseInverter: IR(45/46) renamed to e_pv_generation_total; e_inverter_out_total
+      becomes a deprecated @property → e_pv_generation_total (not in model_dump()).
+    - ThreePhaseInverter: keeps its OWN native e_inverter_out_total (IR1362/3), a genuine,
+      distinct register from its PV total — so it stays a real field with no deprecation.
+      The single-phase IR(45/46) also leaks in as e_pv_generation_total (unverified on 3ph),
+      consistent with the e_pv_generation_today leak; left for #48.
+    """
+    from givenergy_modbus.model.inverter_threephase import ThreePhaseInverter
+    from givenergy_modbus.model.register import IR
+
+    # Single-phase: IR(45/46) is the authoritative PV-generation-total register (uint32, deci).
+    sp_cache = RegisterCache({IR(45): 0, IR(46): 930})
+    sp = SinglePhaseInverter.from_register_cache(sp_cache)
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        assert sp.e_pv_generation_total == 93.0  # type: ignore[attr-defined]
+    assert [x for x in w if issubclass(x.category, DeprecationWarning)] == []
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        assert sp.e_inverter_out_total == 93.0  # type: ignore[attr-defined]  # returns e_pv_generation_total
+    sp_deprecations = [x for x in w if issubclass(x.category, DeprecationWarning)]
+    assert len(sp_deprecations) == 1
+    assert "e_pv_generation_total" in str(sp_deprecations[0].message)
+
+    sp_dumped = sp.model_dump()
+    assert "e_pv_generation_total" in sp_dumped
+    assert "e_inverter_out_total" not in sp_dumped
+
+    # Three-phase: e_inverter_out_total is a genuine native register (IR1362/3) — it stays
+    # a real, non-deprecated field. The single-phase IR(45/46) leaks in as
+    # e_pv_generation_total (unverified on 3ph).
+    tp_cache = RegisterCache({IR(45): 0, IR(46): 930, IR(1362): 0, IR(1363): 1725})
+    tp = ThreePhaseInverter.from_register_cache(tp_cache)
+
+    # Native 3ph e_inverter_out_total reads IR1362/3 with no deprecation warning.
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        assert tp.e_inverter_out_total == 172.5  # type: ignore[attr-defined]
+    assert [x for x in w if issubclass(x.category, DeprecationWarning)] == []
+
+    tp_dumped = tp.model_dump()
+    # Both keys are present on 3ph: the native total field and the leaked single-phase IR(45/46).
+    assert tp_dumped["e_inverter_out_total"] == 172.5  # IR1362/3, native
+    assert tp_dumped["e_pv_generation_total"] == 93.0  # IR45/46, leaked (unverified on 3ph)
 
 
 def test_e_consumption_today_computed_formula():

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -1247,7 +1247,7 @@ def test_from_actual():
         "p_load_demand": 745,
         "p_grid_apparent": 654,
         "e_pv_generation_today": 38.0,  # IR(44) — was mislabelled e_inverter_out_day (#174)
-        "e_inverter_out_total": 1698.7,
+        "e_pv_generation_total": 1698.7,  # IR(45/46) — was mislabelled e_inverter_out_total (#174)
         "work_time_total_hours": 2754,
         "system_mode": 1,
         "v_battery": 51.28,

--- a/tests/model/test_register.py
+++ b/tests/model/test_register.py
@@ -162,8 +162,8 @@ def test_battery_max_power():
     assert _battery_max_power("2001", 100) == 2600
     # Known non-'20' DTC
     assert _battery_max_power("8001", 0) == 6000
-    # Unknown DTC → 0
-    assert _battery_max_power("9999", 0) == 0
+    # Unknown DTC → None (table is incomplete/unverified; "unknown", not 0 W)
+    assert _battery_max_power("9999", 0) is None
     assert _battery_max_power(None, 100) is None
     assert _battery_max_power("2001", None) is None
 


### PR DESCRIPTION
## Summary

Two small register-correctness fixes prompted by hass / energy-conductor coordination, following on from #174.

### 1. `e_inverter_out_total` (IR45/46) → `e_pv_generation_total`

The same sentinel cross-correlation that proved IR(44) is PV-generation-today (#174) confirmed **IR(45/46) is PV-generation-total**, not inverter AC output (app "PV generation total" = sentinel 294916.60). Renamed on `SinglePhaseInverter`, with a deprecated `e_inverter_out_total` @property alias for one release — mirroring the `e_inverter_out_day` → `e_pv_generation_today` change so hass can migrate its "Inverter Output" entity pair (today + total) coherently in one step.

**Single-phase only.** Unlike the day field, three-phase is *not* symmetric here: `ThreePhaseInverter` has its own native `e_inverter_out_total` (IR1362/3), a genuine register distinct from its PV total (`e_pv_total`, IR1374/5). That field is left untouched and stays non-deprecated. The single-phase IR(45/46) also leaks onto 3ph as `e_pv_generation_total` (unverified there), consistent with the existing `e_pv_generation_today` leak — left for #48.

### 2. `battery_max_power` returns `None` for unmapped DTC (was `0`)

`_DTC_BATPOWER` is an incomplete, hardware-unverified DTC→watts lookup. Defaulting an unknown model to `0` reads as "no battery capacity" to a consumer (e.g. a watt↔percent limit conversion or a dispatch coordinator) when the truth is "rated power unknown". Returns `None` so callers can distinguish unavailable from zero.

## Test plan

- [ ] CI green
- [x] `tox`-env pytest green (741 passed); ruff check + format clean on touched files
- [x] New `test_e_pv_generation_total_rename_and_deprecated_alias` covers single-phase rename+alias and the 3ph native-field / leak behaviour
- [x] `test_battery_max_power` updated: unmapped DTC → `None`
- [ ] Codex review