### PR TITLE
chore(prek): autoupdate hook revs (ruff, mypy, uv-pre-commit)

### DIFF
--- a/prek.toml
+++ b/prek.toml
@@ -90,7 +90,7 @@ hooks = [
 
 [[repos]]
 repo = "https://github.com/astral-sh/ruff-pre-commit"
-rev = "v0.15.12"
+rev = "v0.15.15"
 hooks = [
   {
     id = "ruff",
@@ -101,7 +101,7 @@ hooks = [
 
 [[repos]]
 repo = "https://github.com/pre-commit/mirrors-mypy"
-rev = "v2.0.0"
+rev = "v2.1.0"
 hooks = [
   {
     id = "mypy",
@@ -128,7 +128,7 @@ hooks = [
 
 [[repos]]
 repo = "https://github.com/astral-sh/uv-pre-commit"
-rev = "0.11.12"
+rev = "0.11.18"
 hooks = [
   { id = "uv-lock" }
 ]


### PR DESCRIPTION
## Summary

`prek autoupdate` bumped three hook revisions:

| hook | from | to |
|---|---|---|
| ruff-pre-commit | v0.15.12 | v0.15.15 |
| mirrors-mypy | v2.0.0 | v2.1.0 |
| uv-pre-commit | 0.11.12 | 0.11.18 |

## Notes

- The autoupdate was originally run against a pre-#177 `prek.toml`, which would have dropped the #177 codespell (`-L hass,fo`) and name-tests-test (`exclude ^tests/debug/`) config. Re-applied on top of current main so **that config is preserved** — only the three rev strings change here.
- `prek run --all-files` is clean with the new versions (no new reformats or lint/type failures from ruff 0.15.15 / mypy 2.1.0).
- These revs only affect local `prek` runs; tox/CI use the uv.lock-pinned tools, so CI behaviour is unchanged.