### PR TITLE
fix(model/client): tolerate unmapped enum values + gate Smart Load poll (#179, #180)

### DIFF
--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -782,11 +782,14 @@ class Client:
             ]
         if caps.has_extended_slots:
             reqs.append(ReadHoldingRegistersRequest(base_register=240, register_count=60, device_address=inverter))
-        if not is_ems:
-            # HR(540-599) — Smart Load scheduling slots 1–10 (HR554-573). Polled for
-            # all non-EMS inverters: Smart Load confirmed on HYBRID_GEN1 via the app
-            # and likely present across all HYBRID generations. Unmodelled registers
-            # in 540-553 and 574-599 are silently ignored by Plant.update(). (#48)
+        if caps.has_smart_load_block:
+            # HR(540-599) — Smart Load scheduling slots 1–10 (HR554-573). Gated because
+            # the block was added from the app's Direct Control catalogue (writable
+            # surface only — never confirmed to answer a live read) and HYBRID_GEN1 times
+            # out on it (#179). The gate set is currently empty, so this is off for every
+            # model pending hardware confirmation; the smart_load_slot_* decode Defs and
+            # set_smart_load_slot_* write helpers are unaffected. Unmodelled registers in
+            # 540-553 and 574-599 are silently ignored by Plant.update(). (#48, #179)
             reqs.append(ReadHoldingRegistersRequest(base_register=540, register_count=60, device_address=inverter))
         if caps.has_ac_config_block:
             # HR(300-359) — AC-output config: export_priority (HR311), battery_*_limit_ac

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -91,6 +91,16 @@ _AC_CONFIG_BLOCK_MODELS: frozenset[Model] = frozenset(
     }
 )
 
