### PR TITLE
test: stabilise capture-replay tests under load (#188)

### DIFF
--- a/tests/debug/capture_0x11.py
+++ b/tests/debug/capture_0x11.py
@@ -77,13 +77,13 @@ async def main(host: str, duration: float) -> None:
             while True:
                 try:
                     await client.refresh(timeout=3.0, retries=1)
-                except Exception:
+                except Exception:  # nosec B110 - best-effort capture loop; transient read errors ignored
                     pass
                 # Periodically re-run load_config so HR banks appear throughout the capture.
                 if len(frames) % 60 == 0 and len(frames) > 0:
                     try:
                         await client.load_config(timeout=5.0, retries=2)
-                    except Exception:
+                    except Exception:  # nosec B110 - best-effort capture loop; transient read errors ignored
                         pass
                 await asyncio.sleep(10)
 

--- a/tests/model/test_ems.py
+++ b/tests/model/test_ems.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from givenergy_modbus.model.ems import Ems, EmsInverterStatus
 from givenergy_modbus.model.inverter import Status
 from givenergy_modbus.model.meter import MeterStatus
@@ -117,6 +119,7 @@ def test_inverter_status_bitfield():
     assert ems.inverter_2_suspected_status is None  # type: ignore[attr-defined]
 
 
+@pytest.mark.timeout(15)
 def test_bitfield_decode_matches_fixture():
     """Regression for #108 — per-slot status bitfields use LSB-first layout.
 

--- a/tests/testing/test_identify.py
+++ b/tests/testing/test_identify.py
@@ -293,6 +293,7 @@ def test_identify_two_pass_unknown_scale_returns_empty():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.timeout(15)
 def test_mock_plant_from_sentinels_overlays_values():
     """from_sentinels seeds sentinel values on top of the base capture."""
     from pathlib import Path


### PR DESCRIPTION
## What

Two small build-hygiene fixes, landing together:

**`test:` — stabilise capture-replay tests (#188).** The global 1s `pytest-timeout` (`pyproject.toml`) intermittently tripped two capture-replay tests under load (parallel tox envs / CI), since decoding a multi-frame capture can exceed 1s. Marked them with `@pytest.mark.timeout(15)`, matching the existing replay tests in `test_addressing_from_captures.py`, `test_fixture_golden_master.py`, and `test_mock_plant_integration.py`. The tight global stays where it matters for unit tests.

**`chore:` — restore CI lint.** main's `dev.yml` has been red since #187 (`5ae3b66`): bandit B110 flags the two intentional `try/except/pass` blocks in `tests/debug/capture_0x11.py`'s best-effort capture loop, failing the tox `lint` env. Annotated with `# nosec B110` rather than broadening `.bandit.yaml`'s global skips list.

## Verification

`uv run --group test tox` — all envs green (`py314`, `format`, `lint`, `build`). Full suite: 757 passed.

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Improved error handling robustness for capture operations to handle transient failures gracefully.
  * Added execution timeouts to regression tests for improved test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->