### PR TITLE
fix(model): only adopt inverter serial from the inverter's own PDU (hass#95)

### DIFF
--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -534,8 +534,17 @@ class Plant(GivEnergyBaseModel):
             _logger.debug(f"First time encountering device address 0x{device_address:02x}")
             self.register_caches[device_address] = RegisterCache()
 
-        self.inverter_serial_number = pdu.inverter_serial_number
-        self.data_adapter_serial_number = pdu.data_adapter_serial_number
+        # Only the inverter's own responses carry the plant's identity. Battery (0x32-0x37),
+        # BCU/BMS (0x70+/0xA0) and AIO battery-module (0x50-0x53) responses put their *own*
+        # serial in the envelope inverter_serial_number field, so adopting it from every PDU
+        # lets whichever device is polled last clobber the real inverter serial — which merged
+        # the AIO inverter HA device into a battery module downstream (givenergy-hass#95).
+        # Gate on the inverter address (capabilities, or the canonical 0x11/0x31 before detect).
+        inv_addr = self.capabilities.inverter_address if self.capabilities is not None else None
+        is_inverter_pdu = device_address == inv_addr if inv_addr is not None else device_address in (0x11, 0x31)
+        if is_inverter_pdu:
+            self.inverter_serial_number = pdu.inverter_serial_number
+            self.data_adapter_serial_number = pdu.data_adapter_serial_number
 
         if isinstance(pdu, ReadHoldingRegistersResponse):
             incoming = {HR(k): v for k, v in pdu.to_dict().items()}

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -461,7 +461,16 @@ class Plant(GivEnergyBaseModel):
 
     register_caches: dict[int, RegisterCache] = {}
     capabilities: PlantCapabilities | None = None
-    inverter_serial_number: str = ""
+    # DEPRECATED (#227): the envelope-derived inverter serial duplicates the
+    # register-authoritative ``Plant.inverter.serial_number`` (HR13-17). Retained for
+    # backward compatibility; consumers should migrate to ``inverter.serial_number``. A
+    # runtime DeprecationWarning + removal will follow once consumers have migrated.
+    inverter_serial_number: str = Field(
+        default="",
+        description="DEPRECATED (#227): prefer Plant.inverter.serial_number (register-authoritative).",
+    )
+    # NOT deprecated: the TCP dongle's serial has no register source — the frame envelope is the
+    # only place it appears — so this remains the canonical accessor for the dongle identity.
     data_adapter_serial_number: str = ""
     # Ingestion timestamps per committed register block, keyed by
     # (device_address, register_type_name, base_register) → last successful commit time (#65).

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -534,17 +534,21 @@ class Plant(GivEnergyBaseModel):
             _logger.debug(f"First time encountering device address 0x{device_address:02x}")
             self.register_caches[device_address] = RegisterCache()
 
-        # Only the inverter's own responses carry the plant's identity. Battery (0x32-0x37),
-        # BCU/BMS (0x70+/0xA0) and AIO battery-module (0x50-0x53) responses put their *own*
-        # serial in the envelope inverter_serial_number field, so adopting it from every PDU
-        # lets whichever device is polled last clobber the real inverter serial — which merged
-        # the AIO inverter HA device into a battery module downstream (givenergy-hass#95).
-        # Gate on the inverter address (capabilities, or the canonical 0x11/0x31 before detect).
-        inv_addr = self.capabilities.inverter_address if self.capabilities is not None else None
-        is_inverter_pdu = device_address == inv_addr if inv_addr is not None else device_address in (0x11, 0x31)
-        if is_inverter_pdu:
+        # The TCP dongle's serial is identical on every response regardless of the addressed
+        # downstream device (verified across the AIO capture: meters, inverter, modules, BCU and
+        # BMS all carry the same data_adapter serial), so adopt it from any accepted PDU.
+        self.data_adapter_serial_number = pdu.data_adapter_serial_number
+
+        # inverter_serial_number, by contrast, is the *addressed device's* serial in the envelope:
+        # battery (0x32-0x37), BCU/BMS (0x70+/0xA0) and AIO battery-module (0x50-0x53) responses
+        # carry their own, so adopting it from every PDU let whichever device was polled last
+        # clobber the real inverter serial — merging the AIO inverter HA device into a battery
+        # module downstream (givenergy-hass#95). The inverter is canonically addressed at
+        # 0x11/0x31 (inverter_address_for never yields anything else), so gate on that set — it
+        # excludes peripherals and the legacy 0x32 (battery pack #1) a pre-#119 persisted
+        # capability may still carry until detect() self-heals.
+        if device_address in (0x11, 0x31):
             self.inverter_serial_number = pdu.inverter_serial_number
