### PR TITLE
feat(model): per-inverter battery & HV-stack ownership (#106 Phase 2)

### DIFF
--- a/docs/plant-device-graph.md
+++ b/docs/plant-device-graph.md
@@ -83,12 +83,42 @@ where meaningful, and the already-decoded typed model.
 Consumers (Home Assistant) can now enumerate typed devices to name and scope
 entities per device-type instead of assuming a single inverter.
 
-### Phase 2 — per-inverter battery ownership
+> **Superseded by Phase 2:** Phase 1 emitted batteries and HV stacks as
+> top-level `BATTERY` / `HV_STACK` rows. Phase 2 nests them under their owning
+> inverter instead (see below). The `DeviceType.BATTERY` / `HV_STACK` members
+> remain the vocabulary; `Plant.devices` now surfaces them via
+> `inverter_row.device.batteries` / `.hv_stacks`.
 
-Move batteries under their owning inverter (`Inverter.batteries`) with
-reconciliation by serial. **Breaking** for consumers that enumerate a flat
-`Plant.batteries` at setup time, so it ships behind a capability flag with a
-consumer migration. Depends on serial reconciliation maturing.
+### Phase 2 — per-inverter battery & HV-stack ownership ✅ (this increment)
+
+Batteries and HV stacks **belong to an inverter**, not directly to the plant, so
+`Plant.devices` now nests them under their owning `INVERTER` row
+(`inverter_row.device.batteries` / `.hv_stacks`) instead of emitting flat rows.
+The `Inverter` facade's `batteries` / `hv_stacks` (a `[]` stub in Phase 1) are
+populated by `Plant`, which decodes the sub-devices and injects them — keeping
+`devices.py` import-clean of concrete `Battery` / `HvStack` / `RegisterCache`
+types.
+
+- **The model layer stays additive.** `Plant.batteries` / `Plant.hv_stacks` (and
+  every other legacy accessor) are unchanged and still return their flat lists.
+  Only the `Inverter` facade gained populated sub-devices, and `Plant.devices`
+  changed its row shape.
+- **Ownership is unambiguous today.** A plant has exactly one *directly-reachable*
+  inverter, which owns every battery / stack in the plant cache. Blinded
+  (EMS-rollup) inverters honestly carry `[]` — the rollup exposes no per-battery
+  data.
+- **Orphan guard.** A gateway plant suppresses its (spurious) inverter row, so
+  there's no inverter to nest under; any stack the plant decoded there is kept as
+  a flat row rather than dropped.
+
+**What's deferred to Phase 3 (the original spec's "reconciliation by serial").**
+The spec framed this phase as breaking, behind a capability flag, *with serial
+reconciliation*. That reconciliation only bites once a plant has **multiple
+direct inverters or a merged direct+rollup view** — which needs the multi-Client
+work below. On today's single-Client plants there is nothing to reconcile, so
+this increment ships the honest additive slice and defers reconciliation to
+Phase 3. The `Plant.devices` row-shape change is breaking versus 2.1.5 but had no
+production consumer yet; it lands on the v2.2 line.
 
 ### Phase 3 — `Transport` abstraction / multi-Client
 
