### PR TITLE
feat(model): content-staleness primitive for frozen-BMS detection (#91)

### DIFF
--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -1,5 +1,6 @@
 import logging
 import warnings
+from collections import deque
 from datetime import UTC, datetime
 from typing import Any, ClassVar
 
@@ -34,6 +35,11 @@ from givenergy_modbus.pdu import (
 )
 
 _logger = logging.getLogger(__name__)
+
+# Size of the rolling hash deque used for frozen-BMS-cache detection (#91).
+# Storing 10 hashes per block allows is_block_frozen() to be called with n ≤ 10
+# while keeping the per-block memory cost constant and small.
+_FROZEN_HASH_DEQUE_SIZE = 10
 
 # Models whose battery architecture is HV (BCU/BMU stacks rather than LV packs).
 # Coarse families "4" (HYBRID_3PH), "6" (AC_3PH) and "8" (ALL_IN_ONE and variants)
@@ -487,6 +493,13 @@ class Plant(GivEnergyBaseModel):
     # model_dump(): it's ephemeral runtime bookkeeping, not part of the plant's dumpable state.
     register_block_updated_at: dict[tuple[int, str, int, int], datetime] = Field(default_factory=dict, exclude=True)
 
+    # Rolling content-hash deques for frozen-BMS-cache detection (#91).  Keyed identically to
+    # register_block_updated_at; each value is a bounded deque of the last
+    # _FROZEN_HASH_DEQUE_SIZE content hashes of the committed bank.  Private (not part of the
+    # model's serialised state) — ephemeral, resets on reconnect (acceptable: a fresh connection
+    # gets a fresh history, and a reconnected battery starts a new freeze-detection cycle).
+    _block_content_hashes: dict = PrivateAttr(default_factory=dict)
+
     # Direct-inverter register caches injected by add_direct_source() for multi-Client
     # reconciliation (#106 Phase 3). Stored separately from register_caches to avoid the
     # Modbus address collision (both EMS controller and direct inverter live at 0x11).
@@ -563,6 +576,7 @@ class Plant(GivEnergyBaseModel):
             incoming = {HR(k): v for k, v in pdu.to_dict().items()}
             if self._commit_bank(device_address, incoming, pdu.register_count):
                 self._stamp_block(device_address, "HR", pdu.base_register, pdu.register_count, received_at)
+                self._append_block_hash(device_address, "HR", pdu.base_register, pdu.register_count, incoming)
         elif isinstance(pdu, ReadInputRegistersResponse):
             if pdu.is_suspicious():
                 # Pattern A dongle-side substitution from #78 — known fingerprint of 16 fixed
@@ -571,6 +585,7 @@ class Plant(GivEnergyBaseModel):
             incoming = {IR(k): v for k, v in pdu.to_dict().items()}  # type: ignore[misc]
             if self._commit_bank(device_address, incoming, pdu.register_count):
                 self._stamp_block(device_address, "IR", pdu.base_register, pdu.register_count, received_at)
+                self._append_block_hash(device_address, "IR", pdu.base_register, pdu.register_count, incoming)
         elif isinstance(pdu, WriteHoldingRegisterResponse):
             if pdu.register == 0:
                 _logger.warning(f"Ignoring, likely corrupt: {pdu}")
@@ -691,6 +706,63 @@ class Plant(GivEnergyBaseModel):
         if effective_now.tzinfo is None:
             effective_now = effective_now.replace(tzinfo=UTC)
         return (effective_now - ts).total_seconds()
+
+    def _append_block_hash(
+        self,
+        device_address: int,
+        reg_type: str,
+        base_register: int,
+        register_count: int,
+        committed: dict,
+    ) -> None:
+        """Append a content hash of committed to the rolling deque for this block (#91).
+
+        Called from update() whenever _commit_bank() returns True, mirroring _stamp_block().
+        The hash covers the full committed dict so any register change resets the freeze counter.
+        """
+        key = (device_address, reg_type, base_register, register_count)
+        dq = self._block_content_hashes.setdefault(key, deque(maxlen=_FROZEN_HASH_DEQUE_SIZE))
+        dq.append(hash(frozenset(committed.items())))
+
+    def is_block_frozen(
+        self,
+        device_address: int,
+        reg_type: str,
+        base_register: int,
+        register_count: int,
+        *,
+        n: int = 5,
+    ) -> bool:
+        """True if the last n consecutive committed banks of this block were byte-identical (#91).
+
+        A True result indicates the device cache may be frozen — e.g. a BMS in firmware-update
+        bootloader mode that has gone quiet on RS485 while the inverter keeps serving its last
+        cached page unchanged.
+
+        Returns False until n samples have been collected (startup grace period prevents false
+        positives on the first few polls after a reconnect).
+
+        Does not auto-invalidate data; callers decide how to surface the signal (e.g. marking
+        the device unavailable in Home Assistant).
+
+        n=5 at a 30 s poll interval ≈ 2.5 min before the signal fires — long enough to avoid
+        false positives during normal idle periods, short enough to catch a firmware-update
+        freeze within the first few minutes.
+        """
+        dq = self._block_content_hashes.get((device_address, reg_type, base_register, register_count))
+        if dq is None or len(dq) < n:
+            return False
+        recent = list(dq)[-n:]
+        return all(h == recent[0] for h in recent)
+
+    def is_battery_frozen(self, device_address: int, *, n: int = 5) -> bool:
+        """Convenience: frozen-cache check for an LV battery at device_address.
+
+        Delegates to is_block_frozen for the standard battery telemetry block IR(60, 60).
+        Returns True when the last n consecutive polls returned byte-identical data,
+        indicating the BMS may be in firmware-update bootloader mode. See #91.
+        """
+        return self.is_block_frozen(device_address, "IR", 60, 60, n=n)
 
     @property
     def inverter(self) -> SinglePhaseInverter | ThreePhaseInverter:

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -1,6 +1,5 @@
 import logging
 import warnings
-from collections import deque
 from datetime import UTC, datetime
 from typing import Any, ClassVar
 
@@ -35,11 +34,6 @@ from givenergy_modbus.pdu import (
 )
 
 _logger = logging.getLogger(__name__)
-
-# Size of the rolling content-hash deque retained per register block for the
-# frozen-BMS-cache primitive (#91). Bounded so the per-block memory cost stays
-# constant and small regardless of session length.
-_FROZEN_HASH_DEQUE_SIZE = 10
 
 # Models whose battery architecture is HV (BCU/BMU stacks rather than LV packs).
 # Coarse families "4" (HYBRID_3PH), "6" (AC_3PH) and "8" (ALL_IN_ONE and variants)
@@ -493,14 +487,14 @@ class Plant(GivEnergyBaseModel):
     # model_dump(): it's ephemeral runtime bookkeeping, not part of the plant's dumpable state.
     register_block_updated_at: dict[tuple[int, str, int, int], datetime] = Field(default_factory=dict, exclude=True)
 
-    # Rolling content-hash deques — the frozen-BMS-cache primitive (#91). Keyed identically to
-    # register_block_updated_at; each value is a bounded deque of the last
-    # _FROZEN_HASH_DEQUE_SIZE content hashes of the committed bank. Private (not part of the
-    # model's serialised state) — ephemeral, resets on reconnect. No public freeze predicate is
-    # exposed yet: on the real capture corpus, healthy LV batteries hold byte-identical IR(60,60)
-    # content for 23-26 consecutive samples, so consecutive-equality alone cannot distinguish a
-    # freeze from a live-but-static BMS. See _append_block_hash() for the full rationale.
-    _block_content_hashes: dict = PrivateAttr(default_factory=dict)
+    # Content-staleness tracker — the duration substrate for frozen-BMS-cache detection (#91).
+    # Keyed identically to register_block_updated_at; each value is (content_hash, unchanged_since)
+    # where unchanged_since is the ingestion time of the FIRST commit in the current
+    # byte-identical run. O(1) per block and survives arbitrarily long unchanged runs (a bounded
+    # deque of hashes could not — it evicts the run's origin). Private/ephemeral, resets on
+    # reconnect. Surfaced read-only via content_unchanged_seconds(); no freeze *verdict* is
+    # exposed — see that method for why a threshold isn't yet derivable.
+    _block_unchanged_since: dict = PrivateAttr(default_factory=dict)
 
     # Direct-inverter register caches injected by add_direct_source() for multi-Client
     # reconciliation (#106 Phase 3). Stored separately from register_caches to avoid the
@@ -578,7 +572,9 @@ class Plant(GivEnergyBaseModel):
             incoming = {HR(k): v for k, v in pdu.to_dict().items()}
             if self._commit_bank(device_address, incoming, pdu.register_count):
                 self._stamp_block(device_address, "HR", pdu.base_register, pdu.register_count, received_at)
-                self._append_block_hash(device_address, "HR", pdu.base_register, pdu.register_count, incoming)
+                self._track_content_change(
+                    device_address, "HR", pdu.base_register, pdu.register_count, incoming, received_at
+                )
         elif isinstance(pdu, ReadInputRegistersResponse):
             if pdu.is_suspicious():
                 # Pattern A dongle-side substitution from #78 — known fingerprint of 16 fixed
@@ -587,7 +583,9 @@ class Plant(GivEnergyBaseModel):
             incoming = {IR(k): v for k, v in pdu.to_dict().items()}  # type: ignore[misc]
             if self._commit_bank(device_address, incoming, pdu.register_count):
                 self._stamp_block(device_address, "IR", pdu.base_register, pdu.register_count, received_at)
-                self._append_block_hash(device_address, "IR", pdu.base_register, pdu.register_count, incoming)
+                self._track_content_change(
+                    device_address, "IR", pdu.base_register, pdu.register_count, incoming, received_at
+                )
         elif isinstance(pdu, WriteHoldingRegisterResponse):
             if pdu.register == 0:
                 _logger.warning(f"Ignoring, likely corrupt: {pdu}")
@@ -709,34 +707,70 @@ class Plant(GivEnergyBaseModel):
             effective_now = effective_now.replace(tzinfo=UTC)
         return (effective_now - ts).total_seconds()
 
-    def _append_block_hash(
+    def _track_content_change(
         self,
         device_address: int,
         reg_type: str,
         base_register: int,
         register_count: int,
         committed: dict,
+        received_at: datetime | None,
     ) -> None:
-        """Append a content hash of committed to the rolling deque for this block (#91).
+        """Maintain the (content_hash, unchanged_since) tracker for this block (#91).
 
         Called from update() whenever _commit_bank() returns True, mirroring _stamp_block().
-        The hash covers the full committed dict, so byte-identical consecutive banks produce
-        equal hashes and any register change produces a distinct one.
+        Hashes the full committed dict: if the hash matches the stored one the content is
+        byte-identical to the previous commit and unchanged_since is left anchored at the first
+        commit of the run; otherwise (changed content, or first sight) the hash and timestamp
+        are reset. unchanged_since therefore marks when the current content first appeared, and
+        content_unchanged_seconds() reads off how long it has held — the duration signal a freeze
+        detector needs. O(1) per block; survives unchanged runs of any length.
 
-        This is the freeze-detection *primitive*. A public predicate (e.g. is_battery_frozen)
-        is deliberately not exposed yet: replaying the real capture corpus showed healthy,
-        actively-polled LV batteries hold byte-identical IR(60,60) content for streaks of 23-26
-        consecutive samples (dongle fan-out re-serves the same cached frame to every TCP client,
-        and battery telemetry genuinely doesn't change every poll). Naive consecutive-equality
-        therefore can't distinguish a bootloader-mode freeze from a live-but-static BMS without a
-        discriminating signal (or a duration threshold validated against more than one freeze
-        capture). The deque is retained because it is the right substrate for that future work,
-        and #57's bounds-discard calibration ("discarded bank matches last accepted vs genuinely
-        new") consumes the same store. See #91.
+        This is the staleness *primitive*, not a freeze verdict: replaying the real capture
+        corpus showed healthy, actively-polled LV batteries hold byte-identical IR(60,60) content
+        for streaks of 23-26 consecutive samples (dongle fan-out re-serves the same cached frame
+        to every TCP client, and battery telemetry genuinely doesn't change every poll). A verdict
+        needs a duration threshold validated against more than the single freeze capture we have.
+        #57's bounds-discard calibration ("discarded bank matches last accepted vs genuinely new")
+        reads the stored hash too. See #91.
         """
+        ts = received_at or datetime.now(UTC)
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=UTC)
         key = (device_address, reg_type, base_register, register_count)
-        dq = self._block_content_hashes.setdefault(key, deque(maxlen=_FROZEN_HASH_DEQUE_SIZE))
-        dq.append(hash(frozenset(committed.items())))
+        content_hash = hash(frozenset(committed.items()))
+        prev = self._block_unchanged_since.get(key)
+        if prev is None or prev[0] != content_hash:
+            self._block_unchanged_since[key] = (content_hash, ts)
+
+    def content_unchanged_seconds(
+        self,
+        device_address: int,
+        reg_type: str,
+        base_register: int,
+        register_count: int,
+        *,
+        now: datetime | None = None,
+    ) -> float | None:
+        """Seconds a register block's content has been byte-identical, or None if never seen (#91).
+
+        Reports a raw duration, not a freeze verdict: a high value *may* indicate a frozen BMS
+        cache (e.g. a battery whose BMS is in firmware-update bootloader mode), but on the real
+        capture corpus healthy LV batteries also hold IR(60,60) content steady for long stretches
+        (dongle fan-out + genuinely-static telemetry). Distinguishing a freeze from a live-but-
+        static device needs a threshold validated against more freeze captures than currently
+        exist, so this method deliberately makes no claim — callers compose it with their own
+        policy. See #91.
+
+        ``reg_type`` is ``"HR"`` or ``"IR"``; ``register_count`` must match the committed block.
+        """
+        entry = self._block_unchanged_since.get((device_address, reg_type, base_register, register_count))
+        if entry is None:
+            return None
+        effective_now = now or datetime.now(UTC)
+        if effective_now.tzinfo is None:
+            effective_now = effective_now.replace(tzinfo=UTC)
+        return (effective_now - entry[1]).total_seconds()
 
     @property
     def inverter(self) -> SinglePhaseInverter | ThreePhaseInverter:

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -748,7 +748,12 @@ class Plant(GivEnergyBaseModel):
         n=5 at a 30 s poll interval ≈ 2.5 min before the signal fires — long enough to avoid
         false positives during normal idle periods, short enough to catch a firmware-update
         freeze within the first few minutes.
+
+        n must be in 1..._FROZEN_HASH_DEQUE_SIZE: the deque only retains that many samples, so a
+        larger n could never be satisfied and would silently never detect a freeze.
         """
+        if not 1 <= n <= _FROZEN_HASH_DEQUE_SIZE:
+            raise ValueError(f"n must be between 1 and {_FROZEN_HASH_DEQUE_SIZE}, got {n}")
         dq = self._block_content_hashes.get((device_address, reg_type, base_register, register_count))
         if dq is None or len(dq) < n:
             return False

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -36,9 +36,9 @@ from givenergy_modbus.pdu import (
 
 _logger = logging.getLogger(__name__)
 
-# Size of the rolling hash deque used for frozen-BMS-cache detection (#91).
-# Storing 10 hashes per block allows is_block_frozen() to be called with n ≤ 10
-# while keeping the per-block memory cost constant and small.
+# Size of the rolling content-hash deque retained per register block for the
+# frozen-BMS-cache primitive (#91). Bounded so the per-block memory cost stays
+# constant and small regardless of session length.
 _FROZEN_HASH_DEQUE_SIZE = 10
 
 # Models whose battery architecture is HV (BCU/BMU stacks rather than LV packs).
@@ -493,11 +493,13 @@ class Plant(GivEnergyBaseModel):
     # model_dump(): it's ephemeral runtime bookkeeping, not part of the plant's dumpable state.
     register_block_updated_at: dict[tuple[int, str, int, int], datetime] = Field(default_factory=dict, exclude=True)
 
-    # Rolling content-hash deques for frozen-BMS-cache detection (#91).  Keyed identically to
+    # Rolling content-hash deques — the frozen-BMS-cache primitive (#91). Keyed identically to
     # register_block_updated_at; each value is a bounded deque of the last
-    # _FROZEN_HASH_DEQUE_SIZE content hashes of the committed bank.  Private (not part of the
-    # model's serialised state) — ephemeral, resets on reconnect (acceptable: a fresh connection
-    # gets a fresh history, and a reconnected battery starts a new freeze-detection cycle).
+    # _FROZEN_HASH_DEQUE_SIZE content hashes of the committed bank. Private (not part of the
+    # model's serialised state) — ephemeral, resets on reconnect. No public freeze predicate is
+    # exposed yet: on the real capture corpus, healthy LV batteries hold byte-identical IR(60,60)
+    # content for 23-26 consecutive samples, so consecutive-equality alone cannot distinguish a
+    # freeze from a live-but-static BMS. See _append_block_hash() for the full rationale.
     _block_content_hashes: dict = PrivateAttr(default_factory=dict)
 
     # Direct-inverter register caches injected by add_direct_source() for multi-Client
@@ -718,56 +720,23 @@ class Plant(GivEnergyBaseModel):
         """Append a content hash of committed to the rolling deque for this block (#91).
 
         Called from update() whenever _commit_bank() returns True, mirroring _stamp_block().
-        The hash covers the full committed dict so any register change resets the freeze counter.
+        The hash covers the full committed dict, so byte-identical consecutive banks produce
+        equal hashes and any register change produces a distinct one.
+
+        This is the freeze-detection *primitive*. A public predicate (e.g. is_battery_frozen)
+        is deliberately not exposed yet: replaying the real capture corpus showed healthy,
+        actively-polled LV batteries hold byte-identical IR(60,60) content for streaks of 23-26
+        consecutive samples (dongle fan-out re-serves the same cached frame to every TCP client,
+        and battery telemetry genuinely doesn't change every poll). Naive consecutive-equality
+        therefore can't distinguish a bootloader-mode freeze from a live-but-static BMS without a
+        discriminating signal (or a duration threshold validated against more than one freeze
+        capture). The deque is retained because it is the right substrate for that future work,
+        and #57's bounds-discard calibration ("discarded bank matches last accepted vs genuinely
+        new") consumes the same store. See #91.
         """
         key = (device_address, reg_type, base_register, register_count)
         dq = self._block_content_hashes.setdefault(key, deque(maxlen=_FROZEN_HASH_DEQUE_SIZE))
         dq.append(hash(frozenset(committed.items())))
-
-    def is_block_frozen(
-        self,
-        device_address: int,
-        reg_type: str,
-        base_register: int,
-        register_count: int,
-        *,
-        n: int = 5,
-    ) -> bool:
-        """True if the last n consecutive committed banks of this block were byte-identical (#91).
-
-        A True result indicates the device cache may be frozen — e.g. a BMS in firmware-update
-        bootloader mode that has gone quiet on RS485 while the inverter keeps serving its last
-        cached page unchanged.
-
-        Returns False until n samples have been collected (startup grace period prevents false
-        positives on the first few polls after a reconnect).
-
-        Does not auto-invalidate data; callers decide how to surface the signal (e.g. marking
-        the device unavailable in Home Assistant).
-
-        n=5 at a 30 s poll interval ≈ 2.5 min before the signal fires — long enough to avoid
-        false positives during normal idle periods, short enough to catch a firmware-update
-        freeze within the first few minutes.
-
-        n must be in 1..._FROZEN_HASH_DEQUE_SIZE: the deque only retains that many samples, so a
-        larger n could never be satisfied and would silently never detect a freeze.
-        """
-        if not 1 <= n <= _FROZEN_HASH_DEQUE_SIZE:
-            raise ValueError(f"n must be between 1 and {_FROZEN_HASH_DEQUE_SIZE}, got {n}")
-        dq = self._block_content_hashes.get((device_address, reg_type, base_register, register_count))
-        if dq is None or len(dq) < n:
-            return False
-        recent = list(dq)[-n:]
-        return all(h == recent[0] for h in recent)
-
-    def is_battery_frozen(self, device_address: int, *, n: int = 5) -> bool:
-        """Convenience: frozen-cache check for an LV battery at device_address.
-
-        Delegates to is_block_frozen for the standard battery telemetry block IR(60, 60).
-        Returns True when the last n consecutive polls returned byte-identical data,
-        indicating the BMS may be in firmware-update bootloader mode. See #91.
-        """
-        return self.is_block_frozen(device_address, "IR", 60, 60, n=n)
 
     @property
     def inverter(self) -> SinglePhaseInverter | ThreePhaseInverter:

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -1959,7 +1959,12 @@ def test_plant_capabilities_is_ac_coupled():
 
 
 # ---------------------------------------------------------------------------
-# Frozen BMS cache detection (#91) — is_block_frozen / is_battery_frozen
+# Frozen-BMS-cache primitive (#91) — _block_content_hashes / _append_block_hash
+#
+# No public freeze predicate is exposed: replaying the real capture corpus showed
+# healthy LV batteries hold byte-identical IR(60,60) content for 23-26 consecutive
+# samples (dongle fan-out + genuinely-static telemetry), so consecutive-equality
+# alone can't distinguish a freeze. These tests pin the primitive's behaviour only.
 # ---------------------------------------------------------------------------
 
 
@@ -1981,51 +1986,52 @@ def _feed_bank(
     plant.update(pdu)
 
 
-def test_is_block_frozen_false_below_threshold(plant: Plant):
-    """Fewer than n identical banks → False (startup grace period)."""
-    bank = {110: 0x4358, 111: 0x3232, 112: 0x3331, 113: 0x4734, 114: 0x3832}
-    for _ in range(4):  # n-1 = 4 < default n=5
+def test_append_block_hash_records_one_entry_per_commit(plant: Plant):
+    """Each committed bank appends exactly one hash to the block's deque."""
+    bank = {110: 0x4358, 111: 0x3232, 112: 0x3331, 113: 0x4734, 114: 0x3832, 60: 1234}
+    for _ in range(3):
         _feed_bank(plant, bank)
-    assert plant.is_block_frozen(0x32, "IR", 60, 60, n=5) is False
+    dq = plant._block_content_hashes[(0x32, "IR", 60, 60)]
+    assert len(dq) == 3
 
 
-def test_is_block_frozen_false_on_changing_data(plant: Plant):
-    """N banks committed but the last differs → False (data is live)."""
-    bank_a = {110: 0x4358, 111: 0x3232, 112: 0x3331, 113: 0x4734, 114: 0x3832}
-    bank_b = {110: 0x4358, 111: 0x3232, 112: 0x3331, 113: 0x4734, 114: 0x0001}
-    for _ in range(4):
-        _feed_bank(plant, bank_a)
-    _feed_bank(plant, bank_b)
-    assert plant.is_block_frozen(0x32, "IR", 60, 60, n=5) is False
-
-
-def test_is_block_frozen_true_on_n_identical_banks(plant: Plant):
-    """Exactly n consecutive identical banks → True (freeze detected)."""
+def test_append_block_hash_identical_banks_produce_equal_hashes(plant: Plant):
+    """Byte-identical consecutive banks hash equal — the substrate for freeze detection."""
     bank = {110: 0x4358, 111: 0x3232, 112: 0x3331, 113: 0x4734, 114: 0x3832, 60: 1234}
     for _ in range(5):
         _feed_bank(plant, bank)
-    assert plant.is_block_frozen(0x32, "IR", 60, 60, n=5) is True
+    dq = plant._block_content_hashes[(0x32, "IR", 60, 60)]
+    assert len(set(dq)) == 1
 
 
-def test_is_block_frozen_resets_after_change(plant: Plant):
-    """A data change after being frozen resets the freeze signal to False."""
-    bank_frozen = {110: 0x4358, 111: 0x3232, 112: 0x3331, 113: 0x4734, 114: 0x3832}
-    bank_live = {110: 0x4358, 111: 0x3232, 112: 0x3331, 113: 0x4734, 114: 0x0001}
-    for _ in range(5):
-        _feed_bank(plant, bank_frozen)
-    assert plant.is_block_frozen(0x32, "IR", 60, 60, n=5) is True
-    _feed_bank(plant, bank_live)
-    assert plant.is_block_frozen(0x32, "IR", 60, 60, n=5) is False
+def test_append_block_hash_changed_bank_produces_distinct_hash(plant: Plant):
+    """A register change yields a distinct hash from the prior bank."""
+    bank_a = {110: 0x4358, 111: 0x3232, 112: 0x3331, 113: 0x4734, 114: 0x3832, 60: 1234}
+    bank_b = {**bank_a, 60: 5678}
+    _feed_bank(plant, bank_a)
+    _feed_bank(plant, bank_b)
+    dq = plant._block_content_hashes[(0x32, "IR", 60, 60)]
+    assert dq[0] != dq[1]
 
 
-def test_is_battery_frozen_delegates_to_ir_60_60(plant: Plant):
-    """is_battery_frozen is a convenience alias for IR(60, 60)."""
+def test_append_block_hash_keyed_per_block(plant: Plant):
+    """Distinct (device, type, base, count) blocks track separate deques."""
     bank = {110: 0x4358, 111: 0x3232, 112: 0x3331, 113: 0x4734, 114: 0x3832}
-    for _ in range(5):
-        _feed_bank(plant, bank, base=60, count=60)
-    assert plant.is_battery_frozen(0x32) is True
-    # A different block (different base) is not affected.
-    assert plant.is_block_frozen(0x32, "IR", 0, 60, n=5) is False
+    _feed_bank(plant, bank, base=60, count=60)
+    _feed_bank(plant, {0: 1}, base=0, count=60)
+    assert (0x32, "IR", 60, 60) in plant._block_content_hashes
+    assert (0x32, "IR", 0, 60) in plant._block_content_hashes
+
+
+def test_discarded_bank_is_not_hashed(plant: Plant):
+    """A bank rejected by _commit_bank (Pattern B all-zero) records no hash — mirrors _stamp_block."""
+    # Seed a non-zero battery bank, then push an all-zero full block → Pattern B rejection.
+    seed = {60: 3221, 110: 0x4358, 111: 0x3232, 112: 0x3331, 113: 0x4734, 114: 0x3832}
+    _feed_bank(plant, seed)
+    assert len(plant._block_content_hashes[(0x32, "IR", 60, 60)]) == 1
+    _feed_bank(plant, dict.fromkeys(seed, 0))  # all-zero over non-zero cache → rejected
+    # Still only the one hash from the committed bank; the rejected bank added nothing.
+    assert len(plant._block_content_hashes[(0x32, "IR", 60, 60)]) == 1
 
 
 def test_hash_deque_capped_at_max_size(plant: Plant):
@@ -2038,20 +2044,3 @@ def test_hash_deque_capped_at_max_size(plant: Plant):
     key = (0x32, "IR", 60, 60)
     dq = plant._block_content_hashes[key]
     assert len(dq) == _FROZEN_HASH_DEQUE_SIZE
-
-
-def test_is_block_frozen_invalid_n_raises(plant: Plant):
-    """An n outside 1.._FROZEN_HASH_DEQUE_SIZE raises ValueError rather than silently never firing.
-
-    n > the deque cap can never be satisfied (len(dq) tops out at the cap), so a caller asking
-    for more samples than are retained would get a permanent False — a silent misconfiguration.
-    """
-    from givenergy_modbus.model.plant import _FROZEN_HASH_DEQUE_SIZE
-
-    with pytest.raises(ValueError, match="n must be between 1 and"):
-        plant.is_block_frozen(0x32, "IR", 60, 60, n=0)
-    with pytest.raises(ValueError, match="n must be between 1 and"):
-        plant.is_block_frozen(0x32, "IR", 60, 60, n=_FROZEN_HASH_DEQUE_SIZE + 1)
-    # is_battery_frozen forwards n, so the same guard applies through the convenience alias.
-    with pytest.raises(ValueError, match="n must be between 1 and"):
-        plant.is_battery_frozen(0x32, n=0)

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -2038,3 +2038,20 @@ def test_hash_deque_capped_at_max_size(plant: Plant):
     key = (0x32, "IR", 60, 60)
     dq = plant._block_content_hashes[key]
     assert len(dq) == _FROZEN_HASH_DEQUE_SIZE
+
+
+def test_is_block_frozen_invalid_n_raises(plant: Plant):
+    """An n outside 1.._FROZEN_HASH_DEQUE_SIZE raises ValueError rather than silently never firing.
+
+    n > the deque cap can never be satisfied (len(dq) tops out at the cap), so a caller asking
+    for more samples than are retained would get a permanent False — a silent misconfiguration.
+    """
+    from givenergy_modbus.model.plant import _FROZEN_HASH_DEQUE_SIZE
+
+    with pytest.raises(ValueError, match="n must be between 1 and"):
+        plant.is_block_frozen(0x32, "IR", 60, 60, n=0)
+    with pytest.raises(ValueError, match="n must be between 1 and"):
+        plant.is_block_frozen(0x32, "IR", 60, 60, n=_FROZEN_HASH_DEQUE_SIZE + 1)
+    # is_battery_frozen forwards n, so the same guard applies through the convenience alias.
+    with pytest.raises(ValueError, match="n must be between 1 and"):
+        plant.is_battery_frozen(0x32, n=0)

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -1959,12 +1959,15 @@ def test_plant_capabilities_is_ac_coupled():
 
 
 # ---------------------------------------------------------------------------
-# Frozen-BMS-cache primitive (#91) — _block_content_hashes / _append_block_hash
+# Content-staleness primitive (#91) — content_unchanged_seconds / _track_content_change
 #
-# No public freeze predicate is exposed: replaying the real capture corpus showed
-# healthy LV batteries hold byte-identical IR(60,60) content for 23-26 consecutive
-# samples (dongle fan-out + genuinely-static telemetry), so consecutive-equality
-# alone can't distinguish a freeze. These tests pin the primitive's behaviour only.
+# Reports how long a register block's content has been byte-identical, keyed off the
+# #65 ingestion timestamps. This is the duration substrate the eventual freeze detector
+# needs — NOT a freeze verdict: replaying the real corpus showed healthy LV batteries
+# hold byte-identical IR(60,60) content for 23-26 consecutive samples (dongle fan-out +
+# genuinely-static telemetry), so a verdict needs a threshold validated against more
+# than the single freeze capture we have. content_unchanged_seconds() reports the raw
+# fact (a duration), makes no claim, and survives arbitrarily long unchanged runs.
 # ---------------------------------------------------------------------------
 
 
@@ -1976,6 +1979,7 @@ def _feed_bank(
     reg_type: str = "IR",
     base: int = 60,
     count: int = 60,
+    received_at: datetime | None = None,
 ) -> None:
     """Feed one committed bank directly, bypassing PDU construction overhead."""
     pdu: ReadInputRegistersResponse | ReadHoldingRegistersResponse
@@ -1983,64 +1987,70 @@ def _feed_bank(
         pdu = _make_ir_pdu(bank, device_address=device_address, base_register=base, register_count=count)
     else:
         pdu = _make_hr_pdu(bank, device_address=device_address, base_register=base, register_count=count)
-    plant.update(pdu)
+    plant.update(pdu, received_at=received_at)
 
 
-def test_append_block_hash_records_one_entry_per_commit(plant: Plant):
-    """Each committed bank appends exactly one hash to the block's deque."""
+_T0 = datetime(2026, 6, 9, 12, 0, 0, tzinfo=UTC)
+
+
+def test_content_unchanged_seconds_none_for_never_seen(plant: Plant):
+    """A block that has never committed reports None, not a spurious duration."""
+    assert plant.content_unchanged_seconds(0x32, "IR", 60, 60) is None
+
+
+def test_content_unchanged_seconds_accumulates_while_identical(plant: Plant):
+    """Identical consecutive banks hold unchanged_since at the first commit, so the duration grows."""
     bank = {110: 0x4358, 111: 0x3232, 112: 0x3331, 113: 0x4734, 114: 0x3832, 60: 1234}
-    for _ in range(3):
-        _feed_bank(plant, bank)
-    dq = plant._block_content_hashes[(0x32, "IR", 60, 60)]
-    assert len(dq) == 3
+    _feed_bank(plant, bank, received_at=_T0)
+    _feed_bank(plant, bank, received_at=_T0 + timedelta(seconds=30))
+    # Measured from a later 'now', the duration is since the FIRST identical commit.
+    assert plant.content_unchanged_seconds(0x32, "IR", 60, 60, now=_T0 + timedelta(seconds=90)) == 90.0
 
 
-def test_append_block_hash_identical_banks_produce_equal_hashes(plant: Plant):
-    """Byte-identical consecutive banks hash equal — the substrate for freeze detection."""
-    bank = {110: 0x4358, 111: 0x3232, 112: 0x3331, 113: 0x4734, 114: 0x3832, 60: 1234}
-    for _ in range(5):
-        _feed_bank(plant, bank)
-    dq = plant._block_content_hashes[(0x32, "IR", 60, 60)]
-    assert len(set(dq)) == 1
-
-
-def test_append_block_hash_changed_bank_produces_distinct_hash(plant: Plant):
-    """A register change yields a distinct hash from the prior bank."""
+def test_content_unchanged_seconds_resets_on_change(plant: Plant):
+    """A register change resets unchanged_since to that commit's timestamp."""
     bank_a = {110: 0x4358, 111: 0x3232, 112: 0x3331, 113: 0x4734, 114: 0x3832, 60: 1234}
     bank_b = {**bank_a, 60: 5678}
-    _feed_bank(plant, bank_a)
-    _feed_bank(plant, bank_b)
-    dq = plant._block_content_hashes[(0x32, "IR", 60, 60)]
-    assert dq[0] != dq[1]
+    _feed_bank(plant, bank_a, received_at=_T0)
+    _feed_bank(plant, bank_a, received_at=_T0 + timedelta(seconds=30))
+    _feed_bank(plant, bank_b, received_at=_T0 + timedelta(seconds=60))  # content changed → reset
+    assert plant.content_unchanged_seconds(0x32, "IR", 60, 60, now=_T0 + timedelta(seconds=75)) == 15.0
 
 
-def test_append_block_hash_keyed_per_block(plant: Plant):
-    """Distinct (device, type, base, count) blocks track separate deques."""
+def test_content_unchanged_survives_run_longer_than_old_deque(plant: Plant):
+    """An unchanged run of 20 commits still reports its true origin — the fix for Codex's objection.
+
+    A bounded 10-entry hash deque would have evicted the start of the run, losing whether it
+    began seconds or an hour ago. The unchanged_since timestamp is O(1) and survives any run.
+    """
+    bank = {110: 0x4358, 111: 0x3232, 112: 0x3331, 113: 0x4734, 114: 0x3832, 60: 1234}
+    for i in range(20):  # well beyond the former 10-entry deque cap
+        _feed_bank(plant, bank, received_at=_T0 + timedelta(seconds=30 * i))
+    # Duration spans from the first commit, not just the last 10.
+    assert plant.content_unchanged_seconds(0x32, "IR", 60, 60, now=_T0 + timedelta(seconds=600)) == 600.0
+
+
+def test_content_unchanged_seconds_keyed_per_block(plant: Plant):
+    """Distinct (device, type, base, count) blocks track unchanged_since independently."""
     bank = {110: 0x4358, 111: 0x3232, 112: 0x3331, 113: 0x4734, 114: 0x3832}
-    _feed_bank(plant, bank, base=60, count=60)
-    _feed_bank(plant, {0: 1}, base=0, count=60)
-    assert (0x32, "IR", 60, 60) in plant._block_content_hashes
-    assert (0x32, "IR", 0, 60) in plant._block_content_hashes
+    _feed_bank(plant, bank, base=60, count=60, received_at=_T0)
+    _feed_bank(plant, {0: 1}, base=0, count=60, received_at=_T0 + timedelta(seconds=10))
+    assert plant.content_unchanged_seconds(0x32, "IR", 60, 60, now=_T0 + timedelta(seconds=10)) == 10.0
+    assert plant.content_unchanged_seconds(0x32, "IR", 0, 60, now=_T0 + timedelta(seconds=10)) == 0.0
 
 
-def test_discarded_bank_is_not_hashed(plant: Plant):
-    """A bank rejected by _commit_bank (Pattern B all-zero) records no hash — mirrors _stamp_block."""
-    # Seed a non-zero battery bank, then push an all-zero full block → Pattern B rejection.
+def test_discarded_bank_does_not_update_unchanged_since(plant: Plant):
+    """A bank rejected by _commit_bank (Pattern B all-zero) leaves unchanged_since untouched."""
     seed = {60: 3221, 110: 0x4358, 111: 0x3232, 112: 0x3331, 113: 0x4734, 114: 0x3832}
-    _feed_bank(plant, seed)
-    assert len(plant._block_content_hashes[(0x32, "IR", 60, 60)]) == 1
-    _feed_bank(plant, dict.fromkeys(seed, 0))  # all-zero over non-zero cache → rejected
-    # Still only the one hash from the committed bank; the rejected bank added nothing.
-    assert len(plant._block_content_hashes[(0x32, "IR", 60, 60)]) == 1
+    _feed_bank(plant, seed, received_at=_T0)
+    _feed_bank(plant, dict.fromkeys(seed, 0), received_at=_T0 + timedelta(seconds=30))  # rejected
+    # unchanged_since still anchored at the committed bank; the rejected bank changed nothing.
+    assert plant.content_unchanged_seconds(0x32, "IR", 60, 60, now=_T0 + timedelta(seconds=30)) == 30.0
 
 
-def test_hash_deque_capped_at_max_size(plant: Plant):
-    """The internal deque never grows beyond _FROZEN_HASH_DEQUE_SIZE."""
-    from givenergy_modbus.model.plant import _FROZEN_HASH_DEQUE_SIZE
-
+def test_content_unchanged_seconds_normalises_naive_now(plant: Plant):
+    """A timezone-naive now is treated as UTC rather than raising TypeError (mirrors block_age)."""
     bank = {110: 0x4358, 111: 0x3232, 112: 0x3331, 113: 0x4734, 114: 0x3832}
-    for i in range(_FROZEN_HASH_DEQUE_SIZE * 2):
-        _feed_bank(plant, {**bank, 60: i})  # vary one register so hashes differ
-    key = (0x32, "IR", 60, 60)
-    dq = plant._block_content_hashes[key]
-    assert len(dq) == _FROZEN_HASH_DEQUE_SIZE
+    _feed_bank(plant, bank, received_at=_T0)
+    age = plant.content_unchanged_seconds(0x32, "IR", 60, 60, now=datetime(2026, 6, 9, 12, 0, 7))
+    assert age == 7.0

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -1956,3 +1956,85 @@ def test_plant_capabilities_is_ac_coupled():
     assert (ac.is_ac_coupled and not ac.is_three_phase) is True
     ac3 = PlantCapabilities(device_type=Model.AC_3PH)
     assert (ac3.is_ac_coupled and not ac3.is_three_phase) is False
+
+
+# ---------------------------------------------------------------------------
+# Frozen BMS cache detection (#91) — is_block_frozen / is_battery_frozen
+# ---------------------------------------------------------------------------
+
+
+def _feed_bank(
+    plant: "Plant",
+    bank: dict[int, int],
+    *,
+    device_address: int = 0x32,
+    reg_type: str = "IR",
+    base: int = 60,
+    count: int = 60,
+) -> None:
+    """Feed one committed bank directly, bypassing PDU construction overhead."""
+    pdu: ReadInputRegistersResponse | ReadHoldingRegistersResponse
+    if reg_type == "IR":
+        pdu = _make_ir_pdu(bank, device_address=device_address, base_register=base, register_count=count)
+    else:
+        pdu = _make_hr_pdu(bank, device_address=device_address, base_register=base, register_count=count)
+    plant.update(pdu)
+
+
+def test_is_block_frozen_false_below_threshold(plant: Plant):
+    """Fewer than n identical banks → False (startup grace period)."""
+    bank = {110: 0x4358, 111: 0x3232, 112: 0x3331, 113: 0x4734, 114: 0x3832}
+    for _ in range(4):  # n-1 = 4 < default n=5
+        _feed_bank(plant, bank)
+    assert plant.is_block_frozen(0x32, "IR", 60, 60, n=5) is False
+
+
+def test_is_block_frozen_false_on_changing_data(plant: Plant):
+    """N banks committed but the last differs → False (data is live)."""
+    bank_a = {110: 0x4358, 111: 0x3232, 112: 0x3331, 113: 0x4734, 114: 0x3832}
+    bank_b = {110: 0x4358, 111: 0x3232, 112: 0x3331, 113: 0x4734, 114: 0x0001}
+    for _ in range(4):
+        _feed_bank(plant, bank_a)
+    _feed_bank(plant, bank_b)
+    assert plant.is_block_frozen(0x32, "IR", 60, 60, n=5) is False
+
+
+def test_is_block_frozen_true_on_n_identical_banks(plant: Plant):
+    """Exactly n consecutive identical banks → True (freeze detected)."""
+    bank = {110: 0x4358, 111: 0x3232, 112: 0x3331, 113: 0x4734, 114: 0x3832, 60: 1234}
+    for _ in range(5):
+        _feed_bank(plant, bank)
+    assert plant.is_block_frozen(0x32, "IR", 60, 60, n=5) is True
+
+
+def test_is_block_frozen_resets_after_change(plant: Plant):
+    """A data change after being frozen resets the freeze signal to False."""
+    bank_frozen = {110: 0x4358, 111: 0x3232, 112: 0x3331, 113: 0x4734, 114: 0x3832}
+    bank_live = {110: 0x4358, 111: 0x3232, 112: 0x3331, 113: 0x4734, 114: 0x0001}
+    for _ in range(5):
+        _feed_bank(plant, bank_frozen)
+    assert plant.is_block_frozen(0x32, "IR", 60, 60, n=5) is True
+    _feed_bank(plant, bank_live)
+    assert plant.is_block_frozen(0x32, "IR", 60, 60, n=5) is False
+
+
+def test_is_battery_frozen_delegates_to_ir_60_60(plant: Plant):
+    """is_battery_frozen is a convenience alias for IR(60, 60)."""
+    bank = {110: 0x4358, 111: 0x3232, 112: 0x3331, 113: 0x4734, 114: 0x3832}
+    for _ in range(5):
+        _feed_bank(plant, bank, base=60, count=60)
+    assert plant.is_battery_frozen(0x32) is True
+    # A different block (different base) is not affected.
+    assert plant.is_block_frozen(0x32, "IR", 0, 60, n=5) is False
+
+
+def test_hash_deque_capped_at_max_size(plant: Plant):
+    """The internal deque never grows beyond _FROZEN_HASH_DEQUE_SIZE."""
+    from givenergy_modbus.model.plant import _FROZEN_HASH_DEQUE_SIZE
+
+    bank = {110: 0x4358, 111: 0x3232, 112: 0x3331, 113: 0x4734, 114: 0x3832}
+    for i in range(_FROZEN_HASH_DEQUE_SIZE * 2):
+        _feed_bank(plant, {**bank, 60: i})  # vary one register so hashes differ
+    key = (0x32, "IR", 60, 60)
+    dq = plant._block_content_hashes[key]
+    assert len(dq) == _FROZEN_HASH_DEQUE_SIZE


### PR DESCRIPTION
## What

Lands the **content-staleness primitive** on `Plant`: per-register-block tracking of how long the block's content has been byte-identical, exposed read-only as `content_unchanged_seconds()`. This is the duration substrate for #91 (frozen-BMS-cache detection) — it reports a raw duration and makes **no freeze verdict** (see "Why no verdict yet").

## Background

When an LV battery's BMS enters firmware-update bootloader mode it goes quiet on RS485; the inverter freezes its cached register page and serves it byte-identical indefinitely. From the TCP side that's indistinguishable from "live but unchanged" without comparing consecutive reads over time. A ~1-hour freeze was captured on my own plant during a battery firmware update (2026-05-27).

## Changes

- `Plant._block_unchanged_since` (private) — per-`(device, reg_type, base, count)` `(content_hash, unchanged_since)`, where `unchanged_since` is the ingestion time of the **first** commit in the current byte-identical run. O(1) per block; survives unchanged runs of any length.
- `Plant._track_content_change()` — called from `update()` whenever `_commit_bank()` returns True, mirroring `_stamp_block()` (#65). Equal hash keeps the timestamp anchored; a changed/first hash resets it. Discarded banks update nothing.
- `Plant.content_unchanged_seconds(...)` — read-only accessor returning the duration (or `None` if never seen). Parallels `block_age()`.

## Why no verdict yet

The first cut exposed `is_battery_frozen()` with a consecutive-equality test. Codex review flagged it fires on healthy hardware, and replaying the committed corpus confirmed it:

| Capture | Battery | Samples | Max byte-identical streak |
|---|---|---|---|
| hybrid 10-min | 0x32 | 96 | **26** |
| hybrid 10-min | 0x33 | 93 | **23** |
| hybrid 60-min | 0x32 | 346 | 15 |
| AC 30-min | 0x32 | 64 | 7–8 |

The dongle fans out the same cached frame to every connected TCP client (so consecutive `update()` calls aren't independent polls), and battery telemetry genuinely doesn't change every poll. Distinguishing a bootloader freeze from a live-but-static BMS needs a **duration** threshold validated against more than the one freeze capture I have (the real incident never changed for a full hour; healthy 0x32 changed 14× in 10 min). `content_unchanged_seconds()` provides the measured duration that detector will threshold on; the threshold + policy is the deferred #91 work.

A second Codex pass caught that the original retained primitive (a bounded hash deque) discarded the timing a duration detector needs — and evicted the run's origin once a run exceeded the deque size. The `unchanged_since` tracker here fixes that: it records when the current content first appeared and survives arbitrarily long runs.

## Tests

Seven unit tests pinning the duration semantics: never-seen → None, accumulation while identical, reset on change, a 20-commit run reporting its true 600 s origin (the case the old deque couldn't represent), per-block keying, discarded banks leaving the tracker untouched, naive-`now` normalisation.

Full suite + tox py311–py314 + lint + build all green.

Refs #91 (stays open — the freeze *verdict* is deferred pending a validated threshold).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