-            self.data_adapter_serial_number = pdu.data_adapter_serial_number
 
         if isinstance(pdu, ReadHoldingRegistersResponse):
             incoming = {HR(k): v for k, v in pdu.to_dict().items()}

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -461,16 +461,14 @@ class Plant(GivEnergyBaseModel):
 
     register_caches: dict[int, RegisterCache] = {}
     capabilities: PlantCapabilities | None = None
-    # DEPRECATED (#227): the envelope-derived inverter serial duplicates the
-    # register-authoritative ``Plant.inverter.serial_number`` (HR13-17). Retained for
-    # backward compatibility; consumers should migrate to ``inverter.serial_number``. A
-    # runtime DeprecationWarning + removal will follow once consumers have migrated.
-    inverter_serial_number: str = Field(
-        default="",
-        description="DEPRECATED (#227): prefer Plant.inverter.serial_number (register-authoritative).",
-    )
-    # NOT deprecated: the TCP dongle's serial has no register source — the frame envelope is the
-    # only place it appears — so this remains the canonical accessor for the dongle identity.
+    # The inverter serial from the response envelope, adopted only from the inverter's own
+    # responses (see update()). This is the earliest-available inverter identity — populated at
+    # detect() from the 0x11 read — and stays correct across the plant lifecycle, unlike
+    # ``Plant.inverter.serial_number`` which is empty in the detect→first-refresh window for
+    # AC/HYBRID_GEN1 (reads 0x31, not populated by detect) and reads the 0x32 battery cache on a
+    # bare plant. A single unified accessor is tracked in #227. The dongle serial below has no
+    # register source — the envelope is its only home.
+    inverter_serial_number: str = ""
     data_adapter_serial_number: str = ""
     # Ingestion timestamps per committed register block, keyed by
     # (device_address, register_type_name, base_register) → last successful commit time (#65).

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -1967,27 +1967,46 @@ def test_inverter_serial_not_clobbered_by_module_pdu():
     """A module PDU's envelope serial must not overwrite the real inverter serial (hass#95).
 
     On an AIO the 0x50-0x53 battery-module responses carry their own HX… serial in the PDU
-    envelope. Adopting it would merge the inverter device into a battery module downstream.
+    envelope. Adopting it would merge the inverter device into a battery module downstream. The
+    dongle (data_adapter) serial is identical on every response, so it rides along unchanged.
     """
     plant = Plant(capabilities=PlantCapabilities(device_type=Model.ALL_IN_ONE, inverter_address=0x11))
 
     inv = _make_ir_pdu({5: 2367}, device_address=0x11)
     inv.inverter_serial_number = "CH2414G047"
-    inv.data_adapter_serial_number = "WF2414G047"
+    inv.data_adapter_serial_number = "WJ2414G000"
     plant.update(inv)
     assert plant.inverter_serial_number == "CH2414G047"
-    assert plant.data_adapter_serial_number == "WF2414G047"
+    assert plant.data_adapter_serial_number == "WJ2414G000"
 
     module = _make_ir_pdu({60: 3280}, device_address=0x50)
     module.inverter_serial_number = "HX2414G047"
-    module.data_adapter_serial_number = "HX2414G047"
+    module.data_adapter_serial_number = "WJ2414G000"  # same dongle on every response
     plant.update(module)
     assert plant.inverter_serial_number == "CH2414G047", "module envelope must not clobber inverter serial"
