### PR TITLE
feat(model): typed-device enumeration API — Plant.devices (#106 Phase 1)

### DIFF
--- a/docs/plant-device-graph.md
+++ b/docs/plant-device-graph.md
@@ -1,0 +1,120 @@
+# Graph-shaped Plant abstraction (#106)
+
+Tracking design for the `Plant` model refactor. This is a living document —
+phases land independently and the integration keeps working throughout.
+See [#106](https://github.com/dewet22/givenergy-modbus/issues/106).
+
+## The problem
+
+`Plant` currently models the world as *one inverter with peripherals hanging
+off it*:
+
+- a flat `register_caches: dict[int, RegisterCache]` keyed by Modbus address,
+- a single scalar `PlantCapabilities` (one `inverter_address`, global
+  `meter_addresses` / `lv_battery_addresses` / `bcu_stacks` lists),
+- a 1:1 `Client` ↔ `Plant` relationship.
+
+Real installs break this shape:
+
+- an **EMS plant controller is a peer** of the inverters it manages, not their
+  parent — yet `Plant.inverter` (singular) decodes the controller *as* an
+  inverter ([hass#52](https://github.com/dewet22/givenergy-hass/issues/52));
+- a **Gateway** aggregates partner AIOs and CT meters of its own;
+- **batteries belong to their parent inverter**, not directly to the plant;
+- some devices have their own communication path (separate dongles), some are
+  "blinded" (visible only through a controller's rollup);
+- direct-data and rollup views of the same inverter need **reconciliation by
+  serial number**.
+
+## Target architecture
+
+A graph: `Plant` → `Device` subclasses → `Transport` (abstract I/O), with a
+`serial_index` for cross-device reconciliation.
+
+```
+Plant
+ ├─ serial_index: {serial → Device}
+ ├─ Inverter (direct | blinded | merged)
+ │    └─ Battery, Battery, …            (owned by their inverter)
+ ├─ Ems            (peer controller, manages N inverters)
+ ├─ Gateway        (aggregator, owns partner AIOs + CT meters)
+ └─ Meter, HvStack, …
+        ↓ each reachable via
+      Transport (abstract: ModbusTcpTransport today; HTTP/MQTT/… later)
+```
+
+### Design discipline — kept hoist-ready
+
+The `Plant` / `Device` / `Transport` metaphor is a **generic energy-topology
+abstraction** — not GivEnergy-specific, not Modbus-specific. The same shape
+describes a mixed-vendor install (heat pump + Powerwall + Zappi + GivEnergy
+inverter). We keep it hoistable so a future extraction is a code-org refactor,
+not a redesign:
+
+1. no concrete GivEnergy or Modbus types leak into the generic shapes
+   (`givenergy_modbus/model/devices.py` stays import-clean);
+2. generic names (`Inverter`, `DeviceType`) — the GE-specific concretes get a
+   `GivEnergy…` prefix only on extraction;
+3. `Transport` is abstract; Modbus TCP is one concrete implementation;
+4. `RegisterCache` is a Modbus implementation detail, never on the generic
+   surface;
+5. identity is by **serial**, not wire address.
+
+## Phased rollout
+
+Each phase merges independently and keeps the integration working.
+
+### Phase 1 — typed-device enumeration API ✅ (this increment)
+
+A strictly **additive, non-breaking** read surface: `Plant.devices` returns a
+list of `PlantDevice` rows, each tagged with a generic `DeviceType`
+discriminator (`INVERTER` / `EMS` / `GATEWAY` / `BATTERY` / `METER` /
+`HV_STACK`), a serial (where the device exposes a valid one), the plant model
+where meaningful, and the already-decoded typed model.
+
+- Composes the existing accessors (`inverters`, `ems`, `gateway`, `batteries`,
+  `meters`, `hv_stacks`) — the EMS-rollup-vs-direct decision (from the #98
+  `UnifiedInverter` facade) is honoured once, so an **EMS or Gateway controller
+  can never appear as an `INVERTER` row**.
+- Gateway plants suppress the spurious direct-inverter row (the singular
+  `Plant.inverter` decodes the gateway's own cache as an inverter).
+- Every existing `Plant` accessor is untouched.
+
+Consumers (Home Assistant) can now enumerate typed devices to name and scope
+entities per device-type instead of assuming a single inverter.
+
+### Phase 2 — per-inverter battery ownership
+
+Move batteries under their owning inverter (`Inverter.batteries`) with
+reconciliation by serial. **Breaking** for consumers that enumerate a flat
+`Plant.batteries` at setup time, so it ships behind a capability flag with a
+consumer migration. Depends on serial reconciliation maturing.
+
+### Phase 3 — `Transport` abstraction / multi-Client
+
+Extract the Modbus-specific I/O behind a `Transport` interface so a plant can
+span multiple connections (free-standing inverters + an EMS on one plant) and
+so non-Modbus transports can slot in later. Reconciles with
+[#75](https://github.com/dewet22/givenergy-modbus/issues/75).
+
+### Phase 4 — model-aware write-routing
+
+Route `set_*` write commands through the typed device so model-specific
+register differences (three-phase vs single-phase) are enforced at write time.
+Reconciles with [#203](https://github.com/dewet22/givenergy-modbus/issues/203).
+
+## Out of scope (deliberately deferred)
+
+`register_caches` stays flat; `RegisterCache` stays a Modbus detail; no
+serial-product (FC 0x16) reads are added for controller rows — EMS and Gateway
+controller rows carry `serial_number=None` until a later phase. Per-inverter
+battery ownership, multi-transport, and write-routing are Phases 2–4 above.
+
+**Known Phase 1 limitation — meter identity.** `Meter` carries no `device_address`
+field; the address is the dict key in `Plant.meters` and is lost when iterating
+`.values()`. MR(60-61) serials are absent on all known hardware, so two meter rows
+both have `serial_number=None` and are indistinguishable via `Plant.devices`.
+Consumers needing to distinguish meters by address should use `Plant.meters`
+(keyed by address) directly for now. Stable per-device identity for address-only
+devices will be addressed in Phase 2/3 when the transport abstraction makes the
+address a typed transport detail rather than a leaked Modbus integer.

--- a/docs/v2.1-roadmap.md
+++ b/docs/v2.1-roadmap.md
@@ -137,7 +137,8 @@ Better a shipped narrower v2.1 than a perpetually in-progress one. Likely v2.2:
 
 - The graph-shaped Plant abstraction
   ([#106](https://github.com/dewet22/givenergy-modbus/issues/106)) if it doesn't
-  make the beta cut.
+  make the beta cut. Design and phased rollout: [Graph-shaped Plant](plant-device-graph.md)
+  (Phase 1 — the typed-device enumeration API — has landed).
 - Freshness-aware `RegisterCache` invalidation policy (the layer above
   [#65](https://github.com/dewet22/givenergy-modbus/issues/65)'s recording).
 - Internal refresh serialization

--- a/givenergy_modbus/model/devices.py
+++ b/givenergy_modbus/model/devices.py
@@ -18,6 +18,7 @@ the wider refactor sketch in the v2.1 roadmap (see ``docs/v2.1-roadmap.md``).
 from __future__ import annotations
 
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any, Literal
 
 # ``Inverter`` deliberately accepts the concrete decoders as ``Any`` because
@@ -28,6 +29,24 @@ from typing import Any, Literal
 # ``project_plant_abstraction_direction``.
 
 DataSource = Literal["direct", "ems_rollup", "merged"]
+
+
+class DeviceType(str, Enum):
+    """Generic device categories on an energy Plant graph.
+
+    ``str``-valued so members serialise to stable, JSON-safe strings and can
+    be used directly as identifiers (e.g. a Home Assistant entity-id prefix).
+    The names are deliberately generic — no manufacturer- or protocol-specific
+    nouns (``bcu``, ``aio``, ``modbus``) leak in, preserving the hoistability
+    discipline of this module.
+    """
+
+    INVERTER = "inverter"
+    EMS = "ems"
+    GATEWAY = "gateway"
+    BATTERY = "battery"
+    METER = "meter"
+    HV_STACK = "hv_stack"
 
 
 @dataclass(frozen=True)
@@ -261,3 +280,28 @@ class Inverter:
             f"data_source={self.data_source!r}, "
             f"is_blinded={self.is_blinded})"
         )
+
+
+@dataclass(frozen=True)
+class PlantDevice:
+    """One enumerated device on a Plant, tagged with its type and identity.
+
+    A thin, immutable wrapper pairing an already-decoded typed model
+    (:attr:`device`) with a generic :class:`DeviceType` discriminator and,
+    where available, a serial number and model. Consumers enumerate
+    :attr:`Plant.devices` to discover what is on a plant and read rich fields
+    through :attr:`device`.
+
+    The wrapper exists because the concrete device models share no common
+    base — the inverter facade is a plain class, batteries / meters / EMS /
+    gateway are Pydantic models, an HV stack is a dataclass — so tagging them
+    from the outside keeps the enumeration additive rather than mutating every
+    model. No Modbus wire address or :class:`RegisterCache` appears here:
+    identity is by serial, and the wire address (where relevant) stays
+    reachable on the underlying model (e.g. ``HvStack.device_address``).
+    """
+
+    device_type: DeviceType
+    device: Any
+    serial_number: str | None = None
+    model: Any | None = None

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from givenergy_modbus.model import GivEnergyBaseModel
 from givenergy_modbus.model.battery import Battery, BatteryRegisterGetter
+from givenergy_modbus.model.devices import DeviceType, PlantDevice
 from givenergy_modbus.model.devices import Inverter as UnifiedInverter
 from givenergy_modbus.model.ems import Ems
 from givenergy_modbus.model.gateway import GatewayV1, GatewayV2, select_gateway
@@ -454,6 +455,20 @@ class PlantCapabilities(BaseModel):
         return self.device_type == Model.GATEWAY
 
 
+def _validated_serial(device: Any) -> str | None:
+    """Return a device's serial number only when it validates, else None.
+
+    Devices exposing an ``is_valid()`` self-check (battery / meter / BCU) must
+    pass it — an absent device's ghost cache decodes to a junk serial we do not
+    want to surface. Devices without the check fall back to a truthy
+    ``serial_number``.
+    """
+    is_valid = getattr(device, "is_valid", None)
+    if callable(is_valid) and not is_valid():
+        return None
+    return getattr(device, "serial_number", None) or None
+
+
 class Plant(GivEnergyBaseModel):
     """Representation of a complete GivEnergy plant."""
 
@@ -781,3 +796,74 @@ class Plant(GivEnergyBaseModel):
             return None
         cache = self.register_caches.get(self.capabilities.inverter_address, RegisterCache())
         return select_gateway(cache)
+
+    @property
+    def devices(self) -> list[PlantDevice]:
+        """Enumerate every device on this plant as typed :class:`PlantDevice` rows.
+
+        Additive surface (#106 Phase 1): each row carries a generic
+        :class:`DeviceType` discriminator, a serial (where the device exposes a
+        valid one), the plant's model where meaningful, and the already-decoded
+        typed model in :attr:`PlantDevice.device`. Built by composing the
+        existing accessors — :attr:`inverters`, :attr:`ems`, :attr:`gateway`,
+        :attr:`batteries`, :attr:`meters`, :attr:`hv_stacks` — so the
+        EMS-rollup-vs-direct decision is honoured once and a controller (EMS or
+        gateway) can never appear as an ``INVERTER`` row.
+        """
+        caps = self.capabilities
+        model = caps.device_type if caps else None
+        # On EMS/Gateway plants the plant model is the controller's model, not an
+        # inverter model — don't let directly-decoded inverters inherit it.
+        inverter_model = model if caps and not (caps.is_ems or caps.is_gateway) else None
+        rows: list[PlantDevice] = []
+
+        # On a gateway plant the singular ``inverter`` decodes the gateway's own
+        # cache as a spurious inverter — suppress that row; the GATEWAY row below
+        # represents the device instead.
+        if not (caps and caps.is_gateway):
+            for inverter in self.inverters:
+                rows.append(
+                    PlantDevice(
+                        device_type=DeviceType.INVERTER,
+                        device=inverter,
+                        serial_number=inverter.serial_number or None,
+                        # A blinded (EMS-rollup) inverter's own model is unknown;
+                        # only a directly-decoded inverter inherits the plant model.
+                        model=None if inverter.is_blinded else inverter_model,
+                    )
+                )
+
+        if (ems := self.ems) is not None:
+            rows.append(PlantDevice(device_type=DeviceType.EMS, device=ems, model=model))
+
+        if (gateway := self.gateway) is not None:
+            rows.append(PlantDevice(device_type=DeviceType.GATEWAY, device=gateway, model=model))
+
+        for battery in self.batteries:
+            rows.append(
+                PlantDevice(
+                    device_type=DeviceType.BATTERY,
+                    device=battery,
+                    serial_number=_validated_serial(battery),
+                )
+            )
+
+        for meter in self.meters.values():
+            rows.append(
+                PlantDevice(
+                    device_type=DeviceType.METER,
+                    device=meter,
+                    serial_number=_validated_serial(meter),
+                )
+            )
+
+        for stack in self.hv_stacks:
+            rows.append(
+                PlantDevice(
+                    device_type=DeviceType.HV_STACK,
+                    device=stack,
+                    serial_number=_validated_serial(stack.bcu),
+                )
+            )
+
+        return rows

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ nav:
   - Planning:
       - v2.1 roadmap: v2.1-roadmap.md
       - Post-v2.0 improvement plan: post-v2-improvement-plan.md
+      - Graph-shaped Plant (#106): plant-device-graph.md
 theme:
   name: material
   language: en

--- a/tests/model/test_devices.py
+++ b/tests/model/test_devices.py
@@ -4,7 +4,11 @@ Phase 1 of the Plant refactor — see ``docs/v2.1-roadmap.md`` for the
 wider design these tests verify.
 """
 
-from givenergy_modbus.model.devices import Inverter, InverterSummary
+import dataclasses
+
+import pytest
+
+from givenergy_modbus.model.devices import DeviceType, Inverter, InverterSummary, PlantDevice
 from givenergy_modbus.model.ems import Ems
 from givenergy_modbus.model.inverter import Model, Status
 from givenergy_modbus.model.plant import Plant, PlantCapabilities
@@ -358,3 +362,59 @@ def test_plant_inverters_non_ems_returns_single_direct_inverter():
     assert inverters[0].is_blinded is False
     # The wrapped direct source is the same instance Plant.inverter returns.
     assert inverters[0].direct is not None
+
+
+# ---------------------------------------------------------------------------
+# DeviceType + PlantDevice
+# ---------------------------------------------------------------------------
+
+
+def test_device_type_members_are_generic_string_values():
+    """DeviceType is a str-enum of generic device categories — stable, JSON-safe values.
+
+    Values are leaned on as hass entity-id prefixes, so they must be plain
+    lowercase strings and must not leak manufacturer/protocol nouns (no
+    'bcu', 'aio', 'modbus').
+    """
+    assert {dt.name for dt in DeviceType} == {
+        "INVERTER",
+        "EMS",
+        "GATEWAY",
+        "BATTERY",
+        "METER",
+        "HV_STACK",
+    }
+    # str-valued: each member is usable directly as a string.
+    assert DeviceType.INVERTER == "inverter"
+    assert DeviceType.HV_STACK == "hv_stack"
+    assert isinstance(DeviceType.BATTERY, str)
+
+
+def test_plant_device_construction_and_read_through():
+    """PlantDevice tags an already-decoded model with a type, serial, and model."""
+    s = InverterSummary(serial_number="XX1234A567")
+    inv = Inverter.from_summary(s)
+    entry = PlantDevice(
+        device_type=DeviceType.INVERTER,
+        device=inv,
+        serial_number="XX1234A567",
+        model=None,
+    )
+    assert entry.device_type is DeviceType.INVERTER
+    assert entry.device is inv  # read-through to the rich model
+    assert entry.serial_number == "XX1234A567"
+    assert entry.model is None
+
+
+def test_plant_device_serial_and_model_default_to_none():
+    """serial_number and model are optional — a device with neither is valid."""
+    entry = PlantDevice(device_type=DeviceType.EMS, device=object())
+    assert entry.serial_number is None
+    assert entry.model is None
+
+
+def test_plant_device_is_frozen():
+    """PlantDevice is immutable — entries are snapshots, not mutable handles."""
+    entry = PlantDevice(device_type=DeviceType.METER, device=object())
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        entry.serial_number = "tampered"  # type: ignore[misc]

--- a/tests/model/test_plant_devices.py
+++ b/tests/model/test_plant_devices.py
@@ -1,0 +1,120 @@
+"""Tests for ``Plant.devices`` — the typed-device enumeration API (#106 Phase 1).
+
+These verify three things in concert: correct typed enumeration, no
+mis-classification (an EMS / gateway controller must never surface as an
+inverter), and that the existing ``Plant`` accessors are untouched (the API
+is strictly additive). Plants are constructed in-memory, matching the idiom
+in ``test_devices.py`` for the ``Plant.inverters`` tests.
+"""
+
+from givenergy_modbus.model.devices import DeviceType, Inverter
+from givenergy_modbus.model.ems import Ems
+from givenergy_modbus.model.gateway import GatewayV1, GatewayV2
+from givenergy_modbus.model.inverter import Model
+from givenergy_modbus.model.plant import Plant, PlantCapabilities
+from givenergy_modbus.model.register import IR
+from givenergy_modbus.model.register_cache import RegisterCache
+from tests.model.test_devices import _add_rollup_slot, _encode_serial
+
+
+def _battery_cache(serial: str) -> RegisterCache:
+    """A battery register cache carrying a valid serial in IR(110..114)."""
+    return RegisterCache({IR(110 + i): v for i, v in _encode_serial(serial).items()})
+
+
+def test_devices_ems_plant_enumerates_managed_inverters_and_ems_without_misclassification():
+    """EMS plant: managed inverters become INVERTER rows; the EMS is its own EMS row.
+
+    The headline #106 fix — an EMS controller must NEVER appear as an INVERTER
+    row (hass#52). Two managed slots → two INVERTER rows + exactly one EMS row,
+    and no inverter row ever wraps the Ems.
+    """
+    values: dict = {IR(2040): 1, IR(2044): 2}
+    _add_rollup_slot(values, 1, serial="XX1234A567", power=1800, soc=65)
+    _add_rollup_slot(values, 2, serial="ZZ9876B543", power=2200, soc=78)
+    plant = Plant()
+    plant.capabilities = PlantCapabilities(device_type=Model.EMS, inverter_address=0x32)
+    plant.register_caches[0x32] = RegisterCache(values)
+
+    devices = plant.devices
+    by_type = [d.device_type for d in devices]
+
+    assert by_type.count(DeviceType.INVERTER) == 2
+    assert by_type.count(DeviceType.EMS) == 1
+    assert DeviceType.GATEWAY not in by_type
+
+    inverter_rows = [d for d in devices if d.device_type is DeviceType.INVERTER]
+    assert {d.serial_number for d in inverter_rows} == {"XX1234A567", "ZZ9876B543"}
+    assert all(isinstance(d.device, Inverter) for d in inverter_rows)
+    # No mis-classification: the EMS is never wrapped as an inverter.
+    assert not any(isinstance(d.device, Ems) for d in inverter_rows)
+    # Blinded managed inverters have an unknown own-model (the plant model is EMS).
+    assert all(d.model is None for d in inverter_rows)
+
+    ems_row = next(d for d in devices if d.device_type is DeviceType.EMS)
+    assert isinstance(ems_row.device, Ems)
+    assert ems_row.model is Model.EMS
+
+
+def test_devices_batteries_are_typed_rows_with_serials_and_back_compat_preserved():
+    """Non-EMS plant: one INVERTER row plus a BATTERY row per pack, with serials.
+
+    The legacy ``Plant.batteries`` accessor stays untouched (same list, same
+    types) — proving the enumeration is purely additive.
+    """
+    plant = Plant()
+    plant.capabilities = PlantCapabilities(
+        device_type=Model.HYBRID_GEN3,
+        inverter_address=0x31,
+        lv_battery_addresses=[0x32, 0x33],
+    )
+    plant.register_caches[0x32] = _battery_cache("XX1234A567")
+    plant.register_caches[0x33] = _battery_cache("ZZ9876B543")
+
+    devices = plant.devices
+
+    assert [d.device_type for d in devices].count(DeviceType.INVERTER) == 1
+    battery_rows = [d for d in devices if d.device_type is DeviceType.BATTERY]
+    assert {d.serial_number for d in battery_rows} == {"XX1234A567", "ZZ9876B543"}
+
+    # Back-compat: legacy accessor unchanged.
+    assert len(plant.batteries) == 2
+    assert {b.serial_number for b in plant.batteries} == {"XX1234A567", "ZZ9876B543"}
+
+
+def test_devices_gateway_plant_emits_single_gateway_row_and_no_spurious_inverter():
+    """Gateway plant: exactly one GATEWAY row and ZERO inverter rows.
+
+    On a gateway plant the singular ``Plant.inverter`` decodes the gateway's
+    own cache as an inverter — a spurious row. ``Plant.devices`` suppresses it.
+    """
+    plant = Plant()
+    plant.capabilities = PlantCapabilities(device_type=Model.GATEWAY, inverter_address=0x11)
+    plant.register_caches[0x11] = RegisterCache()
+
+    devices = plant.devices
+    by_type = [d.device_type for d in devices]
+
+    assert by_type.count(DeviceType.GATEWAY) == 1
+    assert DeviceType.INVERTER not in by_type
+    gw_row = next(d for d in devices if d.device_type is DeviceType.GATEWAY)
+    assert isinstance(gw_row.device, (GatewayV1, GatewayV2))
+    assert gw_row.model is Model.GATEWAY
+
+
+def test_devices_enumerates_meters_and_hv_stacks_with_correct_types():
+    """Meters and HV stacks surface as typed rows (serials optional this phase)."""
+    plant = Plant()
+    plant.capabilities = PlantCapabilities(
+        device_type=Model.HYBRID_GEN3,
+        inverter_address=0x11,
+        meter_addresses=[0x01],
+        bcu_stacks=[(0, 2)],
+    )
+    plant.register_caches[0x11] = RegisterCache()
+    plant.register_caches[0x01] = RegisterCache()
+    plant.register_caches[0x70] = RegisterCache()
+
+    by_type = [d.device_type for d in plant.devices]
+    assert by_type.count(DeviceType.METER) == 1
+    assert by_type.count(DeviceType.HV_STACK) == 1


### PR DESCRIPTION
## Summary

- Adds `DeviceType` (str enum: `inverter`, `ems`, `gateway`, `battery`, `meter`, `hv_stack`) and `PlantDevice` (frozen dataclass with `device_type`, `device`, `serial_number`, `model`) to `givenergy_modbus/model/devices.py`, kept import-clean of concrete Modbus/GE types for future hoisting.
- Adds `Plant.devices` property composing all existing accessors into a typed enumeration — strictly additive; no existing accessor is touched.
- **Headline fix** (hass#52): an EMS or Gateway controller can no longer appear as an `INVERTER` row. EMS plants enumerate managed inverters as `INVERTER` rows (with rollup serials) plus one `EMS` row; Gateway plants emit a single `GATEWAY` row and suppress the spurious `Plant.inverter`-from-gateway-cache row.
- Adds architecture spec `docs/plant-device-graph.md` with the full phased rollout plan (P1 = this; P2 = per-inverter battery ownership; P3 = Transport abstraction; P4 = model-aware write-routing), cross-linked from `docs/v2.1-roadmap.md`.

## Test plan

- [ ] `tests/model/test_devices.py` — unit tests for `DeviceType` membership/values, `PlantDevice` construction, read-through, frozen enforcement
- [ ] `tests/model/test_plant_devices.py` — in-memory plant integration tests: EMS (no mis-classification), non-EMS with batteries (back-compat), Gateway (no spurious inverter), meters + HV stacks
- [ ] Full suite: 814 tests, no regressions
- [ ] `uv run ruff check --fix && uv run ruff format` — clean
- [ ] `uv run tox` (py311–py314 + lint + build) — all green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)