@@ -107,8 +137,8 @@ Reconciles with [#203](https://github.com/dewet22/givenergy-modbus/issues/203).
 
 `register_caches` stays flat; `RegisterCache` stays a Modbus detail; no
 serial-product (FC 0x16) reads are added for controller rows — EMS and Gateway
-controller rows carry `serial_number=None` until a later phase. Per-inverter
-battery ownership, multi-transport, and write-routing are Phases 2–4 above.
+controller rows carry `serial_number=None` until a later phase. Serial
+reconciliation, multi-transport, and write-routing are Phases 3–4 above.
 
 **Known Phase 1 limitation — meter identity.** `Meter` carries no `device_address`
 field; the address is the dict key in `Plant.meters` and is lost when iterating

--- a/givenergy_modbus/model/devices.py
+++ b/givenergy_modbus/model/devices.py
@@ -104,26 +104,41 @@ class Inverter:
     concern via the underlying sources.
     """
 
-    __slots__ = ("data_source", "_direct", "_summary")
+    __slots__ = ("data_source", "_direct", "_summary", "_batteries", "_hv_stacks")
 
     def __init__(
         self,
         data_source: DataSource,
         direct: Any | None = None,
         summary: InverterSummary | None = None,
+        batteries: list[Any] | None = None,
+        hv_stacks: list[Any] | None = None,
     ) -> None:
         """Construct directly (prefer the factory methods).
 
         The constructor is permissive about which source is present so
         the class can be tested with mocks; the factories enforce the
         invariant that ``data_source`` matches the supplied sources.
+
+        ``batteries`` / ``hv_stacks`` are the inverter's sub-devices,
+        already-decoded and injected by :class:`Plant` (#106 Phase 2).
+        They're typed ``Any`` so this module stays import-clean of the
+        concrete ``Battery`` / ``HvStack`` / ``RegisterCache`` types.
         """
         self.data_source = data_source
         self._direct = direct
         self._summary = summary
+        self._batteries = batteries
+        self._hv_stacks = hv_stacks
 
     @classmethod
-    def from_direct(cls, direct: Any) -> Inverter:
+    def from_direct(
+        cls,
+        direct: Any,
+        *,
+        batteries: list[Any] | None = None,
+        hv_stacks: list[Any] | None = None,
+    ) -> Inverter:
         """Construct from a directly-reachable concrete inverter model.
 
         ``direct`` is duck-typed: anything exposing the standard inverter
@@ -134,29 +149,48 @@ class Inverter:
         only directly exposed on :class:`ThreePhaseInverter`;
         single-phase direct sources will return ``None`` for that field
         unless the rollup ``summary`` is also merged in.
+
+        ``batteries`` / ``hv_stacks`` are the sub-devices owned by this
+        inverter, injected by :class:`Plant` (#106 Phase 2).
         """
-        return cls(data_source="direct", direct=direct)
+        return cls(data_source="direct", direct=direct, batteries=batteries, hv_stacks=hv_stacks)
 
     @classmethod
     def from_summary(cls, summary: InverterSummary) -> Inverter:
         """Construct from a rollup summary (e.g. EMS-managed, no direct dongle).
 
-        The resulting inverter is "blinded": :attr:`batteries` is empty,
-        per-PV-string fields aren't available. Consumers see the same
-        interface as a directly-reachable inverter, just with fewer
-        populated fields.
+        The resulting inverter is "blinded": :attr:`batteries` and
+        :attr:`hv_stacks` are empty, per-PV-string fields aren't
+        available. Consumers see the same interface as a directly-reachable
+        inverter, just with fewer populated fields.
         """
         return cls(data_source="ems_rollup", summary=summary)
 
     @classmethod
-    def merge(cls, direct: Any, summary: InverterSummary) -> Inverter:
+    def merge(
+        cls,
+        direct: Any,
+        summary: InverterSummary,
+        *,
+        batteries: list[Any] | None = None,
+        hv_stacks: list[Any] | None = None,
+    ) -> Inverter:
         """Construct from a direct source reconciled with a rollup summary.
 
         Reconciliation is the caller's responsibility (typically matching
         on serial number at end of detect). Once merged, direct fields
         are preferred; the summary fills any gap the direct source has.
+
+        ``batteries`` / ``hv_stacks`` are the sub-devices owned by this
+        inverter, injected by :class:`Plant` (#106 Phase 2).
         """
-        return cls(data_source="merged", direct=direct, summary=summary)
+        return cls(
+            data_source="merged",
+            direct=direct,
+            summary=summary,
+            batteries=batteries,
+            hv_stacks=hv_stacks,
+        )
 
     # ------------------------------------------------------------------
     # Identity
@@ -242,17 +276,23 @@ class Inverter:
 
     @property
     def batteries(self) -> list[Any]:
-        """List of batteries attached to this inverter.
+        """List of LV battery packs owned by this inverter (#106 Phase 2).
 
-        Empty list when the inverter is blinded — we honestly do not
-        know what batteries (if any) are attached, since the EMS rollup
-        does not expose per-battery serials or SoC. Phase 2 of the Plant
-        refactor populates this from the inverter's own register cache;
-        for now phase 1 conservatively returns ``[]`` for all sources
-        because the legacy ``Plant.batteries`` accessor already serves
-        directly-reachable installs.
+        Populated by :class:`Plant`, which decodes the packs from this
+        inverter's register caches and injects them. Empty when the
+        inverter is blinded — the EMS rollup exposes no per-battery
+        serials or SoC, so we honestly cannot see what's attached.
         """
-        return []
+        return self._batteries or []
+
+    @property
+    def hv_stacks(self) -> list[Any]:
+        """List of HV battery stacks (BCU + BMUs) owned by this inverter (#106 Phase 2).
+
+        Populated by :class:`Plant` from this inverter's register caches.
+        Empty when blinded, mirroring :attr:`batteries`.
+        """
+        return self._hv_stacks or []
 
     # ------------------------------------------------------------------
     # Diagnostics

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -787,7 +787,11 @@ class Plant(GivEnergyBaseModel):
         """
         if self.ems is not None:
             return [UnifiedInverter.from_summary(s) for s in self.ems.managed_inverters]
-        return [UnifiedInverter.from_direct(self.inverter)]
+        # The single direct inverter owns every battery / HV stack in the plant
+        # cache (#106 Phase 2). Inject the already-decoded sub-devices so the
+        # facade can expose ownership without importing concrete Battery /
+        # HvStack types. Splitting across multiple direct inverters is Phase 3.
+        return [UnifiedInverter.from_direct(self.inverter, batteries=self.batteries, hv_stacks=self.hv_stacks)]
 
     @property
     def gateway(self) -> GatewayV1 | GatewayV2 | None:
@@ -801,14 +805,19 @@ class Plant(GivEnergyBaseModel):
     def devices(self) -> list[PlantDevice]:
         """Enumerate every device on this plant as typed :class:`PlantDevice` rows.
 
-        Additive surface (#106 Phase 1): each row carries a generic
-        :class:`DeviceType` discriminator, a serial (where the device exposes a
-        valid one), the plant's model where meaningful, and the already-decoded
-        typed model in :attr:`PlantDevice.device`. Built by composing the
-        existing accessors — :attr:`inverters`, :attr:`ems`, :attr:`gateway`,
-        :attr:`batteries`, :attr:`meters`, :attr:`hv_stacks` — so the
+        Each row carries a generic :class:`DeviceType` discriminator, a serial
+        (where the device exposes a valid one), the plant's model where
+        meaningful, and the already-decoded typed model in
+        :attr:`PlantDevice.device`. Built by composing the existing accessors —
+        :attr:`inverters`, :attr:`ems`, :attr:`gateway`, :attr:`meters` — so the
         EMS-rollup-vs-direct decision is honoured once and a controller (EMS or
         gateway) can never appear as an ``INVERTER`` row.
+
+        Batteries and HV stacks are **owned by their inverter** (#106 Phase 2):
+        they ride on the ``INVERTER`` row's ``device.batteries`` /
+        ``device.hv_stacks`` rather than as top-level rows. Meters are not
+        inverter-owned, so they stay flat rows (the Phase 1 meter-identity
+        limitation).
         """
         caps = self.capabilities
         model = caps.device_type if caps else None
@@ -820,6 +829,7 @@ class Plant(GivEnergyBaseModel):
         # On a gateway plant the singular ``inverter`` decodes the gateway's own
         # cache as a spurious inverter — suppress that row; the GATEWAY row below
         # represents the device instead.
+        inverter_emitted = False
         if not (caps and caps.is_gateway):
             for inverter in self.inverters:
                 rows.append(
@@ -832,6 +842,7 @@ class Plant(GivEnergyBaseModel):
                         model=None if inverter.is_blinded else inverter_model,
                     )
                 )
+                inverter_emitted = True
 
         if (ems := self.ems) is not None:
             rows.append(PlantDevice(device_type=DeviceType.EMS, device=ems, model=model))
@@ -839,14 +850,28 @@ class Plant(GivEnergyBaseModel):
         if (gateway := self.gateway) is not None:
             rows.append(PlantDevice(device_type=DeviceType.GATEWAY, device=gateway, model=model))
 
-        for battery in self.batteries:
-            rows.append(
-                PlantDevice(
-                    device_type=DeviceType.BATTERY,
-                    device=battery,
-                    serial_number=_validated_serial(battery),
+        # Batteries / HV stacks nest under their inverter via the injected
+        # ``inverter.batteries`` / ``.hv_stacks`` (see :attr:`inverters`). The
+        # only case with no inverter row to carry them is a gateway plant, where
+        # the inverter is suppressed — emit those as flat rows rather than drop
+        # them (orphan guard; proper partner-AIO expansion is a later phase).
+        if not inverter_emitted:
+            for battery in self.batteries:
+                rows.append(
+                    PlantDevice(
+                        device_type=DeviceType.BATTERY,
+                        device=battery,
+                        serial_number=_validated_serial(battery),
+                    )
                 )
-            )
+            for stack in self.hv_stacks:
+                rows.append(
+                    PlantDevice(
+                        device_type=DeviceType.HV_STACK,
+                        device=stack,
+                        serial_number=_validated_serial(stack.bcu),
+                    )
+                )
 
         for meter in self.meters.values():
             rows.append(
@@ -854,15 +879,6 @@ class Plant(GivEnergyBaseModel):
                     device_type=DeviceType.METER,
                     device=meter,
                     serial_number=_validated_serial(meter),
-                )
-            )
-
-        for stack in self.hv_stacks:
-            rows.append(
-                PlantDevice(
-                    device_type=DeviceType.HV_STACK,
-                    device=stack,
-                    serial_number=_validated_serial(stack.bcu),
                 )
             )
 

--- a/tests/model/test_devices.py
+++ b/tests/model/test_devices.py
@@ -185,6 +185,53 @@ def test_blinded_inverter_reports_empty_batteries():
     """
     inv = Inverter.from_summary(InverterSummary(serial_number="XX1234A567"))
     assert inv.batteries == []
+    assert inv.hv_stacks == []
+
+
+def test_direct_inverter_exposes_injected_batteries_and_hv_stacks():
+    """from_direct() surfaces the sub-devices Plant injects (#106 Phase 2).
+
+    The facade does not decode — Plant decodes batteries / HV stacks from
+    the register caches and hands them in, keeping ``devices.py`` import-clean
+    of concrete Battery / HvStack / RegisterCache types.
+    """
+
+    class FakeDirect:
+        serial_number = "ZZ9876B543"
+        status = Status.NORMAL
+
+    b1, b2, stack = object(), object(), object()
+    inv = Inverter.from_direct(FakeDirect(), batteries=[b1, b2], hv_stacks=[stack])
+
+    assert inv.batteries == [b1, b2]
+    assert inv.hv_stacks == [stack]
+
+
+def test_direct_inverter_without_injected_sub_devices_is_empty():
+    """from_direct() with no sub-devices injected reports empty lists, not None."""
+
+    class FakeDirect:
+        serial_number = "ZZ9876B543"
+        status = Status.NORMAL
+
+    inv = Inverter.from_direct(FakeDirect())
+    assert inv.batteries == []
+    assert inv.hv_stacks == []
+
+
+def test_merged_inverter_exposes_injected_sub_devices():
+    """merge() also carries injected sub-devices — direct merges keep their batteries."""
+
+    class FakeDirect:
+        serial_number = "ZZ9876B543"
+        status = Status.NORMAL
+
+    b1 = object()
+    summary = InverterSummary(serial_number="ZZ9876B543", p_inverter_out=2200)
+    inv = Inverter.merge(FakeDirect(), summary, batteries=[b1])
+
+    assert inv.batteries == [b1]
+    assert inv.hv_stacks == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/model/test_plant_devices.py
+++ b/tests/model/test_plant_devices.py
@@ -173,6 +173,28 @@ def test_devices_gateway_orphan_stacks_kept_as_flat_rows():
     assert by_type.count(DeviceType.HV_STACK) == 1
 
 
+def test_devices_gateway_orphan_batteries_kept_as_flat_rows():
+    """Gateway plant with stray LV batteries: keep them as flat rows, never drop them.
+
+    Mirrors the HV-stack orphan guard — the gateway suppresses its (spurious)
+    inverter row, so there's no inverter to nest batteries under. The orphan
+    guard emits flat BATTERY rows rather than silently losing them.
+    """
+    plant = Plant()
+    plant.capabilities = PlantCapabilities(
+        device_type=Model.GATEWAY,
+        inverter_address=0x11,
+        lv_battery_addresses=[0x32],
+    )
+    plant.register_caches[0x11] = RegisterCache()
+    plant.register_caches[0x32] = _battery_cache("XX1234A567")
+
+    by_type = [d.device_type for d in plant.devices]
+    assert by_type.count(DeviceType.GATEWAY) == 1
+    assert DeviceType.INVERTER not in by_type
+    assert by_type.count(DeviceType.BATTERY) == 1
+
+
 def test_devices_enumerates_meters_as_flat_rows():
     """Meters surface as top-level rows — they aren't inverter-owned (Phase 1 limitation)."""
     plant = Plant()

--- a/tests/model/test_plant_devices.py
+++ b/tests/model/test_plant_devices.py
@@ -1,10 +1,15 @@
-"""Tests for ``Plant.devices`` — the typed-device enumeration API (#106 Phase 1).
+"""Tests for ``Plant.devices`` — typed-device enumeration with nested ownership.
 
-These verify three things in concert: correct typed enumeration, no
-mis-classification (an EMS / gateway controller must never surface as an
-inverter), and that the existing ``Plant`` accessors are untouched (the API
-is strictly additive). Plants are constructed in-memory, matching the idiom
-in ``test_devices.py`` for the ``Plant.inverters`` tests.
+#106 Phase 1 added the flat enumeration. Phase 2 nests batteries and HV stacks
+**under their owning inverter** (``inverter_row.device.batteries`` /
+``.hv_stacks``) instead of emitting them as top-level rows — batteries and stacks
+belong to an inverter, not directly to the plant. The legacy ``Plant.batteries``
+/ ``Plant.hv_stacks`` accessors are unchanged (the model layer stays additive).
+
+These verify: correct typed enumeration, no mis-classification (an EMS / gateway
+controller must never surface as an inverter), nested sub-device ownership, the
+gateway orphan guard, and that the legacy accessors still return their flat lists.
+Plants are constructed in-memory, matching the idiom in ``test_devices.py``.
 """
 
 from givenergy_modbus.model.devices import DeviceType, Inverter
@@ -27,7 +32,8 @@ def test_devices_ems_plant_enumerates_managed_inverters_and_ems_without_misclass
 
     The headline #106 fix — an EMS controller must NEVER appear as an INVERTER
     row (hass#52). Two managed slots → two INVERTER rows + exactly one EMS row,
-    and no inverter row ever wraps the Ems.
+    and no inverter row ever wraps the Ems. Blinded inverters carry no
+    sub-devices (the rollup can't see batteries).
     """
     values: dict = {IR(2040): 1, IR(2044): 2}
     _add_rollup_slot(values, 1, serial="XX1234A567", power=1800, soc=65)
@@ -50,17 +56,22 @@ def test_devices_ems_plant_enumerates_managed_inverters_and_ems_without_misclass
     assert not any(isinstance(d.device, Ems) for d in inverter_rows)
     # Blinded managed inverters have an unknown own-model (the plant model is EMS).
     assert all(d.model is None for d in inverter_rows)
+    # Blinded inverters honestly carry no sub-devices.
+    assert all(d.device.batteries == [] for d in inverter_rows)
+    assert all(d.device.hv_stacks == [] for d in inverter_rows)
 
     ems_row = next(d for d in devices if d.device_type is DeviceType.EMS)
     assert isinstance(ems_row.device, Ems)
     assert ems_row.model is Model.EMS
 
 
-def test_devices_batteries_are_typed_rows_with_serials_and_back_compat_preserved():
-    """Non-EMS plant: one INVERTER row plus a BATTERY row per pack, with serials.
+def test_devices_batteries_nest_under_their_inverter_and_back_compat_preserved():
+    """Non-EMS plant: LV batteries nest under the inverter, not as top-level rows.
 
-    The legacy ``Plant.batteries`` accessor stays untouched (same list, same
-    types) — proving the enumeration is purely additive.
+    No flat BATTERY rows are emitted; both packs ride on the single INVERTER
+    row's ``device.batteries`` with serials intact. The legacy ``Plant.batteries``
+    accessor stays untouched (same list, same serials) — the model layer is
+    additive.
     """
     plant = Plant()
     plant.capabilities = PlantCapabilities(
@@ -68,18 +79,54 @@ def test_devices_batteries_are_typed_rows_with_serials_and_back_compat_preserved
         inverter_address=0x31,
         lv_battery_addresses=[0x32, 0x33],
     )
+    plant.register_caches[0x31] = RegisterCache()
     plant.register_caches[0x32] = _battery_cache("XX1234A567")
     plant.register_caches[0x33] = _battery_cache("ZZ9876B543")
 
     devices = plant.devices
+    by_type = [d.device_type for d in devices]
 
-    assert [d.device_type for d in devices].count(DeviceType.INVERTER) == 1
-    battery_rows = [d for d in devices if d.device_type is DeviceType.BATTERY]
-    assert {d.serial_number for d in battery_rows} == {"XX1234A567", "ZZ9876B543"}
+    # Nested, not flat: exactly one INVERTER row, zero top-level BATTERY rows.
+    assert by_type.count(DeviceType.INVERTER) == 1
+    assert DeviceType.BATTERY not in by_type
 
-    # Back-compat: legacy accessor unchanged.
+    inverter_row = next(d for d in devices if d.device_type is DeviceType.INVERTER)
+    nested = inverter_row.device.batteries
+    assert len(nested) == 2
+    assert {b.serial_number for b in nested} == {"XX1234A567", "ZZ9876B543"}
+
+    # Back-compat: legacy flat accessor unchanged.
     assert len(plant.batteries) == 2
     assert {b.serial_number for b in plant.batteries} == {"XX1234A567", "ZZ9876B543"}
+
+
+def test_devices_hv_stacks_nest_under_their_inverter():
+    """HV plant (AIO): HV stacks nest under the inverter, not as top-level rows.
+
+    Mirrors LV battery nesting for the HV (BCU/BMU) topology. The inverter row's
+    ``device.hv_stacks`` carries the stack; no flat HV_STACK row is emitted; the
+    legacy ``Plant.hv_stacks`` accessor is unchanged.
+    """
+    plant = Plant()
+    plant.capabilities = PlantCapabilities(
+        device_type=Model.ALL_IN_ONE,
+        inverter_address=0x11,
+        bcu_stacks=[(0, 2)],
+    )
+    plant.register_caches[0x11] = RegisterCache()
+    plant.register_caches[0x70] = RegisterCache()
+
+    devices = plant.devices
+    by_type = [d.device_type for d in devices]
+
+    assert by_type.count(DeviceType.INVERTER) == 1
+    assert DeviceType.HV_STACK not in by_type
+
+    inverter_row = next(d for d in devices if d.device_type is DeviceType.INVERTER)
+    assert len(inverter_row.device.hv_stacks) == 1
+
+    # Back-compat: legacy flat accessor unchanged.
+    assert len(plant.hv_stacks) == 1
 
 
 def test_devices_gateway_plant_emits_single_gateway_row_and_no_spurious_inverter():
@@ -102,19 +149,41 @@ def test_devices_gateway_plant_emits_single_gateway_row_and_no_spurious_inverter
     assert gw_row.model is Model.GATEWAY
 
 
-def test_devices_enumerates_meters_and_hv_stacks_with_correct_types():
-    """Meters and HV stacks surface as typed rows (serials optional this phase)."""
+def test_devices_gateway_orphan_stacks_kept_as_flat_rows():
+    """Gateway plant with a stray HV stack: keep it as a flat row, never drop it.
+
+    The gateway suppresses its (spurious) inverter row, so there's no inverter
+    to nest sub-devices under. Rather than silently lose a stack the plant did
+    decode, the orphan guard emits a flat HV_STACK row. (Proper gateway
+    partner-AIO expansion is deferred to a later phase.)
+    """
+    plant = Plant()
+    plant.capabilities = PlantCapabilities(
+        device_type=Model.GATEWAY,
+        inverter_address=0x11,
+        bcu_stacks=[(0, 2)],
+    )
+    plant.register_caches[0x11] = RegisterCache()
+    plant.register_caches[0x70] = RegisterCache()
+
+    by_type = [d.device_type for d in plant.devices]
+    assert by_type.count(DeviceType.GATEWAY) == 1
+    assert DeviceType.INVERTER not in by_type
+    # Not lost: the stray stack surfaces as a flat row.
+    assert by_type.count(DeviceType.HV_STACK) == 1
+
+
+def test_devices_enumerates_meters_as_flat_rows():
+    """Meters surface as top-level rows — they aren't inverter-owned (Phase 1 limitation)."""
     plant = Plant()
     plant.capabilities = PlantCapabilities(
         device_type=Model.HYBRID_GEN3,
         inverter_address=0x11,
         meter_addresses=[0x01],
-        bcu_stacks=[(0, 2)],
     )
     plant.register_caches[0x11] = RegisterCache()
     plant.register_caches[0x01] = RegisterCache()
-    plant.register_caches[0x70] = RegisterCache()
 
     by_type = [d.device_type for d in plant.devices]
     assert by_type.count(DeviceType.METER) == 1
-    assert by_type.count(DeviceType.HV_STACK) == 1
+    assert by_type.count(DeviceType.INVERTER) == 1


### PR DESCRIPTION
## Summary

- **`Inverter.batteries` / `.hv_stacks` populated**: `from_direct` and `merge` now accept `batteries` / `hv_stacks` keyword args; `Plant.inverters` injects the decoded sub-devices, keeping `devices.py` import-clean of concrete types. Blinded (EMS-rollup) inverters honestly carry `[]`.
- **`Plant.devices` nests sub-devices under INVERTER rows**: flat `BATTERY` / `HV_STACK` rows are gone; both LV batteries and HV stacks now live on `inverter_row.device.batteries` / `.hv_stacks`. Meters remain flat (Phase 1 limitation — no `device_address` on `Meter`).
- **Orphan guard**: when a gateway plant suppresses the (spurious) inverter row, any batteries / stacks that would have nested under it are emitted as flat rows rather than dropped.
- **Model layer stays additive**: `Plant.batteries`, `Plant.hv_stacks`, `Plant.number_batteries`, every other legacy accessor — all untouched.

## Why reconciliation by serial is deferred to Phase 3

The original spec framed Phase 2 as breaking (behind a capability flag, with serial reconciliation). Reconciliation only bites when a plant has multiple direct inverters or a merged direct+rollup view — which requires the multi-Client transport abstraction (#75 / Phase 3). On today's single-Client plants the one direct inverter trivially owns every battery in the cache, so this increment ships the honest additive slice and defers reconciliation to Phase 3.

## Consumer note (`Plant.devices` shape change vs 2.1.5)

The `Plant.devices` row shape is breaking versus Phase 1 (2.1.5), but that surface had no production consumer yet — this PR targets `v2.2`. Consumers (Home Assistant) should enumerate batteries via `inverter_row.device.batteries`, not by filtering for flat `BATTERY` rows.

## Test plan

- [ ] `tests/model/test_devices.py` — 4 new `Inverter` facade unit tests (injected batteries & HV stacks on `from_direct`/`merge`; blinded → `[]`)
- [ ] `tests/model/test_plant_devices.py` — fully rewritten to the nested contract (LV batteries, HV stacks, EMS blinded inverters, gateway orphan guard, meters flat, back-compat)
- [ ] 819 tests passing; `ruff check --fix` + `ruff format` clean; `tox` (py311–py314 + lint + build) exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)