### PR TITLE
chore: make main prek-clean (hook-coverage reconcile, not a ruff version skew)

### DIFF
--- a/givenergy_modbus/model/devices.py
+++ b/givenergy_modbus/model/devices.py
@@ -104,7 +104,7 @@ class Inverter:
         self._summary = summary
 
     @classmethod
-    def from_direct(cls, direct: Any) -> "Inverter":
+    def from_direct(cls, direct: Any) -> Inverter:
         """Construct from a directly-reachable concrete inverter model.
 
         ``direct`` is duck-typed: anything exposing the standard inverter
@@ -119,7 +119,7 @@ class Inverter:
         return cls(data_source="direct", direct=direct)
 
     @classmethod
-    def from_summary(cls, summary: InverterSummary) -> "Inverter":
+    def from_summary(cls, summary: InverterSummary) -> Inverter:
         """Construct from a rollup summary (e.g. EMS-managed, no direct dongle).
 
         The resulting inverter is "blinded": :attr:`batteries` is empty,
@@ -130,7 +130,7 @@ class Inverter:
         return cls(data_source="ems_rollup", summary=summary)
 
     @classmethod
-    def merge(cls, direct: Any, summary: InverterSummary) -> "Inverter":
+    def merge(cls, direct: Any, summary: InverterSummary) -> Inverter:
         """Construct from a direct source reconciled with a rollup summary.
 
         Reconciliation is the caller's responsibility (typically matching

--- a/givenergy_modbus/testing/mock_plant.py
+++ b/givenergy_modbus/testing/mock_plant.py
@@ -137,7 +137,7 @@ class MockPlant:
     def from_sentinels(
         cls,
         *paths: str | Path,
-        spec: list[tuple[int, type, range]],
+        spec: list[tuple[int, type[Register], range]],
         offset: int = 0,
     ) -> MockPlant:
         """Build a sentinel-overlaid mock for register cross-correlation.

--- a/givenergy_modbus/testing/mock_plant.py
+++ b/givenergy_modbus/testing/mock_plant.py
@@ -124,7 +124,7 @@ class MockPlant:
         self._server: asyncio.AbstractServer | None = None
 
     @classmethod
-    def from_capture(cls, *paths: str | Path) -> "MockPlant":
+    def from_capture(cls, *paths: str | Path) -> MockPlant:
         """Build a mock plant seeded from one or more capture ``.log`` files."""
         plant = plant_from_capture(*paths)
         return cls(
@@ -137,9 +137,9 @@ class MockPlant:
     def from_sentinels(
         cls,
         *paths: str | Path,
-        spec: "list[tuple[int, type, range]]",
+        spec: list[tuple[int, type, range]],
         offset: int = 0,
-    ) -> "MockPlant":
+    ) -> MockPlant:
         """Build a sentinel-overlaid mock for register cross-correlation.
 
         Loads a base plant from *paths* (same as :meth:`from_capture`), then
@@ -191,7 +191,7 @@ class MockPlant:
             await self._server.wait_closed()
             self._server = None
 
-    async def __aenter__(self) -> "MockPlant":
+    async def __aenter__(self) -> MockPlant:
         return self
 
     async def __aexit__(self, *exc: object) -> None:

--- a/prek.toml
+++ b/prek.toml
@@ -37,7 +37,9 @@ hooks = [
   },
   {
     id = "name-tests-test",
-    args = ["--django"]
+    args = ["--django"],
+    # tests/debug/ holds interactive probe/replay utilities, not pytest cases.
+    exclude = "^tests/debug/"
   }
 ]
 
@@ -71,7 +73,12 @@ hooks = [
 repo = "https://github.com/codespell-project/codespell"
 rev = "v2.4.2"
 hooks = [
-  { id = "codespell" }
+  {
+    id = "codespell",
+    # Domain false positives: "hass" = Home Assistant (sister repo / integration),
+    # "fo" = a GivEnergy data-adapter serial prefix (e.g. FO2522G000).
+    args = ["-L", "hass,fo"]
+  }
 ]
 
 [[repos]]

--- a/scripts/regen_fixture_crcs.py
+++ b/scripts/regen_fixture_crcs.py
@@ -15,6 +15,7 @@ stay exactly as they came off the wire.
 Usage:
     uv run python scripts/regen_fixture_crcs.py [--dry-run]
 """
+
 from __future__ import annotations
 
 import argparse
@@ -64,6 +65,7 @@ def regen_file(path: Path, *, dry_run: bool) -> tuple[int, int]:
 
 
 def main() -> int:
+    """Recompute and rewrite CRCs across all committed capture fixtures."""
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--dry-run", action="store_true", help="report changes without writing")
     args = ap.parse_args()

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -315,7 +315,7 @@ async def test_send_request_raises_timeout_when_tx_queue_is_full():
         # Simulate the 5s timeout without leaking the Queue.put coroutine that
         # send_request_and_await_response passes into asyncio.wait_for().
         awaitable.close()
-        raise asyncio.TimeoutError
+        raise TimeoutError
 
     # Patch wait_for to immediately raise TimeoutError, simulating the 5s timeout
     # elapsing without the producer draining the queue.


### PR DESCRIPTION
## Summary

Running `prek run --all-files` on a clean main produced spurious auto-fixes on files unrelated to a contributor's change, plus several false-positive failures. This brings the tree into prek compliance so a local `prek run` is clean.

## Root cause (corrected)

The original hunch was a ruff version skew. It isn't: **prek and the uv env both pin ruff 0.15.12.** The real divergence is **hook coverage** — prek runs a broader suite (pyupgrade, ruff-format over `scripts/`, codespell, name-tests-test, …) than tox/CI, which only runs `ruff check` / `ruff format --check` over `givenergy_modbus tests`. So drift and false positives accumulated on main, invisible to CI.

## Changes

**1. Apply the auto-fixer drift once (`832cbbc`)** — so `prek run` stops rewriting committed files:
- `pyupgrade --py313-plus`: strip quotes from forward-ref annotations in `devices.py` / `mock_plant.py` (both already have `from __future__ import annotations`, so safe), and `asyncio.TimeoutError` → `TimeoutError` in `test_client.py` (same object since 3.11).
- `ruff-format` + **D103**: `scripts/regen_fixture_crcs.py` was never in tox's ruff scope — added the post-docstring blank line and a docstring on `main()`.

**2. Silence domain false positives in prek.toml (`8719700`)**:
- `codespell`: ignore `hass` (Home Assistant — the sister repo/integration) and `fo` (a GivEnergy data-adapter serial prefix, e.g. `FO2522G000`). These are correct domain terms, not typos.
- `name-tests-test`: exclude `tests/debug/` (interactive probe/replay utilities, not pytest cases).

## Verification

- `prek run --all-files` — all hooks pass (previously: pyupgrade, codespell, ruff, ruff-format, name-tests-test all failed).
- `tox` — py314, format, lint, build all green.

## Note for reviewers

Worth considering a follow-up to run `prek` in CI so this divergence can't silently re-accumulate — out of scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated type annotations across device and testing models to use direct type references.
  * Enhanced pre-commit hook configurations, including YAML check exclusions and codespell customization.

* **Documentation**
  * Added and expanded docstrings in fixture regeneration tooling.

* **Tests**
  * Corrected exception type handling in client timeout simulation for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->