### PR TITLE
feat(model): per-module AIO battery data as enumerable devices (#192)

### DIFF
--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -465,21 +465,42 @@ class Client:
                 num_modules = bcu_cache.get(IR(64)) or 0
                 caps.bcu_stacks.append((i, num_modules))
 
+    #: Maximum number of battery modules on a single-BCU AIO (addresses 0x50–0x53).
+    _AIO_MAX_MODULES = 4
+
     async def _detect_aio_battery_modules(
-        self, caps: PlantCapabilities, probe_timeout: float, probe_retries: int
+        self,
+        caps: PlantCapabilities,
+        prior: PlantCapabilities | None,
+        probe_timeout: float,
+        probe_retries: int,
     ) -> None:
         """Populate caps.aio_battery_module_addresses for an All-in-One (#192).
 
-        The AIO's first BCU reports its module count (IR 64); each module answers at its
-        own device address 0x50 + index with a plain IR(60-119) block. Probe each, and
-        record those that respond with a present module (a valid serial). Single-BCU AIO
-        only — multi-BCU module addressing is a future extension.
+        Hinted mode (prior is not None): probe only the previously-seen module addresses
+        so detect() stays a confirmation pass rather than a fresh sweep — consistent with
+        the meter and battery hinted contracts.
+
+        Cold mode: derive candidates from the BCU-reported module count (IR 64), bounded
+        to _AIO_MAX_MODULES (0x50–0x53) to guard against stale or corrupt register values.
+
+        Single-BCU AIO only — multi-BCU module addressing is a future extension.
         """
-        if not caps.bcu_stacks:
-            return
-        _offset, num_modules = caps.bcu_stacks[0]
-        for i in range(num_modules):
-            addr = 0x50 + i
+        if prior is not None:
+            candidates: list[int] = list(prior.aio_battery_module_addresses)
+        else:
+            if not caps.bcu_stacks:
+                return
+            _offset, num_modules = caps.bcu_stacks[0]
+            if num_modules > self._AIO_MAX_MODULES:
+                _logger.warning(
+                    "detect: BCU reports %d modules but AIO maximum is %d — clamping",
+                    num_modules,
+                    self._AIO_MAX_MODULES,
+                )
+                num_modules = self._AIO_MAX_MODULES
+            candidates = [0x50 + i for i in range(num_modules)]
+        for addr in candidates:
             if not await self._probe(
                 ReadInputRegistersRequest(base_register=60, register_count=60, device_address=addr),
                 timeout=probe_timeout,
@@ -655,7 +676,7 @@ class Client:
         # battery module at its own device address (0x50+), distinct from the bcu_stacks
         # stride layout, so its per-module cell/temperature/serial data is reachable.
         if caps.device_type is Model.ALL_IN_ONE and caps.bcu_stacks:
-            await self._detect_aio_battery_modules(caps, probe_timeout, probe_retries)
+            await self._detect_aio_battery_modules(caps, prior, probe_timeout, probe_retries)
             _logger.info(
                 "detect: aio_battery_modules=[%s]",
                 ", ".join(f"0x{a:02x}" for a in caps.aio_battery_module_addresses),

--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -487,8 +487,12 @@ class Client:
             ):
                 continue
             cache = self.plant.register_caches.get(addr)
-            if cache is None or not AioBatteryModule.from_register_cache(cache, addr).is_valid():
-                _logger.debug("detect: AIO module probe at 0x%02x responded but is_valid()=False — skipping", addr)
+            try:
+                if cache is None or not AioBatteryModule.from_register_cache(cache, addr).is_valid():
+                    _logger.debug("detect: AIO module probe at 0x%02x responded but is_valid()=False — skipping", addr)
+                    continue
+            except Exception:
+                _logger.debug("detect: AIO module probe at 0x%02x failed to decode — skipping", addr, exc_info=True)
                 continue
             caps.aio_battery_module_addresses.append(addr)
 

--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -18,9 +18,10 @@ from givenergy_modbus.exceptions import (
     RefreshPartiallySucceeded,
 )
 from givenergy_modbus.framer import ClientFramer, Framer
+from givenergy_modbus.model.aio_battery import AioBatteryModule
 from givenergy_modbus.model.battery import Battery
 from givenergy_modbus.model.ems import EmsRegisterGetter
-from givenergy_modbus.model.inverter import resolve_model
+from givenergy_modbus.model.inverter import Model, resolve_model
 from givenergy_modbus.model.meter import Meter
 from givenergy_modbus.model.plant import Plant, PlantCapabilities
 from givenergy_modbus.model.register import HR, IR
@@ -464,6 +465,33 @@ class Client:
                 num_modules = bcu_cache.get(IR(64)) or 0
                 caps.bcu_stacks.append((i, num_modules))
 
+    async def _detect_aio_battery_modules(
+        self, caps: PlantCapabilities, probe_timeout: float, probe_retries: int
+    ) -> None:
+        """Populate caps.aio_battery_module_addresses for an All-in-One (#192).
+
+        The AIO's first BCU reports its module count (IR 64); each module answers at its
+        own device address 0x50 + index with a plain IR(60-119) block. Probe each, and
+        record those that respond with a present module (a valid serial). Single-BCU AIO
+        only — multi-BCU module addressing is a future extension.
+        """
+        if not caps.bcu_stacks:
+            return
+        _offset, num_modules = caps.bcu_stacks[0]
+        for i in range(num_modules):
+            addr = 0x50 + i
+            if not await self._probe(
+                ReadInputRegistersRequest(base_register=60, register_count=60, device_address=addr),
+                timeout=probe_timeout,
+                retries=probe_retries,
+            ):
+                continue
+            cache = self.plant.register_caches.get(addr)
+            if cache is None or not AioBatteryModule.from_register_cache(cache, addr).is_valid():
+                _logger.debug("detect: AIO module probe at 0x%02x responded but is_valid()=False — skipping", addr)
+                continue
+            caps.aio_battery_module_addresses.append(addr)
+
     async def _ems_rollup_cross_check(self, timeout: float, retries: int) -> None:
         """Read IR(2040,55) at detect time and sanity-check the per-managed-inverter rollup.
 
@@ -617,6 +645,16 @@ class Client:
             _logger.info(
                 "detect: bcu_stacks=[%s]",
                 ", ".join(f"0x{0x70 + o:02x} (x{n})" for o, n in caps.bcu_stacks),
+            )
+
+        # Step 2b — AIO per-module battery probing (#192). The All-in-One exposes each
+        # battery module at its own device address (0x50+), distinct from the bcu_stacks
+        # stride layout, so its per-module cell/temperature/serial data is reachable.
+        if caps.device_type is Model.ALL_IN_ONE and caps.bcu_stacks:
+            await self._detect_aio_battery_modules(caps, probe_timeout, probe_retries)
+            _logger.info(
+                "detect: aio_battery_modules=[%s]",
+                ", ".join(f"0x{a:02x}" for a in caps.aio_battery_module_addresses),
             )
 
         # Step 3 — meter probing. Hinted: only previously-seen addresses. Cold: full 0x01–0x08 sweep.
@@ -892,6 +930,9 @@ class Client:
             reqs.append(ReadInputRegistersRequest(base_register=60, register_count=30, device_address=addr))
         for offset, _ in caps.bcu_stacks:
             reqs.append(ReadInputRegistersRequest(base_register=60, register_count=60, device_address=0x70 + offset))
+        # AIO per-module battery caches (#192) — each module answers at its own address.
+        for addr in caps.aio_battery_module_addresses:
+            reqs.append(ReadInputRegistersRequest(base_register=60, register_count=60, device_address=addr))
         await self._execute_reads(reqs, timeout=timeout, retries=retries, retry_delay=retry_delay)
         return self.plant
 

--- a/givenergy_modbus/model/aio_battery.py
+++ b/givenergy_modbus/model/aio_battery.py
@@ -1,0 +1,46 @@
+"""GivEnergy AIO (All-in-One) per-module battery data (#192).
+
+An All-in-One stores each removable battery module in its **own device-address cache**
+(0x50-0x53), each a plain ``IR(60-119)`` block — 24 cell voltages, cell temperatures, and
+the module's own ``HX``-prefixed hardware serial. This differs from the HV ``Bmu`` stride
+layout (modules offset within a single BCU cache); see ``model/hv_bcu.py``. The per-cell
+decode is shared via :func:`decode_cells_temps_serial`.
+"""
+
+from typing import Any
+
+from pydantic import ConfigDict, create_model
+
+from givenergy_modbus.model.hv_bcu import decode_cells_temps_serial, module_cell_temp_serial_fields
+
+
+def _aio_module_fields() -> dict[str, tuple[Any, None]]:
+    fields = module_cell_temp_serial_fields()
+    fields["module_address"] = (int | None, None)
+    return fields
+
+
+_AioBatteryModuleBase = create_model(  # type: ignore[call-overload]
+    "AioBatteryModule",
+    __config__=ConfigDict(frozen=True),
+    **_aio_module_fields(),
+)
+
+
+class AioBatteryModule(_AioBatteryModuleBase):  # type: ignore[misc,valid-type]
+    """One AIO battery module: 24 cell voltages + temperatures + the module serial.
+
+    Decoded from the module's own device-address cache (``base=0``), keyed by its Modbus
+    ``module_address`` (0x50-0x53).
+    """
+
+    @classmethod
+    def from_register_cache(cls, register_cache, module_address: int) -> "AioBatteryModule":
+        """Construct an AioBatteryModule from its own register cache (no stride)."""
+        data = decode_cells_temps_serial(register_cache, base=0)
+        data["module_address"] = module_address
+        return cls.model_validate(data)
+
+    def is_valid(self) -> bool:
+        """True if the module reports a non-blank serial (i.e. a module is present)."""
+        return self.serial_number not in (None, "", "          ")  # type: ignore[attr-defined]

--- a/givenergy_modbus/model/devices.py
+++ b/givenergy_modbus/model/devices.py
@@ -45,6 +45,7 @@ class DeviceType(str, Enum):
     EMS = "ems"
     GATEWAY = "gateway"
     BATTERY = "battery"
+    BATTERY_MODULE = "battery_module"
     METER = "meter"
     HV_STACK = "hv_stack"
 
@@ -104,7 +105,7 @@ class Inverter:
     concern via the underlying sources.
     """
 
-    __slots__ = ("data_source", "_direct", "_summary", "_batteries", "_hv_stacks")
+    __slots__ = ("data_source", "_direct", "_summary", "_batteries", "_hv_stacks", "_battery_modules")
 
     def __init__(
         self,
@@ -113,6 +114,7 @@ class Inverter:
         summary: InverterSummary | None = None,
         batteries: list[Any] | None = None,
         hv_stacks: list[Any] | None = None,
+        battery_modules: list[Any] | None = None,
     ) -> None:
         """Construct directly (prefer the factory methods).
 
@@ -130,6 +132,7 @@ class Inverter:
         self._summary = summary
         self._batteries = batteries
         self._hv_stacks = hv_stacks
+        self._battery_modules = battery_modules
 
     @classmethod
     def from_direct(
@@ -138,6 +141,7 @@ class Inverter:
         *,
         batteries: list[Any] | None = None,
         hv_stacks: list[Any] | None = None,
+        battery_modules: list[Any] | None = None,
     ) -> Inverter:
         """Construct from a directly-reachable concrete inverter model.
 
@@ -153,7 +157,13 @@ class Inverter:
         ``batteries`` / ``hv_stacks`` are the sub-devices owned by this
         inverter, injected by :class:`Plant` (#106 Phase 2).
         """
-        return cls(data_source="direct", direct=direct, batteries=batteries, hv_stacks=hv_stacks)
+        return cls(
+            data_source="direct",
+            direct=direct,
+            batteries=batteries,
+            hv_stacks=hv_stacks,
+            battery_modules=battery_modules,
+        )
 
     @classmethod
     def from_summary(cls, summary: InverterSummary) -> Inverter:
@@ -174,6 +184,7 @@ class Inverter:
         *,
         batteries: list[Any] | None = None,
         hv_stacks: list[Any] | None = None,
+        battery_modules: list[Any] | None = None,
     ) -> Inverter:
         """Construct from a direct source reconciled with a rollup summary.
 
@@ -190,6 +201,7 @@ class Inverter:
             summary=summary,
             batteries=batteries,
             hv_stacks=hv_stacks,
+            battery_modules=battery_modules,
         )
 
     # ------------------------------------------------------------------
@@ -293,6 +305,16 @@ class Inverter:
         Empty when blinded, mirroring :attr:`batteries`.
         """
         return list(self._hv_stacks) if self._hv_stacks else []
+
+    @property
+    def battery_modules(self) -> list[Any]:
+        """List of per-module battery sub-devices owned by this inverter (#192).
+
+        Populated by :class:`Plant` for All-in-One units, which expose each
+        removable battery module at its own device address (cell voltages,
+        temperatures, module serial). Empty for other models and when blinded.
+        """
+        return list(self._battery_modules) if self._battery_modules else []
 
     # ------------------------------------------------------------------
     # Diagnostics

--- a/givenergy_modbus/model/hv_bcu.py
+++ b/givenergy_modbus/model/hv_bcu.py
@@ -92,14 +92,57 @@ _BMU_CELLS = 24
 _BMU_STRIDE = 120
 
 
-# Build the Bmu pydantic model schema using dummy offset 0 to infer field types,
-# then instantiate with real data in from_register_cache.
-def _bmu_fields() -> dict[str, tuple[Any, None]]:
+def module_cell_temp_serial_fields() -> dict[str, tuple[Any, None]]:
+    """Pydantic field schema for a battery module's per-cell data (voltages, temps, serial).
+
+    Shared by `Bmu` (HV stride layout) and `AioBatteryModule` (AIO separate-address layout) —
+    both expose the same 24-cell voltage/temperature + serial shape.
+    """
     fields: dict[str, tuple[Any, None]] = {}
     for i in range(1, _BMU_CELLS + 1):
         fields[f"v_cell_{i:02d}"] = (float | None, None)
         fields[f"t_cell_{i:02d}"] = (float | None, None)
     fields["serial_number"] = (str | None, None)
+    return fields
+
+
+def decode_cells_temps_serial(register_cache, base: int = 0) -> dict[str, Any]:
+    """Decode a battery module's cells, temperatures and serial from a cache, offset by ``base``.
+
+    Reads 24 cell voltages (IR 60-83), temperatures (IR 90-113) and the module serial
+    (IR 114-118). Shared decode for both module layouts: `Bmu` passes ``base = 120 * bmu_index`` (stride
+    within one BCU cache); `AioBatteryModule` passes ``base = 0`` (one cache per module
+    device address). Voltages are milli (÷1000), temperatures deci (÷10). A missing register
+    decodes as None; an incomplete serial group yields ``serial_number = None``.
+    """
+    data: dict[str, Any] = {}
+
+    def _get(reg_idx: int) -> int | None:
+        return register_cache.get(IR(reg_idx))
+
+    for i in range(_BMU_CELLS):
+        v = _get(60 + base + i)
+        data[f"v_cell_{i + 1:02d}"] = v / 1000 if v is not None else None
+    for i in range(_BMU_CELLS):
+        t = _get(90 + base + i)
+        data[f"t_cell_{i + 1:02d}"] = t / 10 if t is not None else None
+    sn_regs = [_get(114 + base + j) for j in range(5)]
+    if None not in sn_regs:
+        data["serial_number"] = (
+            b"".join(v.to_bytes(2, "big") for v in sn_regs)  # type: ignore[union-attr]
+            .decode("latin1")
+            .replace("\x00", "")
+            .upper()
+        )
+    else:
+        data["serial_number"] = None
+    return data
+
+
+# Build the Bmu pydantic model schema using dummy offset 0 to infer field types,
+# then instantiate with real data in from_register_cache.
+def _bmu_fields() -> dict[str, tuple[Any, None]]:
+    fields = module_cell_temp_serial_fields()
     fields["bmu_index"] = (int | None, None)
     return fields
 
@@ -121,35 +164,8 @@ class Bmu(_BmuBase):  # type: ignore[misc,valid-type]
     @classmethod
     def from_register_cache(cls, register_cache, bmu_index: int = 0) -> "Bmu":
         """Construct a Bmu from a RegisterCache for the given bmu_index."""
-        base = _BMU_STRIDE * bmu_index
-        data: dict[str, Any] = {"bmu_index": bmu_index}
-
-        def _get(reg_idx: int) -> int | None:
-            return register_cache.get(IR(reg_idx))
-
-        def _milli(v: int | None) -> float | None:
-            return v / 1000 if v is not None else None
-
-        def _deci(v: int | None) -> float | None:
-            return v / 10 if v is not None else None
-
-        for i in range(_BMU_CELLS):
-            data[f"v_cell_{i + 1:02d}"] = _milli(_get(60 + base + i))
-
-        for i in range(_BMU_CELLS):
-            data[f"t_cell_{i + 1:02d}"] = _deci(_get(90 + base + i))
-
-        sn_regs = [_get(114 + base + j) for j in range(5)]
-        if None not in sn_regs:
-            data["serial_number"] = (
-                b"".join(v.to_bytes(2, "big") for v in sn_regs)  # type: ignore[union-attr]
-                .decode("latin1")
-                .replace("\x00", "")
-                .upper()
-            )
-        else:
-            data["serial_number"] = None
-
+        data = decode_cells_temps_serial(register_cache, base=_BMU_STRIDE * bmu_index)
+        data["bmu_index"] = bmu_index
         return cls.model_validate(data)
 
     def is_valid(self) -> bool:

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -771,11 +771,14 @@ class Plant(GivEnergyBaseModel):
         """
         if not self.capabilities or not self.capabilities.aio_battery_module_addresses:
             return []
-        return [
-            AioBatteryModule.from_register_cache(self.register_caches[addr], addr)
-            for addr in self.capabilities.aio_battery_module_addresses
-            if addr in self.register_caches
-        ]
+        modules = []
+        for addr in self.capabilities.aio_battery_module_addresses:
+            if addr in self.register_caches:
+                try:
+                    modules.append(AioBatteryModule.from_register_cache(self.register_caches[addr], addr))
+                except Exception:
+                    _logger.error("Failed to decode AIO battery module at 0x%02x", addr, exc_info=True)
+        return modules
 
     @property
     def meters(self) -> dict[int, Meter]:
@@ -945,7 +948,7 @@ class Plant(GivEnergyBaseModel):
                 PlantDevice(
                     device_type=DeviceType.BATTERY_MODULE,
                     device=module,
-                    serial_number=module.serial_number if module.is_valid() else None,  # type: ignore[attr-defined]
+                    serial_number=_validated_serial(module),
                 )
             )
 

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -6,6 +6,7 @@ from typing import Any, ClassVar
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, model_validator
 
 from givenergy_modbus.model import GivEnergyBaseModel
+from givenergy_modbus.model.aio_battery import AioBatteryModule
 from givenergy_modbus.model.battery import Battery, BatteryRegisterGetter
 from givenergy_modbus.model.devices import DeviceType, PlantDevice
 from givenergy_modbus.model.devices import Inverter as UnifiedInverter
@@ -190,6 +191,9 @@ class PlantCapabilities(BaseModel):
     lv_battery_addresses: list[int] = Field(default_factory=list)
     # Each entry is (bcu_offset, num_modules) where the BCU device address is 0x70 + bcu_offset.
     bcu_stacks: list[tuple[int, int]] = Field(default_factory=list)
+    # AIO (All-in-One) per-module battery device addresses (0x50-0x53). Separate-address
+    # layout, distinct from the bcu_stacks stride model — see model/aio_battery.py (#192).
+    aio_battery_module_addresses: list[int] = Field(default_factory=list)
 
     def __init__(
         self,
@@ -198,6 +202,7 @@ class PlantCapabilities(BaseModel):
         meter_addresses: list[int] | None = None,
         lv_battery_addresses: list[int] | None = None,
         bcu_stacks: list[tuple[int, int]] | None = None,
+        aio_battery_module_addresses: list[int] | None = None,
         **kwargs: Any,
     ) -> None:
         # Custom __init__ for two reasons:
@@ -218,6 +223,8 @@ class PlantCapabilities(BaseModel):
             kwargs["lv_battery_addresses"] = lv_battery_addresses
         if bcu_stacks is not None:
             kwargs["bcu_stacks"] = bcu_stacks
+        if aio_battery_module_addresses is not None:
+            kwargs["aio_battery_module_addresses"] = aio_battery_module_addresses
         _map_legacy_aliases(kwargs, stacklevel=3)
         super().__init__(**kwargs)
 
@@ -336,6 +343,7 @@ class PlantCapabilities(BaseModel):
             "meter_addresses": [f"0x{a:02x}" for a in self.meter_addresses],
             "lv_battery_addresses": [f"0x{a:02x}" for a in self.lv_battery_addresses],
             "bcu_stacks": [[offset, modules] for offset, modules in self.bcu_stacks],
+            "aio_battery_module_addresses": [f"0x{a:02x}" for a in self.aio_battery_module_addresses],
         }
 
     @classmethod
@@ -395,19 +403,22 @@ class PlantCapabilities(BaseModel):
             # payloads can put strings here, which would TypeError downstream
             # (`0x70 + offset` in detect()). Fail loud at parse time instead.
             bcu_stacks=[(int(offset), int(modules)) for offset, modules in (normalised.get("bcu_stacks") or [])],
+            aio_battery_module_addresses=[_addr(a) for a in (normalised.get("aio_battery_module_addresses") or [])],
         )
 
     def __repr__(self) -> str:
         meters = ", ".join(f"0x{a:02x}" for a in self.meter_addresses)
         batts = ", ".join(f"0x{a:02x}" for a in self.lv_battery_addresses)
         bcus = ", ".join(f"({o}, {n})" for o, n in self.bcu_stacks)
+        aio_mods = ", ".join(f"0x{a:02x}" for a in self.aio_battery_module_addresses)
         return (
             f"PlantCapabilities("
             f"device_type=Model.{self.device_type.name}, "
             f"inverter_address=0x{self.inverter_address:02x}, "
             f"meter_addresses=[{meters}], "
             f"lv_battery_addresses=[{batts}], "
-            f"bcu_stacks=[{bcus}])"
+            f"bcu_stacks=[{bcus}], "
+            f"aio_battery_module_addresses=[{aio_mods}])"
         )
 
     @property
@@ -751,6 +762,22 @@ class Plant(GivEnergyBaseModel):
         return stacks
 
     @property
+    def aio_battery_modules(self) -> list[AioBatteryModule]:
+        """Return per-module AIO battery models (#192), one per separate-address module cache.
+
+        All-in-One units expose each removable module at its own device address (0x50-0x53),
+        each carrying 24 cell voltages, temperatures, and the module's own serial. Empty for
+        non-AIO plants and until the module caches have been polled.
+        """
+        if not self.capabilities or not self.capabilities.aio_battery_module_addresses:
+            return []
+        return [
+            AioBatteryModule.from_register_cache(self.register_caches[addr], addr)
+            for addr in self.capabilities.aio_battery_module_addresses
+            if addr in self.register_caches
+        ]
+
+    @property
     def meters(self) -> dict[int, Meter]:
         """Return Meter models keyed by device address."""
         if not self.capabilities or not self.capabilities.meter_addresses:
@@ -844,11 +871,19 @@ class Plant(GivEnergyBaseModel):
 
             return result
 
-        # The single direct inverter owns every battery / HV stack in the plant
-        # cache (#106 Phase 2). Inject the already-decoded sub-devices so the
-        # facade can expose ownership without importing concrete Battery /
-        # HvStack types. Splitting across multiple direct inverters is Phase 3.
-        return [UnifiedInverter.from_direct(self.inverter, batteries=self.batteries, hv_stacks=self.hv_stacks)]
+        # The single direct inverter owns every battery / HV stack / AIO module in
+        # the plant cache (#106 Phase 2, #192). Inject the already-decoded sub-devices
+        # so the facade can expose ownership without importing concrete Battery /
+        # HvStack / AioBatteryModule types. Splitting across multiple direct inverters
+        # is Phase 3.
+        return [
+            UnifiedInverter.from_direct(
+                self.inverter,
+                batteries=self.batteries,
+                hv_stacks=self.hv_stacks,
+                battery_modules=self.aio_battery_modules,
+            )
+        ]
 
     @property
     def gateway(self) -> GatewayV1 | GatewayV2 | None:
@@ -900,6 +935,19 @@ class Plant(GivEnergyBaseModel):
                     )
                 )
                 inverter_emitted = True