+# Models with a *readable* Smart Load slot block at HR(540-599). Deliberately empty:
+# the block was added speculatively from the GivEnergy app's Direct Control catalogue
+# (which only proves the writable surface, not that a live read answers), and no model
+# has yet been confirmed to return data on real hardware. HYBRID_GEN1 is confirmed to
+# *time out* on the read (#179, two independent reports). device_type here is the
+# firmware-resolved variant (resolve_model), so members may be gen-specific once any
+# model is confirmed. Until then the bulk read is gated off everywhere; the
+# smart_load_slot_* decode Defs and set_smart_load_slot_* write helpers are unaffected.
+_SMART_LOAD_CAPABLE_MODELS: frozenset[Model] = frozenset()
+
 
 _CAPABILITIES_LEGACY_ALIASES = {
     "inverter_slave": "inverter_address",
@@ -421,6 +431,16 @@ class PlantCapabilities(BaseModel):
         DC-coupled/hybrid models. See `_AC_CONFIG_BLOCK_MODELS` (#162).
         """
         return self.device_type in _AC_CONFIG_BLOCK_MODELS
+
+    @property
+    def has_smart_load_block(self) -> bool:
+        """Return True if this system exposes a readable HR(540–599) Smart Load block.
+
+        Currently False for every model: no inverter has been confirmed to answer the
+        read on real hardware, and HYBRID_GEN1 is confirmed to time out on it. See
+        `_SMART_LOAD_CAPABLE_MODELS` (#179).
+        """
+        return self.device_type in _SMART_LOAD_CAPABLE_MODELS
 
     @property
     def is_ems(self) -> bool:

--- a/givenergy_modbus/model/register.py
+++ b/givenergy_modbus/model/register.py
@@ -1,6 +1,7 @@
 import logging
 import re
 from datetime import datetime
+from enum import Enum
 from json import JSONEncoder
 from typing import Any, ClassVar, get_type_hints
 
@@ -328,6 +329,16 @@ class RegisterGetter:
         if defn.post_conv:
             if isinstance(defn.post_conv, tuple):
                 val = defn.post_conv[0](val, *defn.post_conv[1:])
+            elif isinstance(defn.post_conv, type) and issubclass(defn.post_conv, Enum):
+                # A garbage register value that isn't a defined enum member raises
+                # ValueError from Enum.__call__. Degrade that single field to None
+                # rather than letting it abort the whole build() — same "nonsense
+                # decodes to None" posture as the out-of-bounds guard below (#82, #180).
+                try:
+                    val = defn.post_conv(val)
+                except ValueError:
+                    _logger.debug("%r is not a valid %s", val, defn.post_conv.__name__)
+                    return None
             else:
                 val = defn.post_conv(val)
 

--- a/givenergy_modbus/model/register.py
+++ b/givenergy_modbus/model/register.py
@@ -336,7 +336,7 @@ class RegisterGetter:
                 # decodes to None" posture as the out-of-bounds guard below (#82, #180).
                 try:
                     val = defn.post_conv(val)
-                except ValueError:
+                except ValueError, TypeError:
                     _logger.debug("%r is not a valid %s", val, defn.post_conv.__name__)
                     return None
             else:

--- a/tests/client/test_load_refresh.py
+++ b/tests/client/test_load_refresh.py
@@ -48,7 +48,7 @@ async def test_load_config_single_phase():
     client = _client_with_caps(Model.HYBRID)
     with patch.object(client, "_execute_reads", new_callable=AsyncMock) as mock_exec:
         await client.load_config()
-    assert _reqs(mock_exec) == [_hr(0, 60), _hr(60, 60), _hr(120, 60), _ir(120, 60), _hr(540, 60)]
+    assert _reqs(mock_exec) == [_hr(0, 60), _hr(60, 60), _hr(120, 60), _ir(120, 60)]
 
 
 async def test_load_config_ac_polls_hr300():
@@ -61,7 +61,6 @@ async def test_load_config_ac_polls_hr300():
         _hr(60, 60, device=0x31),
         _hr(120, 60, device=0x31),
         _ir(120, 60, device=0x31),
-        _hr(540, 60, device=0x31),
         _hr(300, 60, device=0x31),
     ]
 
@@ -76,8 +75,20 @@ async def test_load_config_hybrid_gen1_uses_0x31_no_hr300():
         _hr(60, 60, device=0x31),
         _hr(120, 60, device=0x31),
         _ir(120, 60, device=0x31),
-        _hr(540, 60, device=0x31),
     ]
+
+
+async def test_load_config_hybrid_gen1_does_not_poll_smart_load():
+    """HYBRID_GEN1 must not poll HR(540-599): the block times out on it (#179).
+
+    The Smart Load gate (_SMART_LOAD_CAPABLE_MODELS) is currently empty, so no model
+    polls it. Once a model is confirmed to answer the read, add it to that set and the
+    HR(540) request returns for that model.
+    """
+    client = _client_with_caps(Model.HYBRID_GEN1)
+    with patch.object(client, "_execute_reads", new_callable=AsyncMock) as mock_exec:
+        await client.load_config()
+    assert _hr(540, 60, device=0x31) not in _reqs(mock_exec)
 
 
 async def test_load_config_three_phase():
@@ -93,7 +104,6 @@ async def test_load_config_three_phase():
         _hr(1000, 60),
         _hr(1060, 60),
         _hr(1120, 5),
-        _hr(540, 60),
     ]
 
 
@@ -108,7 +118,6 @@ async def test_load_config_extended_slots():
         _hr(120, 60),
         _ir(120, 60),
         _hr(240, 60),
-        _hr(540, 60),
     ]
 
 
@@ -123,7 +132,7 @@ async def test_load_config_residential_aio_no_1000_range():
     with patch.object(client, "_execute_reads", new_callable=AsyncMock) as mock_exec:
         await client.load_config()
     reqs = _reqs(mock_exec)
-    assert reqs == [_hr(0, 60), _hr(60, 60), _hr(120, 60), _ir(120, 60), _hr(240, 60), _hr(540, 60), _hr(300, 60)]
+    assert reqs == [_hr(0, 60), _hr(60, 60), _hr(120, 60), _ir(120, 60), _hr(240, 60), _hr(300, 60)]
     assert all(base < 1000 for _, _, base, _ in reqs), "AIO must not poll the 1000-range bank"
 
 

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -1689,6 +1689,27 @@ class TestPlantCapabilitiesProperties:
         for m in (Model.HYBRID, Model.HYBRID_GEN1, Model.HYBRID_GEN3, Model.HYBRID_3PH, Model.EMS, Model.GATEWAY):
             assert not self._caps(m).has_ac_config_block, f"{m} should not have the AC config block"
 
+    def test_has_smart_load_block_empty_for_all_models(self):
+        """No model carries a confirmed readable HR(540-599) Smart Load block yet (#179).
+
+        The gate set is deliberately empty pending live-hardware confirmation; HYBRID_GEN1
+        is confirmed to time out on the read. When a model is confirmed, add it to
+        _SMART_LOAD_CAPABLE_MODELS and assert it here.
+        """
+        for m in (
+            Model.HYBRID,
+            Model.HYBRID_GEN1,
+            Model.HYBRID_GEN3,
+            Model.HYBRID_GEN4,
+            Model.AC,
+            Model.AC_3PH,
+            Model.ALL_IN_ONE,
+            Model.HYBRID_3PH,
+            Model.EMS,
+            Model.GATEWAY,
+        ):
+            assert not self._caps(m).has_smart_load_block, f"{m} should not have the Smart Load block"
+
     def test_is_ems_true(self):
         """EMS and EMS_COMMERCIAL report is_ems True."""
         assert self._caps(Model.EMS).is_ems

--- a/tests/model/test_register.py
+++ b/tests/model/test_register.py
@@ -376,6 +376,59 @@ def test_issue_82_healthy_soc_values_pass_through():
 
 
 # ---------------------------------------------------------------------------
+# Regression: #180 unmapped enum value must not abort the whole build
+# ---------------------------------------------------------------------------
+
+
+def test_unmapped_enum_value_returns_none(caplog):
+    """A garbage register value that isn't a valid enum member degrades to None.
+
+    Reproduces #180: HR(29) held 62453, which is not a BatteryCalibrationStage,
+    and the strict Enum.__call__ raised ValueError mid-build(), aborting the entire
+    inverter decode. The offending field should resolve to None instead.
+    """
+    from givenergy_modbus.model.inverter import BatteryCalibrationStage
+
+    defn = RegisterDefinition(Converter.uint16, BatteryCalibrationStage, IR(0))
+    with caplog.at_level(logging.DEBUG, logger="givenergy_modbus.model.register"):
+        val = _getter(defn, 62453).get("field")
+    assert val is None
+    assert any("not a valid BatteryCalibrationStage" in r.message for r in caplog.records)
+
+
+def test_valid_enum_value_still_decodes():
+    """Counter-example: a defined enum member decodes normally."""
+    from givenergy_modbus.model.inverter import BatteryCalibrationStage
+
+    defn = RegisterDefinition(Converter.uint16, BatteryCalibrationStage, IR(0))
+    assert _getter(defn, 1).get("field") == BatteryCalibrationStage.DISCHARGE
+
+
+def test_non_enum_converter_valueerror_still_propagates():
+    """The guard is scoped to enums only — a real converter bug must not be swallowed."""
+
+    def _boom(_val):
+        raise ValueError("converter bug")
+
+    defn = RegisterDefinition(Converter.uint16, _boom, IR(0))
+    with pytest.raises(ValueError, match="converter bug"):
+        _getter(defn, 1).get("field")
+
+
+def test_unmapped_enum_value_survives_full_inverter_build():
+    """Integration: a bad HR(29) leaves battery_calibration_stage None, rest decodes."""
+    from givenergy_modbus.model.inverter import SinglePhaseInverter
+
+    cache = RegisterCache({HR(k): v for k, v in HOLDING_REGISTERS.items()})
+    cache.update({IR(k): v for k, v in INPUT_REGISTERS.items()})
+    cache[HR(29)] = 62453
+
+    inverter = SinglePhaseInverter.from_register_cache(cache)
+    assert inverter.battery_calibration_stage is None
+    assert inverter.serial_number is not None
+
+
+# ---------------------------------------------------------------------------
 # is_valid_serial
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Two Gen1 Hybrid bugfixes filed by britkat1980 against v2.1.2, both corroborated independently on a HYBRID_GEN1 unit (DTC 2001, ARM 449) via the hass coordination inbox.

- **#180** — `ValueError: 62453 is not a valid BatteryCalibrationStage` aborted the entire `from_register_cache()` call. A single garbage register value (0xF3F5 — transient corruption) crashed the whole inverter decode. Now caught narrowly at the enum post-conv layer and degraded to `None`, consistent with the existing out-of-bounds → None pattern (#82). Non-enum converters still propagate `ValueError`.

- **#179** — `load_config()` polled HR(540–599) unconditionally, burning ~4–6 s on a guaranteed timeout for HYBRID_GEN1. The block was added speculatively from the GivEnergy app's writable catalogue; no model has been confirmed to answer the read on real hardware. Introduces `_SMART_LOAD_CAPABLE_MODELS` (empty) + `has_smart_load_block` in `PlantCapabilities`, mirroring the HR(300–359) AC-config gate pattern (#162). Smart Load decode Defs and `set_smart_load_slot_*` write helpers are unaffected — add to the set once a model is confirmed to answer the read.

## Test plan

- [ ] 747 tests pass (`uv run pytest --cov`)
- [ ] prek clean (`uv run prek run --all-files`)
- [ ] tox matrix clean (py313, py314, format, lint, build)
- [ ] HYBRID_GEN1 `load_config()` no longer requests HR(540) — covered by `test_load_config_hybrid_gen1_does_not_poll_smart_load`
- [ ] `from_register_cache()` with a garbage HR(29) value yields `battery_calibration_stage is None`, rest of model intact — covered by `test_unmapped_enum_value_survives_full_inverter_build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)