### PR TITLE
feat: ingestion timestamps (#65), IR(0,60) skip-if-fresh (#196), all-zero bank rejection (#206)

### DIFF
--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -803,7 +803,13 @@ class Client:
         await self._execute_reads(reqs, timeout=timeout, retries=retries, retry_delay=retry_delay)
         return self.plant
 
-    async def refresh(self, timeout: float = 2.0, retries: int = 1, retry_delay: float = 0.5) -> Plant:
+    async def refresh(
+        self,
+        timeout: float = 2.0,
+        retries: int = 1,
+        retry_delay: float = 0.5,
+        ir0_max_age: float | None = None,
+    ) -> Plant:
         """Read IR measurement blocks for all known devices.
 
         Returns the populated plant on full success. On partial/total read
@@ -814,6 +820,16 @@ class Client:
         Predbat) poll the same unit a tighter budget produces spurious timeouts even
         though the device is responsive (#132). Pass a tighter budget if you own the
         bus exclusively and want genuine failures surfaced faster.
+
+        ``ir0_max_age`` (seconds) opts in to skip-if-fresh for the IR(0,60) live block
+        (#196): GivEnergy dongles fan out the responses to whoever is polling them (the
+        cloud, the app, another client), so the network consumer often already has a
+        recent IR(0,60) in cache without us asking. When set, if IR(0,60) was committed
+        within ``ir0_max_age`` seconds it is not re-solicited this cycle, sparing the
+        (often flaky) dongle a request. Defaults to ``None`` — always solicit, the
+        historic behaviour. Scoped to IR(0,60) only for now; broaden once soak-tested.
+        Note the fan-out only exists while something else is polling the unit; on a
+        cloud-disconnected dongle the block ages out and we solicit it as normal.
         """
         caps = self.plant.capabilities
         if caps is None:
@@ -825,10 +841,17 @@ class Client:
         reqs: list[TransparentRequest] = []
         # EMS plant controllers don't expose IR(0,60) or IR(180,60) — see load_config() and #86.
         if not caps.is_ems:
-            reqs += [
-                ReadInputRegistersRequest(base_register=0, register_count=60, device_address=inverter),
-                ReadInputRegistersRequest(base_register=180, register_count=60, device_address=inverter),
-            ]
+            ir0_age = self.plant.block_age(inverter, "IR", 0) if ir0_max_age is not None else None
+            if ir0_max_age is not None and ir0_age is not None and ir0_age <= ir0_max_age:
+                _logger.debug(
+                    "Skipping IR(0,60) solicit for device 0x%02x — fan-out kept it fresh (%.1fs <= %.1fs)",
+                    inverter,
+                    ir0_age,
+                    ir0_max_age,
+                )
+            else:
+                reqs.append(ReadInputRegistersRequest(base_register=0, register_count=60, device_address=inverter))
+            reqs.append(ReadInputRegistersRequest(base_register=180, register_count=60, device_address=inverter))
         if caps.is_three_phase:
             for base in range(1000, 1414, 60):
                 reqs.append(

--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -841,7 +841,7 @@ class Client:
         reqs: list[TransparentRequest] = []
         # EMS plant controllers don't expose IR(0,60) or IR(180,60) — see load_config() and #86.
         if not caps.is_ems:
-            ir0_age = self.plant.block_age(inverter, "IR", 0) if ir0_max_age is not None else None
+            ir0_age = self.plant.block_age(inverter, "IR", 0, 60) if ir0_max_age is not None else None
             if ir0_max_age is not None and ir0_age is not None and ir0_age <= ir0_max_age:
                 _logger.debug(
                     "Skipping IR(0,60) solicit for device 0x%02x — fan-out kept it fresh (%.1fs <= %.1fs)",

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -469,7 +469,7 @@ class Plant(GivEnergyBaseModel):
     # solicited responses and the dongle's unsolicited fan-out. Consumers (and refresh()'s
     # skip-if-fresh path, #196) use block_age() to reason about freshness. Excluded from
     # model_dump(): it's ephemeral runtime bookkeeping, not part of the plant's dumpable state.
-    register_block_updated_at: dict[tuple[int, str, int], datetime] = Field(default_factory=dict, exclude=True)
+    register_block_updated_at: dict[tuple[int, str, int, int], datetime] = Field(default_factory=dict, exclude=True)
 
     def model_post_init(self, __context: Any) -> None:
         """Ensure a default register cache is always present."""
@@ -540,7 +540,7 @@ class Plant(GivEnergyBaseModel):
         if isinstance(pdu, ReadHoldingRegistersResponse):
             incoming = {HR(k): v for k, v in pdu.to_dict().items()}
             if self._commit_bank(device_address, incoming):
-                self._stamp_block(device_address, "HR", pdu.base_register, received_at)
+                self._stamp_block(device_address, "HR", pdu.base_register, pdu.register_count, received_at)
         elif isinstance(pdu, ReadInputRegistersResponse):
             if pdu.is_suspicious():
                 # Pattern A dongle-side substitution from #78 — known fingerprint of 16 fixed
@@ -548,7 +548,7 @@ class Plant(GivEnergyBaseModel):
                 return
             incoming = {IR(k): v for k, v in pdu.to_dict().items()}  # type: ignore[misc]
             if self._commit_bank(device_address, incoming):
-                self._stamp_block(device_address, "IR", pdu.base_register, received_at)
+                self._stamp_block(device_address, "IR", pdu.base_register, pdu.register_count, received_at)
         elif isinstance(pdu, WriteHoldingRegisterResponse):
             if pdu.register == 0:
                 _logger.warning(f"Ignoring, likely corrupt: {pdu}")
@@ -612,24 +612,50 @@ class Plant(GivEnergyBaseModel):
         return True
 
     def _stamp_block(
-        self, device_address: int, reg_type: str, base_register: int, received_at: datetime | None
+        self,
+        device_address: int,
+        reg_type: str,
+        base_register: int,
+        register_count: int,
+        received_at: datetime | None,
     ) -> None:
-        """Record the ingestion time of a committed register block (#65)."""
-        self.register_block_updated_at[(device_address, reg_type, base_register)] = received_at or datetime.now(UTC)
+        """Record the ingestion time of a committed register block (#65).
+
+        The key includes ``register_count`` so that a partial response (e.g. IR(0,1)) does
+        not mark a full 60-register block as fresh — skip-if-fresh (#196) specifically checks
+        for the IR(0,60) key (count=60). See Codex review on PR #208.
+        """
+        ts = received_at or datetime.now(UTC)
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=UTC)
+        self.register_block_updated_at[(device_address, reg_type, base_register, register_count)] = ts
 
     def block_age(
-        self, device_address: int, reg_type: str, base_register: int, *, now: datetime | None = None
+        self,
+        device_address: int,
+        reg_type: str,
+        base_register: int,
+        register_count: int,
+        *,
+        now: datetime | None = None,
     ) -> float | None:
         """Seconds since a register block was last committed, or None if never seen.
 
-        ``reg_type`` is ``"HR"`` or ``"IR"``. Used to reason about freshness — e.g.
-        refresh()'s skip-if-fresh path for the fan-out IR(0,60) block (#196), and the
-        staleness signal that pairs with all-zero-bank rejection (#206).
+        ``reg_type`` is ``"HR"`` or ``"IR"``. ``register_count`` must match the count used
+        when the block was stamped — typically 60 for standard GivEnergy IR/HR blocks. This
+        prevents a partial response (e.g. IR(0,1)) from being mistaken for a full IR(0,60)
+        block by the skip-if-fresh logic in refresh() (#196).
+
+        Used to reason about freshness and staleness in the fan-out skip (#196) and Pattern B
+        all-zero rejection (#206).
         """
-        ts = self.register_block_updated_at.get((device_address, reg_type, base_register))
+        ts = self.register_block_updated_at.get((device_address, reg_type, base_register, register_count))
         if ts is None:
             return None
-        return ((now or datetime.now(UTC)) - ts).total_seconds()
+        effective_now = now or datetime.now(UTC)
+        if effective_now.tzinfo is None:
+            effective_now = effective_now.replace(tzinfo=UTC)
+        return (effective_now - ts).total_seconds()
 
     @property
     def inverter(self) -> SinglePhaseInverter | ThreePhaseInverter:

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -569,6 +569,27 @@ class Plant(GivEnergyBaseModel):
         so the caller only records an ingestion timestamp (#65) for banks that actually
         landed.
         """
+        cache = self.register_caches[device_address]
+        # Pattern B (#78/#147/#199, tracked in #206): a bank that previously held non-zero data and
+        # now reads entirely zero is a block-level dropout (an empty page served during a
+        # transition), not real data — reject it and keep last-good. Contextual, to resolve the
+        # dropout-vs-absent ambiguity that made #147 hard to action: was-non-zero & now-all-zero =
+        # dropout -> reject; always-zero (absent / first read) -> fall through to the existing
+        # serial-coherence / is_valid() handling that already treats all-zero as device-absence.
+        # Staleness is free: a rejected bank records no #65 timestamp, so block_age() keeps growing.
+        if incoming and all(v == 0 for v in incoming.values()) and any(cache.get(k) for k in incoming):
+            sample = next(iter(incoming))
+            # WARNING (not debug): we have no on-wire capture of this event — surfacing it turns every
+            # deployment (and the maintainer's soak run) into an evidence collector. A silent no-op on
+            # healthy systems, since it only fires when a present device's bank drops to all-zero.
+            _logger.warning(
+                "Rejected all-zero %s bank (base %d) for device 0x%02x over non-zero cache — likely a "
+                "Pattern B block dropout (#206); keeping last-good. Please report if seen.",
+                type(sample).__name__,
+                min(r._idx for r in incoming),
+                device_address,
+            )
+            return False
         getter_cls = self._getter_for_device_address(device_address)
         if getter_cls is not None:
             if not getter_cls.is_coherent(incoming, self.register_caches[device_address]):

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -539,7 +539,7 @@ class Plant(GivEnergyBaseModel):
 
         if isinstance(pdu, ReadHoldingRegistersResponse):
             incoming = {HR(k): v for k, v in pdu.to_dict().items()}
-            if self._commit_bank(device_address, incoming):
+            if self._commit_bank(device_address, incoming, pdu.register_count):
                 self._stamp_block(device_address, "HR", pdu.base_register, pdu.register_count, received_at)
         elif isinstance(pdu, ReadInputRegistersResponse):
             if pdu.is_suspicious():
@@ -547,7 +547,7 @@ class Plant(GivEnergyBaseModel):
                 # constants. is_suspicious() logs at debug when it fires.
                 return
             incoming = {IR(k): v for k, v in pdu.to_dict().items()}  # type: ignore[misc]
-            if self._commit_bank(device_address, incoming):
+            if self._commit_bank(device_address, incoming, pdu.register_count):
                 self._stamp_block(device_address, "IR", pdu.base_register, pdu.register_count, received_at)
         elif isinstance(pdu, WriteHoldingRegisterResponse):
             if pdu.register == 0:
@@ -562,12 +562,18 @@ class Plant(GivEnergyBaseModel):
                 target = self.capabilities.inverter_address if self.capabilities is not None else device_address
                 self.register_caches.setdefault(target, RegisterCache()).update({HR(pdu.register): pdu.value})
 
-    def _commit_bank(self, device_address: int, incoming: dict) -> bool:
+    def _commit_bank(self, device_address: int, incoming: dict, register_count: int = 60) -> bool:
         """Validate incoming register bank against bounds and commit if clean.
 
         Returns True if the bank was committed to the cache, False if it was discarded —
         so the caller only records an ingestion timestamp (#65) for banks that actually
         landed.
+
+        ``register_count`` is the declared size of the PDU response (typically 60 for
+        standard IR/HR blocks). It is used by the Pattern B guard: rejection only applies
+        to full blocks (>= 60 registers), where a simultaneous all-zero read is genuinely
+        suspicious. A short read (e.g. a single power register legitimately settling to
+        zero) must not be blocked.
         """
         cache = self.register_caches[device_address]
         # Pattern B (#78/#147/#199, tracked in #206): a bank that previously held non-zero data and
@@ -577,7 +583,14 @@ class Plant(GivEnergyBaseModel):
         # dropout -> reject; always-zero (absent / first read) -> fall through to the existing
         # serial-coherence / is_valid() handling that already treats all-zero as device-absence.
         # Staleness is free: a rejected bank records no #65 timestamp, so block_age() keeps growing.
-        if incoming and all(v == 0 for v in incoming.values()) and any(cache.get(k) for k in incoming):
+        # Gated on register_count >= 60: short reads (fan-out of a single-register query returning
+        # zero) are legitimate and must not be blocked here.
+        if (
+            register_count >= 60
+            and incoming
+            and all(v == 0 for v in incoming.values())
+            and any(cache.get(k) for k in incoming)
+        ):
             sample = next(iter(incoming))
             # WARNING (not debug): we have no on-wire capture of this event — surfacing it turns every
             # deployment (and the maintainer's soak run) into an evidence collector. A silent no-op on

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -1,5 +1,6 @@
 import logging
 import warnings
+from datetime import UTC, datetime
 from typing import Any, ClassVar
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -462,6 +463,13 @@ class Plant(GivEnergyBaseModel):
     capabilities: PlantCapabilities | None = None
     inverter_serial_number: str = ""
     data_adapter_serial_number: str = ""
+    # Ingestion timestamps per committed register block, keyed by
+    # (device_address, register_type_name, base_register) → last successful commit time (#65).
+    # Maintained continuously by the network consumer's update() calls, so it captures both
+    # solicited responses and the dongle's unsolicited fan-out. Consumers (and refresh()'s
+    # skip-if-fresh path, #196) use block_age() to reason about freshness. Excluded from
+    # model_dump(): it's ephemeral runtime bookkeeping, not part of the plant's dumpable state.
+    register_block_updated_at: dict[tuple[int, str, int], datetime] = Field(default_factory=dict, exclude=True)
 
     def model_post_init(self, __context: Any) -> None:
         """Ensure a default register cache is always present."""
@@ -494,8 +502,13 @@ class Plant(GivEnergyBaseModel):
             return BcuRegisterGetter
         return None
 
-    def update(self, pdu: ClientIncomingMessage):
-        """Update the Plant state from a PDU message."""
+    def update(self, pdu: ClientIncomingMessage, *, received_at: datetime | None = None):
+        """Update the Plant state from a PDU message.
+
+        ``received_at`` overrides the ingestion timestamp recorded for a committed
+        register block (see ``register_block_updated_at`` / #65); it defaults to the
+        current UTC time and is provided mainly for deterministic testing and replay.
+        """
         if not isinstance(pdu, TransparentResponse):
             _logger.debug(f"Ignoring non-Transparent response {pdu}")
             return
@@ -526,14 +539,16 @@ class Plant(GivEnergyBaseModel):
 
         if isinstance(pdu, ReadHoldingRegistersResponse):
             incoming = {HR(k): v for k, v in pdu.to_dict().items()}
-            self._commit_bank(device_address, incoming)
+            if self._commit_bank(device_address, incoming):
+                self._stamp_block(device_address, "HR", pdu.base_register, received_at)
         elif isinstance(pdu, ReadInputRegistersResponse):
             if pdu.is_suspicious():
                 # Pattern A dongle-side substitution from #78 — known fingerprint of 16 fixed
                 # constants. is_suspicious() logs at debug when it fires.
                 return
             incoming = {IR(k): v for k, v in pdu.to_dict().items()}  # type: ignore[misc]
-            self._commit_bank(device_address, incoming)
+            if self._commit_bank(device_address, incoming):
+                self._stamp_block(device_address, "IR", pdu.base_register, received_at)
         elif isinstance(pdu, WriteHoldingRegisterResponse):
             if pdu.register == 0:
                 _logger.warning(f"Ignoring, likely corrupt: {pdu}")
@@ -547,8 +562,13 @@ class Plant(GivEnergyBaseModel):
                 target = self.capabilities.inverter_address if self.capabilities is not None else device_address
                 self.register_caches.setdefault(target, RegisterCache()).update({HR(pdu.register): pdu.value})
 
-    def _commit_bank(self, device_address: int, incoming: dict) -> None:
-        """Validate incoming register bank against bounds and commit if clean."""
+    def _commit_bank(self, device_address: int, incoming: dict) -> bool:
+        """Validate incoming register bank against bounds and commit if clean.
+
+        Returns True if the bank was committed to the cache, False if it was discarded —
+        so the caller only records an ingestion timestamp (#65) for banks that actually
+        landed.
+        """
         getter_cls = self._getter_for_device_address(device_address)
         if getter_cls is not None:
             if not getter_cls.is_coherent(incoming, self.register_caches[device_address]):
@@ -556,7 +576,7 @@ class Plant(GivEnergyBaseModel):
                 # empty slots beyond the user's actual hardware, and we see the responses
                 # go by. The discard is correct; logging at WARNING was actionable noise.
                 _logger.debug("Discarding register bank with invalid serial for device 0x%02x", device_address)
-                return
+                return False
             violations = getter_cls.validate_bank(incoming, self.register_caches[device_address])
             if violations:
                 _logger.debug(
@@ -564,10 +584,31 @@ class Plant(GivEnergyBaseModel):
                     device_address,
                     violations,
                 )
-                # TODO(enforcement): add `return` here to discard the entire bank on any violation.
-                # When that happens, also raise this back to WARNING — at that point it has
-                # user-visible consequences (a poll cycle's data is dropped).
+                # TODO(enforcement): add `return False` here to discard the entire bank on any
+                # violation. When that happens, also raise this back to WARNING — at that point
+                # it has user-visible consequences (a poll cycle's data is dropped).
         self.register_caches[device_address].update(incoming)
+        return True
+
+    def _stamp_block(
+        self, device_address: int, reg_type: str, base_register: int, received_at: datetime | None
+    ) -> None:
+        """Record the ingestion time of a committed register block (#65)."""
+        self.register_block_updated_at[(device_address, reg_type, base_register)] = received_at or datetime.now(UTC)
+
+    def block_age(
+        self, device_address: int, reg_type: str, base_register: int, *, now: datetime | None = None
+    ) -> float | None:
+        """Seconds since a register block was last committed, or None if never seen.
+
+        ``reg_type`` is ``"HR"`` or ``"IR"``. Used to reason about freshness — e.g.
+        refresh()'s skip-if-fresh path for the fan-out IR(0,60) block (#196), and the
+        staleness signal that pairs with all-zero-bank rejection (#206).
+        """
+        ts = self.register_block_updated_at.get((device_address, reg_type, base_register))
+        if ts is None:
+            return None
+        return ((now or datetime.now(UTC)) - ts).total_seconds()
 
     @property
     def inverter(self) -> SinglePhaseInverter | ThreePhaseInverter:

--- a/tests/client/test_refresh_resilience.py
+++ b/tests/client/test_refresh_resilience.py
@@ -262,3 +262,78 @@ async def test_execute_reads_reraises_cancellation():
     with patch.object(client, "execute", new_callable=AsyncMock, return_value=[asyncio.CancelledError()]):
         with pytest.raises(asyncio.CancelledError):
             await client._execute_reads([req], timeout=1.0, retries=0, retry_delay=0.0)
+
+
+# ---------------------------------------------------------------------------
+# refresh(ir0_max_age=...) skip-if-fresh for the fan-out IR(0,60) block (#196)
+# ---------------------------------------------------------------------------
+
+
+def _recording_send(recorded):
+    """A send_request_and_await_response stand-in that records each request and succeeds."""
+
+    def _side(request, *args, **kwargs):
+        recorded.append(request)
+        return SimpleNamespace(error=False, device_address=request.device_address)
+
+    return _side
+
+
+async def _refresh_recording_requests(client, **refresh_kwargs):
+    recorded: list = []
+    with patch.object(
+        client, "send_request_and_await_response", new_callable=AsyncMock, side_effect=_recording_send(recorded)
+    ):
+        await client.refresh(**refresh_kwargs)
+    return recorded
+
+
+def _ir0_requested(recorded, inverter: int) -> bool:
+    return any(getattr(r, "base_register", None) == 0 and r.device_address == inverter for r in recorded)
+
+
+async def test_refresh_skips_fresh_ir0_when_opted_in():
+    """ir0_max_age set + IR(0,60) recently ingested → not re-solicited; IR(180,60) still is."""
+    from datetime import UTC, datetime
+
+    client = _client_with_caps(Model.HYBRID)
+    inverter = client.plant.capabilities.inverter_address
+    client.plant.register_block_updated_at[(inverter, "IR", 0)] = datetime.now(UTC)
+
+    recorded = await _refresh_recording_requests(client, ir0_max_age=30, timeout=0.1, retries=0)
+    assert not _ir0_requested(recorded, inverter), "fresh IR(0,60) should not be solicited"
+    # The neighbouring live block is unaffected — still requested every cycle.
+    assert any(getattr(r, "base_register", None) == 180 and r.device_address == inverter for r in recorded)
+
+
+async def test_refresh_solicits_stale_ir0():
+    """ir0_max_age set but the last IR(0,60) ingest is older than the threshold → solicit it."""
+    from datetime import UTC, datetime, timedelta
+
+    client = _client_with_caps(Model.HYBRID)
+    inverter = client.plant.capabilities.inverter_address
+    client.plant.register_block_updated_at[(inverter, "IR", 0)] = datetime.now(UTC) - timedelta(seconds=120)
+
+    recorded = await _refresh_recording_requests(client, ir0_max_age=30, timeout=0.1, retries=0)
+    assert _ir0_requested(recorded, inverter), "stale IR(0,60) must be solicited"
+
+
+async def test_refresh_solicits_ir0_when_never_ingested():
+    """ir0_max_age set but IR(0,60) has never been seen → no timestamp → solicit it."""
+    client = _client_with_caps(Model.HYBRID)
+    inverter = client.plant.capabilities.inverter_address
+
+    recorded = await _refresh_recording_requests(client, ir0_max_age=30, timeout=0.1, retries=0)
+    assert _ir0_requested(recorded, inverter)
+
+
+async def test_refresh_default_always_solicits_ir0():
+    """Without ir0_max_age (default), a fresh IR(0,60) is still solicited — historic behaviour."""
+    from datetime import UTC, datetime
+
+    client = _client_with_caps(Model.HYBRID)
+    inverter = client.plant.capabilities.inverter_address
+    client.plant.register_block_updated_at[(inverter, "IR", 0)] = datetime.now(UTC)
+
+    recorded = await _refresh_recording_requests(client, timeout=0.1, retries=0)
+    assert _ir0_requested(recorded, inverter)

--- a/tests/client/test_refresh_resilience.py
+++ b/tests/client/test_refresh_resilience.py
@@ -298,7 +298,7 @@ async def test_refresh_skips_fresh_ir0_when_opted_in():
 
     client = _client_with_caps(Model.HYBRID)
     inverter = client.plant.capabilities.inverter_address
-    client.plant.register_block_updated_at[(inverter, "IR", 0)] = datetime.now(UTC)
+    client.plant.register_block_updated_at[(inverter, "IR", 0, 60)] = datetime.now(UTC)
 
     recorded = await _refresh_recording_requests(client, ir0_max_age=30, timeout=0.1, retries=0)
     assert not _ir0_requested(recorded, inverter), "fresh IR(0,60) should not be solicited"
@@ -312,7 +312,7 @@ async def test_refresh_solicits_stale_ir0():
 
     client = _client_with_caps(Model.HYBRID)
     inverter = client.plant.capabilities.inverter_address
-    client.plant.register_block_updated_at[(inverter, "IR", 0)] = datetime.now(UTC) - timedelta(seconds=120)
+    client.plant.register_block_updated_at[(inverter, "IR", 0, 60)] = datetime.now(UTC) - timedelta(seconds=120)
 
     recorded = await _refresh_recording_requests(client, ir0_max_age=30, timeout=0.1, retries=0)
     assert _ir0_requested(recorded, inverter), "stale IR(0,60) must be solicited"
@@ -333,7 +333,7 @@ async def test_refresh_default_always_solicits_ir0():
 
     client = _client_with_caps(Model.HYBRID)
     inverter = client.plant.capabilities.inverter_address
-    client.plant.register_block_updated_at[(inverter, "IR", 0)] = datetime.now(UTC)
+    client.plant.register_block_updated_at[(inverter, "IR", 0, 60)] = datetime.now(UTC)
 
     recorded = await _refresh_recording_requests(client, timeout=0.1, retries=0)
     assert _ir0_requested(recorded, inverter)

--- a/tests/debug/README.md
+++ b/tests/debug/README.md
@@ -60,3 +60,44 @@ One JSON object per OOB event, one event per line:
 ```
 
 Stats are emitted to stderr at the end of the run.
+
+## `unsolicited_responses.py` — fan-out / broadcast detection for #196
+
+Quantifies the responses a dongle volunteers without being asked. It pairs each
+received `TransparentResponse` to a preceding `TransparentRequest` using the
+library's own `shape_hash` matching (the same logic the network consumer uses to
+resolve futures); responses that match no request are unsolicited — the dongle
+fanned out someone else's poll (the GE cloud, the app, another client).
+
+Built to inform #196 (Gen3 poll slowness). Finding: across every device class we
+have a capture for (AIO, AC, EMS, Gen1 hybrid) the live blocks (`IR(0,60)` etc.)
+arrive unsolicited on a ~10–32s cloud-driven cadence — so a slow *solicited*
+read is not necessarily a failure if a fan-out frame already refreshed the cache.
+The open question it's waiting to answer: does a Gen3 dongle answer solicited
+reads at all, or *only* fan out? (No Gen3 capture yet.)
+
+### Usage
+
+```bash
+uv run python tests/debug/unsolicited_responses.py CAPTURE.log [CAPTURE2.log ...]
+```
+
+### Interpreting the output
+
+```
+events=727  requests(tx)=241  responses(rx)=478
+solicited (matched a prior request) = 216
+unanswered requests                 = 25
+UNSOLICITED (no prior request)      = 262
+
+  [   52x] ReadInputRegistersResponse dev=0x31 fc=0x04 base=0 count=60  cadence: min=0.16s avg=11.46s max=22.33s
+```
+
+- A **passive** capture (no `tx` lines) trivially reports every response as
+  unsolicited — there were no requests to match. It still proves the data flows
+  without *us* asking, and the cadence figures are valid.
+- A capture containing the client's own `tx` requests is what proves fan-out
+  coexists with solicited traffic (here: 216 answered *and* 262 volunteered).
+- `cadence` is the inter-arrival time of each unsolicited shape — low jitter and
+  a tight `max` mean a consumer could lean on the stream; a large `max` (the AIO
+  hits 114s) means passive-only freshness is unreliable.

--- a/tests/debug/README.md
+++ b/tests/debug/README.md
@@ -84,7 +84,7 @@ uv run python tests/debug/unsolicited_responses.py CAPTURE.log [CAPTURE2.log ...
 
 ### Interpreting the output
 
-```
+```text
 events=727  requests(tx)=241  responses(rx)=478
 solicited (matched a prior request) = 216
 unanswered requests                 = 25

--- a/tests/debug/unsolicited_responses.py
+++ b/tests/debug/unsolicited_responses.py
@@ -105,7 +105,7 @@ def analyse(paths: list[str]) -> None:
             requests += 1
             try:
                 pending[pdu.expected_response().shape_hash()].append(ts)
-            except Exception:  # noqa: BLE001 — malformed request; skip
+            except Exception:  # noqa: BLE001  # nosec B110 — malformed request; skip silently
                 pass
         elif isinstance(pdu, TransparentResponse):
             h = pdu.shape_hash()

--- a/tests/debug/unsolicited_responses.py
+++ b/tests/debug/unsolicited_responses.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+r"""Find unsolicited (fan-out / broadcast) responses in a wire capture — #196.
+
+A GivEnergy dongle fans out the responses to *whoever* is polling it — the GE
+cloud, the vendor app, another TCP client — to every connected client. So a
+library client sees a continuous stream of register responses it never
+requested. This harness quantifies that stream: it pairs each received
+``TransparentResponse`` to a preceding ``TransparentRequest`` using the
+library's own ``shape_hash`` matching (the same logic
+``Client._task_network_consumer`` uses to resolve futures), and reports the
+responses that match no request — i.e. the dongle volunteered them.
+
+Why it matters for #196: if the live blocks (``IR(0,60)`` etc.) arrive reliably
+unsolicited, then a slow *solicited* read is not necessarily a failure — the
+cache may already have been refreshed by a fan-out frame. The cadence/jitter
+figures show how reliable that stream is, and whether it differs by dongle
+generation (the open Gen3 question).
+
+Note on interpretation: a *passive* capture (no ``tx`` lines) trivially reports
+every response as unsolicited — there were no requests to match. Only a capture
+that contains the client's own ``tx`` requests proves fan-out coexists with
+solicited traffic. The cadence figures are meaningful either way.
+
+Usage::
+
+    uv run python tests/debug/unsolicited_responses.py CAPTURE.log [CAPTURE2.log ...]
+
+Capture files are ``givenergy-cli capture`` ``.log`` output (``<ts> rx|tx <hex>``).
+"""
+
+from __future__ import annotations
+
+import sys
+from collections import defaultdict, deque
+from datetime import datetime
+from pathlib import Path
+
+from givenergy_modbus.pdu import (
+    ClientIncomingMessage,
+    ServerIncomingMessage,  # = ClientOutgoingMessage; decodes tx frames as requests
+    TransparentRequest,
+    TransparentResponse,
+)
+from givenergy_modbus.pdu.heartbeat import HeartbeatRequest, HeartbeatResponse
+
+_MARKER = bytes.fromhex("59590001")
+
+
+def _decode(raw: bytes, direction: str) -> object:
+    """Decode a frame with the direction-appropriate base class (tx=request, rx=response)."""
+    cls = ServerIncomingMessage if direction == "tx" else ClientIncomingMessage
+    try:
+        return cls.decode_bytes(raw)
+    except Exception as e:  # noqa: BLE001 — untrusted capture bytes; report, don't crash
+        return e
+
+
+def _frames(path: str | Path):
+    """Yield (ts, direction, raw_frame) from a capture, splitting chunks on the MBAP marker."""
+    for line in Path(path).read_text(encoding="utf-8").splitlines():
+        parts = line.split()
+        if len(parts) < 3 or parts[1] not in ("tx", "rx"):
+            continue
+        try:
+            ts = datetime.fromisoformat(parts[0])
+            buf = bytes.fromhex(parts[-1])
+        except ValueError:
+            continue
+        i, n = 0, len(buf)
+        while i + 6 <= n:
+            if buf[i : i + 4] != _MARKER:
+                i += 1
+                continue
+            flen = 6 + int.from_bytes(buf[i + 4 : i + 6], "big")
+            if flen < 18 or i + flen > n:
+                break
+            yield ts, parts[1], buf[i : i + flen]
+            i += flen
+
+
+def _shape_key(pdu: object) -> str:
+    fc = getattr(pdu, "transparent_function_code", None)
+    dev = getattr(pdu, "device_address", None)
+    base = getattr(pdu, "base_register", None)
+    cnt = getattr(pdu, "register_count", None)
+    dev_s = f"0x{dev:02x}" if isinstance(dev, int) else dev
+    fc_s = f"0x{fc:02x}" if isinstance(fc, int) else fc
+    return f"{type(pdu).__name__} dev={dev_s} fc={fc_s} base={base} count={cnt}"
+
+
+def analyse(paths: list[str]) -> None:
+    events = sorted((e for p in paths for e in _frames(p)), key=lambda e: e[0])
+
+    pending: dict[int, deque[datetime]] = defaultdict(deque)  # shape_hash -> unanswered request times
+    unsolicited: dict[str, list[datetime]] = defaultdict(list)
+    solicited = requests = hb_in = hb_out = decode_errors = 0
+
+    for ts, direction, raw in events:
+        pdu = _decode(raw, direction)
+        if isinstance(pdu, HeartbeatRequest):
+            hb_in += 1
+        elif isinstance(pdu, HeartbeatResponse):
+            hb_out += 1
+        elif isinstance(pdu, TransparentRequest):
+            requests += 1
+            try:
+                pending[pdu.expected_response().shape_hash()].append(ts)
+            except Exception:  # noqa: BLE001 — malformed request; skip
+                pass
+        elif isinstance(pdu, TransparentResponse):
+            h = pdu.shape_hash()
+            if pending[h]:
+                pending[h].popleft()
+                solicited += 1
+            else:
+                unsolicited[_shape_key(pdu)].append(ts)
+        elif isinstance(pdu, Exception):
+            decode_errors += 1
+
+    unanswered = sum(len(q) for q in pending.values())
+    total_unsol = sum(len(v) for v in unsolicited.values())
+
+    print(f"events={len(events)}  requests(tx)={requests}  responses(rx)={solicited + total_unsol}")
+    print(f"heartbeats: in={hb_in} out={hb_out}  decode_errors={decode_errors}")
+    print(f"solicited (matched a prior request) = {solicited}")
+    print(f"unanswered requests                 = {unanswered}")
+    print(f"UNSOLICITED (no prior request)      = {total_unsol}")
+    print()
+    for key, tss in sorted(unsolicited.items(), key=lambda kv: -len(kv[1])):
+        tss.sort()
+        cadence = ""
+        if len(tss) >= 2:
+            deltas = [(b - a).total_seconds() for a, b in zip(tss, tss[1:])]
+            cadence = f"  cadence: min={min(deltas):.2f}s avg={sum(deltas) / len(deltas):.2f}s max={max(deltas):.2f}s"
+        print(f"  [{len(tss):5d}x] {key}{cadence}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print(__doc__)
+        raise SystemExit(2)
+    analyse(sys.argv[1:])

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -1375,10 +1375,13 @@ def test_from_actual():
 # ---------------------------------------------------------------------------
 
 
-def _make_ir_pdu(registers: dict[int, int], device_address: int = 0x32) -> ReadInputRegistersResponse:
+def _make_ir_pdu(
+    registers: dict[int, int], device_address: int = 0x32, base_register: int = 0
+) -> ReadInputRegistersResponse:
     """Build a minimal ReadInputRegistersResponse mock for update() tests."""
     pdu = MagicMock(spec=ReadInputRegistersResponse)
     pdu.device_address = device_address
+    pdu.base_register = base_register
     pdu.error = False
     pdu.inverter_serial_number = ""
     pdu.data_adapter_serial_number = ""
@@ -1387,10 +1390,13 @@ def _make_ir_pdu(registers: dict[int, int], device_address: int = 0x32) -> ReadI
     return pdu
 
 
-def _make_hr_pdu(registers: dict[int, int], device_address: int = 0x32) -> ReadHoldingRegistersResponse:
+def _make_hr_pdu(
+    registers: dict[int, int], device_address: int = 0x32, base_register: int = 0
+) -> ReadHoldingRegistersResponse:
     """Build a minimal ReadHoldingRegistersResponse mock for update() tests."""
     pdu = MagicMock(spec=ReadHoldingRegistersResponse)
     pdu.device_address = device_address
+    pdu.base_register = base_register
     pdu.error = False
     pdu.inverter_serial_number = ""
     pdu.data_adapter_serial_number = ""
@@ -1650,6 +1656,50 @@ def test_update_pattern_a_signature_is_recognised_and_discarded(plant: Plant):
         assert IR(reg) not in plant.register_caches[0x32], (
             f"IR({reg}) leaked into the cache despite Pattern A fingerprint"
         )
+
+
+# ---------------------------------------------------------------------------
+# Ingestion timestamps (#65) — block_age() / register_block_updated_at
+# ---------------------------------------------------------------------------
+
+
+def test_update_stamps_ingestion_timestamp_on_commit(plant: Plant):
+    """A committed IR bank records its ingestion time keyed by (device, type, base)."""
+    t = datetime(2026, 6, 6, 12, 0, 0, tzinfo=UTC)
+    plant.update(_make_ir_pdu({5: 2367}, base_register=0), received_at=t)
+    assert plant.register_block_updated_at[(0x32, "IR", 0)] == t
+    # block_age measured from a later 'now' is the elapsed seconds.
+    assert plant.block_age(0x32, "IR", 0, now=t + timedelta(seconds=9)) == 9.0
+
+
+def test_update_stamps_hr_block_distinctly(plant: Plant):
+    """HR and IR blocks at the same base are tracked under separate keys."""
+    t = datetime(2026, 6, 6, 12, 0, 0, tzinfo=UTC)
+    plant.update(_make_hr_pdu({20: 1}, base_register=0), received_at=t)
+    assert plant.register_block_updated_at[(0x32, "HR", 0)] == t
+    assert (0x32, "IR", 0) not in plant.register_block_updated_at
+
+
+def test_update_stamps_block_at_its_base_register(plant: Plant):
+    """The timestamp key uses the response's base_register, not a fixed 0."""
+    t = datetime(2026, 6, 6, 12, 0, 0, tzinfo=UTC)
+    plant.update(_make_ir_pdu({180: 1}, base_register=180), received_at=t)
+    assert plant.block_age(0x32, "IR", 180, now=t) == 0.0
+    assert plant.block_age(0x32, "IR", 0) is None  # a different block was never seen
+
+
+def test_discarded_bank_is_not_stamped(plant: Plant):
+    """An incoherent (discarded) bank must NOT record an ingestion time — it never landed."""
+    # All-zero battery serial at IR(110-114) → incoherent → discarded by _commit_bank.
+    t = datetime(2026, 6, 6, 12, 0, 0, tzinfo=UTC)
+    pdu = _make_ir_pdu({110: 0, 111: 0, 112: 0, 113: 0, 114: 0, 60: 3221}, device_address=0x33, base_register=60)
+    plant.update(pdu, received_at=t)
+    assert plant.block_age(0x33, "IR", 60) is None
+
+
+def test_block_age_none_for_never_seen_block(plant: Plant):
+    """block_age returns None when the block has never been committed."""
+    assert plant.block_age(0x99, "IR", 0) is None
 
 
 def test_getter_for_device_meter_address(plant: Plant):

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -1376,12 +1376,16 @@ def test_from_actual():
 
 
 def _make_ir_pdu(
-    registers: dict[int, int], device_address: int = 0x32, base_register: int = 0
+    registers: dict[int, int],
+    device_address: int = 0x32,
+    base_register: int = 0,
+    register_count: int = 60,
 ) -> ReadInputRegistersResponse:
     """Build a minimal ReadInputRegistersResponse mock for update() tests."""
     pdu = MagicMock(spec=ReadInputRegistersResponse)
     pdu.device_address = device_address
     pdu.base_register = base_register
+    pdu.register_count = register_count
     pdu.error = False
     pdu.inverter_serial_number = ""
     pdu.data_adapter_serial_number = ""
@@ -1391,12 +1395,16 @@ def _make_ir_pdu(
 
 
 def _make_hr_pdu(
-    registers: dict[int, int], device_address: int = 0x32, base_register: int = 0
+    registers: dict[int, int],
+    device_address: int = 0x32,
+    base_register: int = 0,
+    register_count: int = 60,
 ) -> ReadHoldingRegistersResponse:
     """Build a minimal ReadHoldingRegistersResponse mock for update() tests."""
     pdu = MagicMock(spec=ReadHoldingRegistersResponse)
     pdu.device_address = device_address
     pdu.base_register = base_register
+    pdu.register_count = register_count
     pdu.error = False
     pdu.inverter_serial_number = ""
     pdu.data_adapter_serial_number = ""
@@ -1667,25 +1675,25 @@ def test_update_stamps_ingestion_timestamp_on_commit(plant: Plant):
     """A committed IR bank records its ingestion time keyed by (device, type, base)."""
     t = datetime(2026, 6, 6, 12, 0, 0, tzinfo=UTC)
     plant.update(_make_ir_pdu({5: 2367}, base_register=0), received_at=t)
-    assert plant.register_block_updated_at[(0x32, "IR", 0)] == t
+    assert plant.register_block_updated_at[(0x32, "IR", 0, 60)] == t
     # block_age measured from a later 'now' is the elapsed seconds.
-    assert plant.block_age(0x32, "IR", 0, now=t + timedelta(seconds=9)) == 9.0
+    assert plant.block_age(0x32, "IR", 0, 60, now=t + timedelta(seconds=9)) == 9.0
 
 
 def test_update_stamps_hr_block_distinctly(plant: Plant):
     """HR and IR blocks at the same base are tracked under separate keys."""
     t = datetime(2026, 6, 6, 12, 0, 0, tzinfo=UTC)
     plant.update(_make_hr_pdu({20: 1}, base_register=0), received_at=t)
-    assert plant.register_block_updated_at[(0x32, "HR", 0)] == t
-    assert (0x32, "IR", 0) not in plant.register_block_updated_at
+    assert plant.register_block_updated_at[(0x32, "HR", 0, 60)] == t
+    assert (0x32, "IR", 0, 60) not in plant.register_block_updated_at
 
 
 def test_update_stamps_block_at_its_base_register(plant: Plant):
     """The timestamp key uses the response's base_register, not a fixed 0."""
     t = datetime(2026, 6, 6, 12, 0, 0, tzinfo=UTC)
     plant.update(_make_ir_pdu({180: 1}, base_register=180), received_at=t)
-    assert plant.block_age(0x32, "IR", 180, now=t) == 0.0
-    assert plant.block_age(0x32, "IR", 0) is None  # a different block was never seen
+    assert plant.block_age(0x32, "IR", 180, 60, now=t) == 0.0
+    assert plant.block_age(0x32, "IR", 0, 60) is None  # a different block was never seen
 
 
 def test_discarded_bank_is_not_stamped(plant: Plant):
@@ -1694,12 +1702,12 @@ def test_discarded_bank_is_not_stamped(plant: Plant):
     t = datetime(2026, 6, 6, 12, 0, 0, tzinfo=UTC)
     pdu = _make_ir_pdu({110: 0, 111: 0, 112: 0, 113: 0, 114: 0, 60: 3221}, device_address=0x33, base_register=60)
     plant.update(pdu, received_at=t)
-    assert plant.block_age(0x33, "IR", 60) is None
+    assert plant.block_age(0x33, "IR", 60, 60) is None
 
 
 def test_block_age_none_for_never_seen_block(plant: Plant):
     """block_age returns None when the block has never been committed."""
-    assert plant.block_age(0x99, "IR", 0) is None
+    assert plant.block_age(0x99, "IR", 0, 60) is None
 
 
 # ---------------------------------------------------------------------------
@@ -1756,7 +1764,7 @@ def test_allzero_rejection_preserves_staleness(plant: Plant):
     t1 = t0 + timedelta(seconds=30)
     plant.update(_make_ir_pdu({0: 0, 5: 0}, device_address=0x32), received_at=t1)  # rejected
     # age reflects t0 (last good commit), not t1 — the rejected bank left no fresh stamp.
-    assert plant.block_age(0x32, "IR", 0, now=t0 + timedelta(seconds=45)) == 45.0
+    assert plant.block_age(0x32, "IR", 0, 60, now=t0 + timedelta(seconds=45)) == 45.0
 
 
 def test_getter_for_device_meter_address(plant: Plant):

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -1735,6 +1735,7 @@ def test_hr_bank_rejected_by_commit_is_not_stamped(plant: Plant):
     plant.update(_make_hr_pdu({0: 0, 20: 0}, base_register=0))
     # Cache should still hold the good values; the all-zero bank was rejected.
     from givenergy_modbus.model.register import HR
+
     assert plant.register_caches[0x32][HR(0)] == 1
     assert plant.register_caches[0x32][HR(20)] == 100
 

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -1767,6 +1767,19 @@ def test_allzero_rejection_preserves_staleness(plant: Plant):
     assert plant.block_age(0x32, "IR", 0, 60, now=t0 + timedelta(seconds=45)) == 45.0
 
 
+def test_commit_allows_short_read_zero_transition(plant: Plant):
+    """Pattern B must not block a short read (register_count < 60) going legitimately to zero.
+
+    A single-register fan-out of e.g. a power reading can validly go non-zero → zero (power
+    off at night) and must commit normally. Regression for Codex review on PR #208.
+    """
+    # Seed a non-zero value for a single register at device 0x32.
+    plant.update(_make_ir_pdu({5: 100}, device_address=0x32, register_count=1))
+    # A subsequent single-register read returning zero should commit, not be rejected.
+    plant.update(_make_ir_pdu({5: 0}, device_address=0x32, register_count=1))
+    assert plant.register_caches[0x32][IR(5)] == 0  # zero committed normally
+
+
 def test_getter_for_device_meter_address(plant: Plant):
     """A bank arriving on a meter device address (0x01–0x08) must be accepted."""
     pdu = _make_ir_pdu({0: 1}, device_address=0x01)

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -1710,6 +1710,35 @@ def test_block_age_none_for_never_seen_block(plant: Plant):
     assert plant.block_age(0x99, "IR", 0, 60) is None
 
 
+def test_stamp_block_normalises_naive_received_at(plant: Plant):
+    """A timezone-naive received_at is treated as UTC rather than raising TypeError (#208 Gemini)."""
+    naive = datetime(2026, 6, 6, 12, 0, 0)  # no tzinfo
+    plant.update(_make_ir_pdu({5: 2367}, base_register=0), received_at=naive)
+    # Should have been stamped at UTC; block_age at the same naive-but-equivalent UTC moment is ~0.
+    age = plant.block_age(0x32, "IR", 0, 60, now=datetime(2026, 6, 6, 12, 0, 5, tzinfo=UTC))
+    assert age == 5.0
+
+
+def test_block_age_normalises_naive_now(plant: Plant):
+    """A timezone-naive now is treated as UTC rather than raising TypeError (#208 Gemini)."""
+    t = datetime(2026, 6, 6, 12, 0, 0, tzinfo=UTC)
+    plant.update(_make_ir_pdu({5: 2367}, base_register=0), received_at=t)
+    # Pass a naive now that is 7 seconds later; should compute without TypeError.
+    age = plant.block_age(0x32, "IR", 0, 60, now=datetime(2026, 6, 6, 12, 0, 7))
+    assert age == 7.0
+
+
+def test_hr_bank_rejected_by_commit_is_not_stamped(plant: Plant):
+    """An incoherent HR bank must not record an ingestion timestamp."""
+    # Seed non-zero HR data, then push all-zero (Pattern B) to trigger rejection.
+    plant.update(_make_hr_pdu({0: 1, 20: 100}, base_register=0))
+    plant.update(_make_hr_pdu({0: 0, 20: 0}, base_register=0))
+    # Cache should still hold the good values; the all-zero bank was rejected.
+    from givenergy_modbus.model.register import HR
+    assert plant.register_caches[0x32][HR(0)] == 1
+    assert plant.register_caches[0x32][HR(20)] == 100
+
+
 # ---------------------------------------------------------------------------
 # All-zero bank rejection — Pattern B (#206)
 # ---------------------------------------------------------------------------

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -1702,6 +1702,63 @@ def test_block_age_none_for_never_seen_block(plant: Plant):
     assert plant.block_age(0x99, "IR", 0) is None
 
 
+# ---------------------------------------------------------------------------
+# All-zero bank rejection — Pattern B (#206)
+# ---------------------------------------------------------------------------
+
+
+def test_commit_rejects_allzero_over_nonzero_inverter_bank(plant: Plant, caplog):
+    """#199: an all-zero IR(0,60) over good inverter data is rejected and logged at WARNING.
+
+    The inverter bank has no serial, so is_coherent can't catch this — the Pattern B rule must.
+    This is the genuinely-new protection (and the evidence-collection WARNING).
+    """
+    import logging
+
+    plant.update(_make_ir_pdu({0: 1, 5: 2367}, device_address=0x32))
+    with caplog.at_level(logging.WARNING, logger="givenergy_modbus.model.plant"):
+        plant.update(_make_ir_pdu({0: 0, 5: 0}, device_address=0x32))
+    assert plant.register_caches[0x32][IR(5)] == 2367  # last-good retained, not zeroed
+    assert plant.register_caches[0x32][IR(0)] == 1
+    warns = [r for r in caplog.records if r.levelno == logging.WARNING and "Pattern B" in r.message]
+    assert len(warns) == 1, "an all-zero bank rejected over good data must log once at WARNING"
+
+
+def test_commit_rejects_allzero_over_nonzero_battery_bank(plant: Plant):
+    """#147: an all-zero battery page over previously-good data is rejected (kept last-good)."""
+    # Valid serial ("BG1234G567" across IR110-114) + data, so the seed is coherent and commits.
+    seed = {110: 0x4247, 111: 0x3132, 112: 0x3334, 113: 0x3536, 114: 0x3738, 60: 3221}
+    plant.update(_make_ir_pdu(seed, device_address=0x33, base_register=60))
+    assert plant.register_caches[0x33][IR(60)] == 3221
+    plant.update(_make_ir_pdu(dict.fromkeys(seed, 0), device_address=0x33, base_register=60))
+    assert plant.register_caches[0x33][IR(60)] == 3221  # retained
+
+
+def test_commit_allows_allzero_on_first_read(plant: Plant):
+    """An all-zero bank with no prior data (absent / first read) is NOT rejected by Pattern B.
+
+    Uses an unknown device (no getter) so the Pattern B check is the only gate in play.
+    """
+    plant.update(_make_ir_pdu({60: 0, 61: 0}, device_address=0x99, base_register=60))
+    assert IR(60) in plant.register_caches[0x99]  # committed, not rejected
+
+
+def test_commit_allows_mixed_bank_with_some_nonzero(plant: Plant):
+    """A bank with any non-zero value commits normally — the all-zero gate must not catch it."""
+    plant.update(_make_ir_pdu({0: 0, 1: 5, 2: 0}, device_address=0x32))
+    assert plant.register_caches[0x32][IR(1)] == 5
+
+
+def test_allzero_rejection_preserves_staleness(plant: Plant):
+    """A rejected all-zero bank records no ingestion timestamp, so block_age keeps growing (#65/#206)."""
+    t0 = datetime(2026, 6, 6, 12, 0, 0, tzinfo=UTC)
+    plant.update(_make_ir_pdu({0: 1, 5: 2367}, device_address=0x32), received_at=t0)
+    t1 = t0 + timedelta(seconds=30)
+    plant.update(_make_ir_pdu({0: 0, 5: 0}, device_address=0x32), received_at=t1)  # rejected
+    # age reflects t0 (last good commit), not t1 — the rejected bank left no fresh stamp.
+    assert plant.block_age(0x32, "IR", 0, now=t0 + timedelta(seconds=45)) == 45.0
+
+
 def test_getter_for_device_meter_address(plant: Plant):
     """A bank arriving on a meter device address (0x01–0x08) must be accepted."""
     pdu = _make_ir_pdu({0: 1}, device_address=0x01)


### PR DESCRIPTION
Three related changes building on one another: ingestion timestamps as the foundation, then two consumers of them.

## #65 — per-block ingestion timestamps

`Plant` now records when each register block was last successfully committed, keyed by `(device_address, register_type, base_register)`, in a new `register_block_updated_at` map maintained in `update()`. `_commit_bank` returns a bool so a discarded bank (incoherent serial, all-zero dropout) does **not** record a timestamp — only data that actually landed counts as fresh. A `block_age()` helper exposes seconds-since-last-commit (None if never seen), with optional clock injection for deterministic tests. The field is excluded from `model_dump()` as ephemeral runtime bookkeeping.

The map is maintained continuously by the network consumer, so it captures both solicited responses **and** the dongle's unsolicited fan-out.

## #196 — opt-in IR(0,60) skip-if-fresh

GivEnergy dongles fan out the responses to whoever is polling them (the cloud, the app, another TCP client) to every connected client — so the consumer often already holds a recent `IR(0,60)` without us asking. Confirmed across every device class we have a capture for (AIO, AC, EMS, Gen1 hybrid): the live blocks arrive unsolicited on a ~10–32s cloud-driven cadence.

`refresh(ir0_max_age=...)` opts in to skipping the `IR(0,60)` solicit when its last ingest is within the threshold, sparing the often-flaky dongle a request. Defaults to `None` — always solicit, the historic behaviour. Scoped to `IR(0,60)` only for now. Degrades safely: the fan-out only exists while something else polls the unit, so on a cloud-disconnected dongle the block ages out and we solicit it as normal.

Also adds `tests/debug/unsolicited_responses.py`, the capture-analysis tool used to establish the fan-out behaviour.

## #206 — reject degenerate all-zero register banks (Pattern B)

`_commit_bank` committed an all-zero bank straight over good cached data. `is_coherent()` catches all-zero *battery* banks (serial check) but is a no-op for the serial-less inverter `IR(0,60)` bank, so the #199 inverter case (and #147 on the battery sub-bus) could zero out live values.

A contextual rejection now fires when a bank is entirely zero **and** its registers previously held non-zero data — a block-level dropout — keeping last-good. The "previously non-zero" gate resolves the dropout-vs-absent ambiguity: an always-zero/first-read bank (an absent device's ghost ACK) falls through to existing handling, so device detection is unaffected (verified). Staleness rides on #65 — a rejected bank records no timestamp, so `block_age()` grows.

Logged at **WARNING**: there is no on-wire capture of this event in any fixture (only a synthetic reproduction), so surfacing it turns every deployment into an evidence collector. It's a silent no-op on healthy systems.

## Notes

- `ir0_max_age` (#196) and the rejection (#206) are both **safe by construction** — opt-in / conservative-contextual respectively. Self-tuning skip-if-fresh is tracked in #207.
- 802 tests pass; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Refresh operation can now conditionally skip re-fetching register data if cached data is recent enough.
  * System now tracks when each register block was last updated.

* **Bug Fixes**
  * System now properly detects and rejects all-zero register blocks that follow valid data, preventing misinterpretation of temporary data loss.

* **Documentation**
  * Added debug harness documentation for analyzing unsolicited response patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->