+
+        # AIO per-module battery sub-devices (#192) — enumerable BATTERY_MODULE rows,
+        # owned by the inverter (also injected on its ``device.battery_modules``), keyed
+        # by the module's own HX-prefixed serial. GivTCP surfaces these as separate
+        # per-module devices; mirror that so consumers can name one HA device per module.
+        for module in self.aio_battery_modules:
+            rows.append(
+                PlantDevice(
+                    device_type=DeviceType.BATTERY_MODULE,
+                    device=module,
+                    serial_number=module.serial_number if module.is_valid() else None,  # type: ignore[attr-defined]
+                )
+            )
 
         if (ems := self.ems) is not None:
             rows.append(PlantDevice(device_type=DeviceType.EMS, device=ems, model=model))

--- a/tests/client/test_detect.py
+++ b/tests/client/test_detect.py
@@ -409,6 +409,29 @@ async def test_detect_aio_skips_modules_with_no_serial():
 
 
 @pytest.mark.asyncio
+async def test_detect_aio_module_decode_error_skips_address(monkeypatch):
+    """A ValidationError during AIO module decode skips the address without crashing detect()."""
+    from givenergy_modbus.model.aio_battery import AioBatteryModule
+
+    client = _make_client()
+    _prime_cache(client, 0x11, {HR(0): 0x8001, HR(21): 612})
+    _prime_cache(client, 0xA0, {IR(61): 1})
+    _prime_cache(client, 0x70, {IR(64): 1})
+    _prime_aio_module_serial(client, 0x50)
+
+    def _raise(cache, addr):
+        raise ValueError("simulated decode failure")
+
+    monkeypatch.setattr(AioBatteryModule, "from_register_cache", staticmethod(_raise))
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
+        with patch.object(client, "_probe", new=AsyncMock(return_value=True)):
+            caps = await client.detect()
+
+    assert caps.aio_battery_module_addresses == []
+
+
+@pytest.mark.asyncio
 async def test_detect_battery_decode_value_error_stops_probe(monkeypatch):
     """A battery register-decode ValueError stops the probe rather than propagating.
 

--- a/tests/client/test_detect.py
+++ b/tests/client/test_detect.py
@@ -63,6 +63,18 @@ def test_plant_capabilities_round_trip_with_bcus():
     assert restored.bcu_stacks == [(0, 3), (1, 2)]
 
 
+def test_plant_capabilities_round_trip_with_aio_modules():
+    caps = PlantCapabilities(
+        device_type=Model.ALL_IN_ONE,
+        inverter_address=0x11,
+        bcu_stacks=[(0, 4)],
+        aio_battery_module_addresses=[0x50, 0x51, 0x52, 0x53],
+    )
+    restored = PlantCapabilities.from_dict(caps.to_dict())
+    assert restored == caps
+    assert restored.aio_battery_module_addresses == [0x50, 0x51, 0x52, 0x53]
+
+
 def test_plant_capabilities_from_dict_accepts_v2_0_0_legacy_shape():
     """Regression: a v2.0.0-shaped payload must still parse after the v2.0.1 schema change.
 