-    assert plant.data_adapter_serial_number == "WF2414G047"
+    assert plant.data_adapter_serial_number == "WJ2414G000"
 
 
-def test_inverter_serial_bootstrap_without_capabilities():
-    """Without capabilities, only the canonical inverter addresses (0x11/0x31) set the serial."""
+def test_data_adapter_serial_adopted_from_any_device_but_inverter_serial_is_not():
+    """The dongle serial is adopted from a peripheral-only stream; the inverter serial is not.
+
+    data_adapter_serial_number identifies the TCP dongle, identical across every response
+    regardless of addressed device, so a battery/meter/BCU response must still populate it.
+    inverter_serial_number stays gated to the inverter address.
+    """
+    plant = Plant()
+
+    batt = _make_ir_pdu({60: 3221}, device_address=0x32)
+    batt.inverter_serial_number = "ZZ9999Z999"  # the battery's own envelope serial
+    batt.data_adapter_serial_number = "WJ2414G000"
+    plant.update(batt)
+
+    assert plant.data_adapter_serial_number == "WJ2414G000", "dongle serial must be adopted from any PDU"
+    assert plant.inverter_serial_number == "", "a battery PDU must not set the inverter serial"
+
+
+def test_inverter_serial_set_from_canonical_addresses():
+    """Both canonical inverter addresses (0x11 and the AC/HYBRID_GEN1 0x31 facade) set the serial."""
     plant = Plant()
 
     inv = _make_ir_pdu({5: 2367}, device_address=0x11)
@@ -1995,22 +2014,22 @@ def test_inverter_serial_bootstrap_without_capabilities():
     plant.update(inv)
     assert plant.inverter_serial_number == "CH2414G047"
 
+    facade = _make_ir_pdu({5: 2367}, device_address=0x31)
+    facade.inverter_serial_number = "SA2114G047"
+    plant.update(facade)
+    assert plant.inverter_serial_number == "SA2114G047"
+
+
+def test_inverter_serial_ignores_stale_0x32_capability():
+    """Even a stale pre-#119 capability with inverter_address=0x32 can't let a battery PDU set it.
+
+    0x32 is battery pack #1; a persisted pre-#119 capability may still carry it as the inverter
+    address until detect() self-heals. The gate is the canonical {0x11, 0x31} set, so 0x32 never
+    qualifies regardless of capabilities.
+    """
+    plant = Plant(capabilities=PlantCapabilities(device_type=Model.HYBRID_GEN1, inverter_address=0x32))
+
     batt = _make_ir_pdu({60: 3221}, device_address=0x32)
     batt.inverter_serial_number = "ZZ9999Z999"
     plant.update(batt)
-    assert plant.inverter_serial_number == "CH2414G047", "a battery PDU must not set the inverter serial"
-
-
-def test_inverter_serial_respects_capabilities_inverter_address():
-    """When the inverter lives at 0x31, only 0x31 PDUs set the serial (not other devices)."""
-    plant = Plant(capabilities=PlantCapabilities(device_type=Model.HYBRID_GEN1, inverter_address=0x31))
-
-    inv = _make_ir_pdu({5: 2367}, device_address=0x31)
-    inv.inverter_serial_number = "SA2114G047"
-    plant.update(inv)
-    assert plant.inverter_serial_number == "SA2114G047"
-
-    module = _make_ir_pdu({60: 3280}, device_address=0x50)
-    module.inverter_serial_number = "HX2414G047"
-    plant.update(module)
-    assert plant.inverter_serial_number == "SA2114G047"
+    assert plant.inverter_serial_number == "", "a stale 0x32 inverter_address must not let a battery clobber it"

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -1956,3 +1956,61 @@ def test_plant_capabilities_is_ac_coupled():
     assert (ac.is_ac_coupled and not ac.is_three_phase) is True
     ac3 = PlantCapabilities(device_type=Model.AC_3PH)
     assert (ac3.is_ac_coupled and not ac3.is_three_phase) is False
