### PR TITLE
feat(model)!: remove unreliable first_battery_serial_number (#191)

### DIFF
--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -90,6 +90,13 @@ def _build_serial_register_groups() -> "list[tuple[str, int, int]]":
                     if key not in seen:
                         seen.add(key)
                         groups.append(key)
+    # Legacy first_battery_serial_number registers (HR 8-12) — removed from the LUT
+    # (#191: GivTCP-heritage, unused, unverifiable), but still redacted: AIO firmware
+    # stores the unit serial here byte-swapped (CH… → HC…), recoverable to the real
+    # serial, so it must not leak in shared captures. Appended unconditionally — no LUT
+    # Def carries it any more, and a duplicate (if a future field re-used HR 8) would
+    # only redact it twice, which is idempotent.
+    groups.append(("HR", 8, 5))
     return groups
 
 

--- a/givenergy_modbus/model/inverter.py
+++ b/givenergy_modbus/model/inverter.py
@@ -411,7 +411,10 @@ class SinglePhaseInverterRegisterGetter(RegisterGetter):
         "num_phases": Def((C.duint8, 1), None, HR(3)),
         # HR(4-6) unused
         "enable_ammeter": Def(C.bool, None, HR(7)),
-        "first_battery_serial_number": Def(C.serial, None, HR(8), HR(9), HR(10), HR(11), HR(12)),
+        # HR(8-12) was first_battery_serial_number — removed (#191): GivTCP-heritage,
+        # unused, unverifiable; on AIO firmware it held the unit serial byte-swapped,
+        # not a battery serial. Still redacted in captures via an explicit serial group
+        # in client._build_serial_register_groups (recoverable to the real serial).
         "serial_number": Def(C.serial, None, HR(13), HR(14), HR(15), HR(16), HR(17)),
         "first_battery_bms_firmware_version": Def(C.uint16, None, HR(18)),
         "dsp_firmware_version": Def(C.uint16, None, HR(19)),

--- a/givenergy_modbus/model/register_cache.py
+++ b/givenergy_modbus/model/register_cache.py
@@ -62,6 +62,11 @@ def _get_serial_groups() -> "list[tuple[str, int, int]]":
         if key not in seen:
             seen.add(key)
             groups.append(key)
+    # Legacy first_battery_serial_number registers (HR 8-12) — removed from the LUT
+    # (#191), but still redacted: AIO firmware stores the unit serial here byte-swapped
+    # (CH… → HC…), recoverable to the real serial, so it must not leak in a shared
+    # export. Appended explicitly, like the BMU serials, since no LUT Def carries it.
+    groups.append(("HR", 8, 5))
     _SERIAL_GROUPS = groups
     return _SERIAL_GROUPS
 

--- a/tests/client/test_capture.py
+++ b/tests/client/test_capture.py
@@ -114,6 +114,31 @@ def test_frame_redactor_redacts_payload_inverter_serial():
     assert len(out) == len(frame)
 
 
+def test_frame_redactor_redacts_hr8_serial_register():
+    """HR(8-12) is still redacted after first_battery_serial_number was removed (#191).
+
+    The field was dropped from the LUT, but AIO firmware stores the unit serial here
+    byte-swapped (recoverable to the real serial), so HR(8-12) must stay in the
+    redaction set via an explicit group. Guards against a silent privacy regression.
+    """
+    from givenergy_modbus.pdu import ClientIncomingMessage
+
+    serial_str = "HC2114G047"  # AIO-style byte-swapped copy lives at HR(8-12)
+    serial_regs = [int.from_bytes(serial_str[i * 2 : i * 2 + 2].encode("latin1"), "big") for i in range(5)]
+    values = [0] * 60
+    values[8:13] = serial_regs
+
+    frame = _make_holding_response("ZZ0000H000", base=0, values=values)
+    r = FrameRedactor()
+    out = r.feed(frame) + r.flush()
+
+    pdu = ClientIncomingMessage.decode_bytes(out)
+    raw = b"".join(pdu.register_values[8 + i].to_bytes(2, "big") for i in range(5))
+    redacted_serial = raw.decode("latin1").replace("\x00", "").upper()
+    assert redacted_serial == "HC2114G000"  # date kept, unit digits zeroed
+    assert len(out) == len(frame)
+
+
 def test_frame_redactor_invalid_frame_emitted_intact():
     """An undecodable frame (bad MBAP / unknown function) is emitted intact, not dropped."""
     # Build a syntactically valid GivEnergy MBAP wrapping an unknown function code

--- a/tests/model/test_inverter.py
+++ b/tests/model/test_inverter.py
@@ -18,7 +18,19 @@ from givenergy_modbus.model.inverter import (
     inverter_address_for,
     resolve_model,
 )
+from givenergy_modbus.model.register import HR
 from givenergy_modbus.model.register_cache import RegisterCache
+
+
+def test_first_battery_serial_number_removed():
+    """first_battery_serial_number is gone from the model (#191).
+
+    GivTCP-heritage, unused, and unverifiable: on AIO firmware it held the unit serial
+    byte-swapped, not a battery serial. Removed outright — no field, no alias.
+    """
+    assert "first_battery_serial_number" not in SinglePhaseInverter().model_dump()
+    cache = RegisterCache({HR(8): 0x4843, HR(9): 0x3234, HR(10): 0x3134, HR(11): 0x4731, HR(12): 0x3637})
+    assert "first_battery_serial_number" not in SinglePhaseInverter.from_register_cache(cache).model_dump()
 
 
 def test_inverter():
@@ -57,7 +69,6 @@ def test_inverter():
             "enable_reversed_418_meter": None,
             "firmware_version": None,
             "first_battery_bms_firmware_version": None,
-            "first_battery_serial_number": None,
             "grid_port_max_power_output": None,
             "meter_type": None,
             "modbus_address": None,
@@ -464,7 +475,6 @@ def test_from_registers(register_cache):
         "enable_reversed_ct_clamp": True,
         "firmware_version": "D0.449-A0.449",
         "first_battery_bms_firmware_version": 3005,
-        "first_battery_serial_number": "BG1234G567",
         "grid_port_max_power_output": 6000,
         "meter_type": MeterType.EM115,
         "modbus_address": 0x11,
@@ -808,7 +818,6 @@ def test_from_registers_actual_data(register_cache_inverter_daytime_discharging_
         "enable_reversed_ct_clamp": True,
         "firmware_version": "D0.449-A0.449",
         "first_battery_bms_firmware_version": 3005,
-        "first_battery_serial_number": "BG1234G567",
         "grid_port_max_power_output": 6000,
         "meter_type": MeterType.EM115,
         "modbus_address": 0x11,

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -1191,7 +1191,6 @@ def test_from_actual():
         "enable_reversed_ct_clamp": True,
         "firmware_version": "D0.449-A0.449",
         "first_battery_bms_firmware_version": 3005,
-        "first_battery_serial_number": "BG1234G567",
         "grid_port_max_power_output": 6000,
         "meter_type": MeterType.EM115,
         "modbus_address": 0x11,

--- a/tests/model/test_register_cache.py
+++ b/tests/model/test_register_cache.py
@@ -205,7 +205,12 @@ def test_redact_serials_battery_ir_group():
 
 
 def test_redact_serials_inverter_hr_group():
-    """Inverter serial in HR(13-17) is redacted; battery HR serial in HR(8-12) also redacted."""
+    """Inverter serial HR(13-17) redacted; HR(8-12) also redacted via the explicit group.
+
+    HR(8-12) is the legacy first_battery_serial_number location, removed from the LUT in
+    #191 but kept in the redaction set explicitly (AIO stores the unit serial there
+    byte-swapped, recoverable). Guards against that group going missing.
+    """
     registers = {**_encode_serial("SA2231A456", HR, 13), **_encode_serial("BA2231A789", HR, 8)}
     registers[HR(0)] = 42  # unrelated
 


### PR DESCRIPTION
## What

Removes `first_battery_serial_number` (HR 8–12) from `SinglePhaseInverter`.

## Why

A GivTCP-heritage field that earns its keep nowhere:

- **Unused** — not in `Plant.devices`, the `Inverter`/`UnifiedInverter` facade, any computed field, the cli, or docs; only the LUT def + test fixtures.
- **Unverifiable** — GivEnergy is bust, so nothing confirms HR(8–12) is ever a genuine battery serial. The only non-AIO value in the tree was a synthetic test fixture.
- **Harmful in its one known use** — on residential AIO firmware it holds the inverter's own serial with the first register word byte-swapped (`CH…` → `HC…`), not a battery serial. The Home Assistant integration was creating a ghost `HC…` device from it (dewet22/givenergy-hass#95). GivTCP ignores it entirely.
- **Superseded** — the genuine per-module serials (`HX…`, #192) come from the battery-module registers, not this field.

Removed outright — no deprecation alias.

## Redaction preserved

HR(8–12) stays in the capture-redaction set via an explicit serial group in `_build_serial_register_groups`, mirroring the BMU-serial precedent — the byte-swapped serial is recoverable to the real one, so it mustn't start leaking in shared captures just because the field is gone. Guarded by `test_frame_redactor_redacts_hr8_serial_register`.

## Breaking

`first_battery_serial_number` no longer appears in `SinglePhaseInverter.model_dump()`. It was never reliable.

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced serial number redaction mechanism to reliably protect device serials in legacy register storage locations, ensuring consistent data security across all supported device generations.

* **Tests**
  * Added new regression tests and updated existing test cases to comprehensively verify serial redaction functionality works correctly across all device types and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->