@@ -341,6 +353,59 @@ async def test_detect_finds_lv_batteries():
             caps = await client.detect()
 
     assert caps.lv_battery_addresses == [0x32, 0x33]
+
+
+def _prime_aio_module_serial(client: Client, device_address: int, serial: str = "HX2414G832") -> None:
+    """Prime an AIO module cache with a valid module serial (IR 114-118)."""
+    regs = {IR(114 + i): int.from_bytes(serial[i * 2 : i * 2 + 2].encode("latin1"), "big") for i in range(5)}
+    _prime_cache(client, device_address, regs)
+
+
+@pytest.mark.asyncio
+async def test_detect_finds_aio_battery_modules():
+    """An AIO with a 4-module BCU records its per-module addresses at 0x50-0x53 (#192)."""
+    client = _make_client()
+    # DTC 0x8001 + fw 612 → Model.ALL_IN_ONE (HV, single-phase).
+    _prime_cache(client, 0x11, {HR(0): 0x8001, HR(21): 612})
+    # BMS at 0xA0 reports 1 BCU; BCU at 0x70 reports 4 modules.
+    _prime_cache(client, 0xA0, {IR(61): 1})
+    _prime_cache(client, 0x70, {IR(64): 4})
+    for addr in (0x50, 0x51, 0x52, 0x53):
+        _prime_aio_module_serial(client, addr, serial=f"HX2414G83{addr - 0x50}")
+
+    responders = {0xA0, 0x70, 0x50, 0x51, 0x52, 0x53}
+
+    async def _probe_side_effect(request, *, timeout, retries):
+        return request.device_address in responders
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
+        with patch.object(client, "_probe", side_effect=_probe_side_effect):
+            caps = await client.detect()
+
+    assert caps.device_type is Model.ALL_IN_ONE
+    assert caps.bcu_stacks == [(0, 4)]
+    assert caps.aio_battery_module_addresses == [0x50, 0x51, 0x52, 0x53]
+
+
+@pytest.mark.asyncio
+async def test_detect_aio_skips_modules_with_no_serial():
+    """An AIO module that responds but has no serial is not recorded (ghost guard)."""
+    client = _make_client()
+    _prime_cache(client, 0x11, {HR(0): 0x8001, HR(21): 612})
+    _prime_cache(client, 0xA0, {IR(61): 1})
+    _prime_cache(client, 0x70, {IR(64): 2})
+    _prime_aio_module_serial(client, 0x50)  # 0x51 responds but has no serial primed
+
+    responders = {0xA0, 0x70, 0x50, 0x51}
+
+    async def _probe_side_effect(request, *, timeout, retries):
+        return request.device_address in responders
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
+        with patch.object(client, "_probe", side_effect=_probe_side_effect):
+            caps = await client.detect()
+
+    assert caps.aio_battery_module_addresses == [0x50]
 
 
 @pytest.mark.asyncio