+
+
+# ---------------------------------------------------------------------------
+# Inverter-serial identity: only the inverter's own PDU sets it (givenergy-hass#95)
+# ---------------------------------------------------------------------------
+
+
+def test_inverter_serial_not_clobbered_by_module_pdu():
+    """A module PDU's envelope serial must not overwrite the real inverter serial (hass#95).
+
+    On an AIO the 0x50-0x53 battery-module responses carry their own HX… serial in the PDU
+    envelope. Adopting it would merge the inverter device into a battery module downstream.
+    """
+    plant = Plant(capabilities=PlantCapabilities(device_type=Model.ALL_IN_ONE, inverter_address=0x11))
+
+    inv = _make_ir_pdu({5: 2367}, device_address=0x11)
+    inv.inverter_serial_number = "CH2414G047"
+    inv.data_adapter_serial_number = "WF2414G047"
+    plant.update(inv)
+    assert plant.inverter_serial_number == "CH2414G047"
+    assert plant.data_adapter_serial_number == "WF2414G047"
+
+    module = _make_ir_pdu({60: 3280}, device_address=0x50)
+    module.inverter_serial_number = "HX2414G047"
+    module.data_adapter_serial_number = "HX2414G047"
+    plant.update(module)
+    assert plant.inverter_serial_number == "CH2414G047", "module envelope must not clobber inverter serial"
+    assert plant.data_adapter_serial_number == "WF2414G047"
+
+
+def test_inverter_serial_bootstrap_without_capabilities():
+    """Without capabilities, only the canonical inverter addresses (0x11/0x31) set the serial."""
+    plant = Plant()
+
+    inv = _make_ir_pdu({5: 2367}, device_address=0x11)
+    inv.inverter_serial_number = "CH2414G047"
+    plant.update(inv)
+    assert plant.inverter_serial_number == "CH2414G047"
+
+    batt = _make_ir_pdu({60: 3221}, device_address=0x32)
+    batt.inverter_serial_number = "ZZ9999Z999"
+    plant.update(batt)
+    assert plant.inverter_serial_number == "CH2414G047", "a battery PDU must not set the inverter serial"
+
+
+def test_inverter_serial_respects_capabilities_inverter_address():
+    """When the inverter lives at 0x31, only 0x31 PDUs set the serial (not other devices)."""
+    plant = Plant(capabilities=PlantCapabilities(device_type=Model.HYBRID_GEN1, inverter_address=0x31))
+
+    inv = _make_ir_pdu({5: 2367}, device_address=0x31)
+    inv.inverter_serial_number = "SA2114G047"
+    plant.update(inv)
+    assert plant.inverter_serial_number == "SA2114G047"
+
+    module = _make_ir_pdu({60: 3280}, device_address=0x50)
+    module.inverter_serial_number = "HX2414G047"
+    plant.update(module)
+    assert plant.inverter_serial_number == "SA2114G047"


### PR DESCRIPTION
## Problem

On an AIO, the inverter HA device **merges into a battery module** downstream — the inverter's own serial disappears. Reported by the hass agent validating #192 on AberDino's real 4-module AIO (givenergy-hass#95); blocks hass v1.2.0 stable.

## Root cause

`Plant.update()` set `inverter_serial_number` / `data_adapter_serial_number` from **every** `TransparentResponse`, last-write-wins. The `0x50–0x53` AIO battery-module responses carry their *own* `HX…` serial in the envelope `inverter_serial_number` field, so a poll cycle ending on a module overwrote the real inverter serial.

Confirmed against the `aio_a` fixture — the per-device envelope serials are:

| device | envelope `inverter_serial_number` |
|---|---|
| `0x11` inverter | `CH2414G000` ✅ the real one |
| `0x50–0x53` modules | `HX0000G000` |
| `0x70`/`0xA0` BCU/BMS | `HC0000G000` |

The fixture only *looks* correct because its last frame happens to be the `0x11` response — pure ordering luck. Live hardware ends on a module. The same latent bug affects HV BCU (`0x70`) envelopes on non-AIO HV systems, which is why this lands on `main` rather than v2.2-only.

## Fix

Gate the envelope-serial adoption on the inverter address — `capabilities.inverter_address` when known, else the canonical `{0x11, 0x31}` before `detect()` has run. Modules, batteries, BCU/BMS and meters are all excluded. The model field `plant.inverter.serial_number` (HR13-17 decode) was always correct; this makes the envelope field match it regardless of frame order.

## Tests (TDD, synthetic — the fixture is ordering-masked so a golden replay can't catch it)

- inverter PDU sets the serial, then a `0x50` module PDU with an `HX…` envelope must **not** clobber it
- bootstrap without capabilities: `0x11` sets it, a `0x32` battery PDU does not
- with `capabilities.inverter_address = 0x31`: only `0x31` sets it

Full suite (826) + tox py311–314 + lint + build green; zero fallout. `aio_a` replay still resolves `CH2414G000`.

Fixes givenergy-hass#95 (library side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where inverter and data adapter serial numbers could be incorrectly overwritten by other connected devices (such as batteries or stack modules) within the larger system. Serial number assignments are now properly validated and gated by device address, ensuring only the true primary inverter can update these identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

### Updates after review

- **Codex/Gemini**: gate **only** `inverter_serial_number` (on the canonical `{0x11, 0x31}` set, which sidesteps a stale pre-#119 `0x32` capability). `data_adapter_serial_number` is the **dongle** serial — identical across every response address (verified) — so it's adopted unconditionally; gating it had regressed peripheral-only streams.