--- a/tests/client/test_detect.py
+++ b/tests/client/test_detect.py
@@ -432,6 +432,75 @@ async def test_detect_aio_module_decode_error_skips_address(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_detect_aio_hinted_probes_only_prior_addresses():
+    """Hinted detect() for AIO modules sweeps only the prior addresses, not a fresh BCU count.
+
+    If prior has [0x50, 0x51] but the BCU now reports 4 modules, the hinted pass must
+    probe only 0x50 and 0x51 — consistent with the confirm-only contract for meters and
+    batteries.
+    """
+    client = _make_client()
+    _prime_cache(client, 0x11, {HR(0): 0x8001, HR(21): 612})
+    # BCU now reports 4 modules, but prior only knew about 2.
+    _prime_cache(client, 0x70, {IR(64): 4})
+    for addr in (0x50, 0x51):
+        _prime_aio_module_serial(client, addr, serial=f"HX2414G83{addr - 0x50}")
+    # 0x52 and 0x53 are present on hardware but were not in prior.
+    for addr in (0x52, 0x53):
+        _prime_aio_module_serial(client, addr, serial=f"HX2414G83{addr - 0x50}")
+
+    prior = PlantCapabilities(
+        device_type=Model.ALL_IN_ONE,
+        inverter_address=0x11,
+        bcu_stacks=[(0, 2)],
+        aio_battery_module_addresses=[0x50, 0x51],
+    )
+    probed: list[int] = []
+
+    async def _probe_side_effect(request, *, timeout, retries):
+        probed.append(request.device_address)
+        return True
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
+        with patch.object(client, "_probe", side_effect=_probe_side_effect):
+            from givenergy_modbus.exceptions import PlantTopologyMismatch
+
+            try:
+                await client.detect(prior=prior)
+            except PlantTopologyMismatch:
+                pass  # topology changed (BCU count 2→4) — that's expected; we only care what was probed
+
+    aio_probed = [a for a in probed if 0x50 <= a <= 0x53]
+    assert aio_probed == [0x50, 0x51], f"hinted AIO sweep must not probe 0x52/0x53; got {aio_probed}"
+
+
+@pytest.mark.asyncio
+async def test_detect_aio_cold_clamps_module_count_to_max():
+    """Cold detect() clamps a corrupt/large BCU module count to _AIO_MAX_MODULES (4)."""
+    client = _make_client()
+    _prime_cache(client, 0x11, {HR(0): 0x8001, HR(21): 612})
+    _prime_cache(client, 0xA0, {IR(61): 1})
+    # BCU reports 6 modules — should be clamped to 4.
+    _prime_cache(client, 0x70, {IR(64): 6})
+    for addr in range(0x50, 0x56):
+        _prime_aio_module_serial(client, addr, serial=f"HX2414G8{addr:02x}")
+
+    probed: list[int] = []
+
+    async def _probe_side_effect(request, *, timeout, retries):
+        probed.append(request.device_address)
+        return True
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
+        with patch.object(client, "_probe", side_effect=_probe_side_effect):
+            caps = await client.detect()
+
+    aio_probed = [a for a in probed if 0x50 <= a <= 0x5F]
+    assert all(a <= 0x53 for a in aio_probed), f"must not probe beyond 0x53; got {aio_probed}"
+    assert len(caps.aio_battery_module_addresses) <= 4
+
+
+@pytest.mark.asyncio
 async def test_detect_battery_decode_value_error_stops_probe(monkeypatch):
     """A battery register-decode ValueError stops the probe rather than propagating.
 

--- a/tests/client/test_load_refresh.py
+++ b/tests/client/test_load_refresh.py
@@ -269,6 +269,16 @@ async def test_refresh_bcu_stacks():
     assert _ir(60, 60, device=0x71) in reqs
 
 
+async def test_refresh_aio_battery_modules():
+    """AIO battery modules each add an IR 60+60 read at their own device address (#192)."""
+    client = _client_with_caps(Model.ALL_IN_ONE, aio_battery_module_addresses=[0x50, 0x51, 0x52, 0x53])
+    with patch.object(client, "_execute_reads", new_callable=AsyncMock) as mock_exec:
+        await client.refresh()
+    reqs = _reqs(mock_exec)
+    for addr in (0x50, 0x51, 0x52, 0x53):
+        assert _ir(60, 60, device=addr) in reqs
+
+
 async def test_refresh_plant_forwards_timeout_retries_and_retry_delay_post_detect():
     """Once capabilities is set, refresh_plant() must thread timeout/retries/retry_delay through.
 

--- a/tests/model/test_aio_battery.py
+++ b/tests/model/test_aio_battery.py
@@ -1,0 +1,111 @@
+"""Tests for #192 — per-module AIO battery data (AioBatteryModule).
+
+The AIO stores each battery module in its own device-address cache (0x50-0x53), each a
+plain IR(60-119) block: 24 cell voltages (IR 60-83), temperatures (IR 90-113; only the
+first ~12 are populated on known hardware), and the module serial (IR 114-118). Decoded
+against the real aio_a fixture.
+"""
+
+import pytest
+
+from givenergy_modbus.model.aio_battery import AioBatteryModule
+from givenergy_modbus.model.devices import DeviceType
+from givenergy_modbus.model.inverter import Model
+from givenergy_modbus.model.plant import PlantCapabilities
+from givenergy_modbus.model.register import IR
+from givenergy_modbus.model.register_cache import RegisterCache
+from tests.model.test_fixture_golden_master import _replay
+
+_AIO_MODULE_ADDRS = [0x50, 0x51, 0x52, 0x53]
+
+
+async def _aio_plant_with_caps():
+    """Replay the aio_a fixture and attach AIO capabilities (as detect() would)."""
+    plant = await _replay("aio_a/aio_arm612_5min.log")
+    plant.capabilities = PlantCapabilities(
+        device_type=Model.ALL_IN_ONE,
+        inverter_address=0x11,
+        bcu_stacks=[(0, 4)],
+        aio_battery_module_addresses=_AIO_MODULE_ADDRS,
+    )
+    return plant
+
+
+@pytest.mark.timeout(20)
+async def test_aio_module_decodes_cells_temps_serial_from_own_cache():
+    """A module's own 0x50 cache decodes to 24 cell voltages, temps, and an HX serial."""
+    plant = await _replay("aio_a/aio_arm612_5min.log")
+    cache = plant.register_caches[0x50]
+
+    module = AioBatteryModule.from_register_cache(cache, 0x50)
+
+    assert module.module_address == 0x50
+    # 24 cell voltages, all ~3.28 V on this capture
+    assert module.v_cell_01 == pytest.approx(3.28, abs=0.01)
+    assert module.v_cell_24 == pytest.approx(3.28, abs=0.01)
+    # temperatures present on the first sensors (IR 90-101 ≈ 20 °C)
+    assert module.t_cell_01 == pytest.approx(20.2, abs=0.5)
+    # serial is the module's own HX-prefixed hardware serial
+    assert module.serial_number is not None
+    assert module.serial_number.startswith("HX")
+
+
+def test_aio_module_empty_cache_has_no_serial():
+    """An empty cache yields a module with no serial (is_valid False)."""
+    module = AioBatteryModule.from_register_cache(RegisterCache(), 0x50)
+    assert module.serial_number is None
+    assert not module.is_valid()
+
+
+def test_aio_module_serial_decodes_from_ir_114():
+    """Serial decodes from IR(114-118) of the module's own cache."""
+    # "HX2414G832" encoded big-endian into IR(114-118)
+    serial = "HX2414G832"
+    regs = {IR(114 + i): int.from_bytes(serial[i * 2 : i * 2 + 2].encode("latin1"), "big") for i in range(5)}
+    module = AioBatteryModule.from_register_cache(RegisterCache(regs), 0x52)
+    assert module.serial_number == "HX2414G832"
+    assert module.module_address == 0x52
+    assert module.is_valid()
+
+
+# ---------------------------------------------------------------------------
+# Plant enumeration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.timeout(20)
+async def test_plant_aio_battery_modules_lists_four_modules():
+    """Plant.aio_battery_modules decodes one module per address from its own cache."""
+    plant = await _aio_plant_with_caps()
+    modules = plant.aio_battery_modules
+
+    assert [m.module_address for m in modules] == _AIO_MODULE_ADDRS
+    assert all(m.serial_number and m.serial_number.startswith("HX") for m in modules)
+    # The fixture is redacted to a common HX0000G000 serial, but the per-module
+    # temperatures differ — proof each module is decoded from its own separate cache
+    # (0x50-0x53), not re-read from one shared cache.
+    assert len({m.t_cell_01 for m in modules}) > 1, "modules decode from distinct caches"
+
+
+@pytest.mark.timeout(20)
+async def test_plant_aio_battery_modules_empty_without_caps():
+    """No AIO module addresses in caps → empty list (additive, non-AIO unaffected)."""
+    plant = await _replay("aio_a/aio_arm612_5min.log")
+    plant.capabilities = PlantCapabilities(device_type=Model.ALL_IN_ONE, inverter_address=0x11)
+    assert plant.aio_battery_modules == []
+
+
+@pytest.mark.timeout(20)
+async def test_plant_devices_emits_battery_module_rows_under_inverter():
+    """Plant.devices emits 4 BATTERY_MODULE rows, and they ride on the inverter facade too."""
+    plant = await _aio_plant_with_caps()
+    rows = plant.devices
+
+    module_rows = [r for r in rows if r.device_type is DeviceType.BATTERY_MODULE]
+    assert len(module_rows) == 4
+    assert all(r.serial_number and r.serial_number.startswith("HX") for r in module_rows)
+
+    # The AIO inverter row carries the same modules on its facade (#106 ownership).
+    inverter_rows = [r for r in rows if r.device_type is DeviceType.INVERTER]
+    assert len(inverter_rows) == 1
+    assert len(inverter_rows[0].device.battery_modules) == 4

--- a/tests/model/test_aio_battery.py
+++ b/tests/model/test_aio_battery.py
@@ -96,6 +96,29 @@ async def test_plant_aio_battery_modules_empty_without_caps():
 
 
 @pytest.mark.timeout(20)
+async def test_plant_aio_battery_modules_skips_on_decode_error(monkeypatch):
+    """A decode error for one module is caught; the remaining modules are still returned."""
+    from givenergy_modbus.model.aio_battery import AioBatteryModule
+
+    plant = await _aio_plant_with_caps()
+    call_count = 0
+
+    original = AioBatteryModule.from_register_cache
+
+    def _raise_on_first(cache, addr):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise ValueError("simulated decode failure")
+        return original(cache, addr)
+
+    monkeypatch.setattr(AioBatteryModule, "from_register_cache", staticmethod(_raise_on_first))
+    modules = plant.aio_battery_modules
+
+    assert len(modules) == 3  # first module skipped, remaining 3 returned
+
+
+@pytest.mark.timeout(20)
 async def test_plant_devices_emits_battery_module_rows_under_inverter():
     """Plant.devices emits 4 BATTERY_MODULE rows, and they ride on the inverter facade too."""
     plant = await _aio_plant_with_caps()

--- a/tests/model/test_devices.py
+++ b/tests/model/test_devices.py
@@ -428,6 +428,7 @@ def test_device_type_members_are_generic_string_values():
         "EMS",
         "GATEWAY",
         "BATTERY",
+        "BATTERY_MODULE",
         "METER",
         "HV_STACK",
     }

--- a/tests/model/test_register_cache.py
+++ b/tests/model/test_register_cache.py
@@ -204,6 +204,20 @@ def test_redact_serials_battery_ir_group():
     assert result[IR(0)] == 1234  # untouched
 
 
+def test_redact_serials_aio_module_ir_114_group():
+    """AIO module serial at IR(114-118) is redacted (#192).
+
+    AIO battery modules carry their own HX serial at IR(114-118) in their own
+    device-address cache; the IR(114,5) BMU group already covers it, so a shared export
+    must zero the unit digits. Guards the per-module privacy surface.
+    """
+    registers = _encode_serial("HX2414G832", IR, 114)
+    result = RegisterCache(registers).redact_serials()
+    expected = _encode_serial("HX2414G000", IR, 114)
+    for reg, val in expected.items():
+        assert result[reg] == val, f"{reg} mismatch"
+
+
 def test_redact_serials_inverter_hr_group():
     """Inverter serial HR(13-17) redacted; HR(8-12) also redacted via the explicit group.
 

--- a/tests/test_deprecation_aliases.py
+++ b/tests/test_deprecation_aliases.py
@@ -178,6 +178,7 @@ def test_capabilities_to_dict_format():
         "meter_addresses": ["0x01"],
         "lv_battery_addresses": ["0x33"],
         "bcu_stacks": [[0, 2]],
+        "aio_battery_module_addresses": [],
     }
 
 


### PR DESCRIPTION
## What

Exposes per-module AIO battery data as enumerable devices (#192), closing the gap AberDino raised in dewet22/givenergy-hass#95: the integration only surfaced a pack-level battery for All-in-One units, not the per-module sub-devices GivTCP shows.

## Background

An AIO stores each removable battery module at its **own device address** (`0x50–0x53`), each a plain `IR(60–119)` block — 24 cell voltages, temperatures, and the module's own `HX`-prefixed serial. This is a *separate-address* layout, distinct from the HV `Bmu` stride model (modules offset within one BCU cache), which is left untouched. Confirmed against the real `tests/fixtures/captures/aio_a/` fixture (4 modules).

## Changes

- **`AioBatteryModule`** (`model/aio_battery.py`) — decoded from each module's own cache. The per-cell/temperature/serial decode is extracted from `Bmu` into a shared `hv_bcu.decode_cells_temps_serial` helper (AIO passes `base=0`); `Bmu` behaviour is unchanged.
- **Detection + refresh** — `PlantCapabilities.aio_battery_module_addresses`; `detect()` records `0x50+i` for an AIO BCU's modules; `refresh()` polls each so the caches populate on live hardware.
- **Enumeration** — `Plant.aio_battery_modules`; new `DeviceType.BATTERY_MODULE` rows in `Plant.devices`, nested under the AIO inverter and injected on its facade (`inverter.battery_modules`), keyed by module serial.
- **Redaction** — module serials (`IR 114–118`) are already covered by the existing serial group; regression test added.

## Scope / safety

Additive — no existing accessor, and neither the HV `Bmu`/`HvStack` path nor non-AIO plants change. Single-BCU AIO; multi-BCU module addressing is noted as a follow-up.

Full suite + tox py311–py314 green.

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)
