### PR TITLE
fix(model): close redact_serials() gaps — meter serial + Plant header (#224 H2)

### DIFF
--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -519,11 +519,15 @@ class Plant(GivEnergyBaseModel):
         """
         from givenergy_modbus.model.register import Converter
 
+        # Fail closed: redact_serial_strict blanks any unrecognised identifier rather than leaking
+        # it verbatim (redact_serial is fail-open). register_block_updated_at is copied so the
+        # redacted snapshot stays independent of later updates to the original.
         return self.model_copy(
             update={
                 "register_caches": {addr: cache.redact_serials() for addr, cache in self.register_caches.items()},
-                "inverter_serial_number": Converter.redact_serial(self.inverter_serial_number) or "",
-                "data_adapter_serial_number": Converter.redact_serial(self.data_adapter_serial_number) or "",
+                "inverter_serial_number": Converter.redact_serial_strict(self.inverter_serial_number),
+                "data_adapter_serial_number": Converter.redact_serial_strict(self.data_adapter_serial_number),
+                "register_block_updated_at": dict(self.register_block_updated_at),
             }
         )
 

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -509,6 +509,24 @@ class Plant(GivEnergyBaseModel):
             return BcuRegisterGetter
         return None
 
+    def redact(self) -> "Plant":
+        """Return a share-safe copy: every register cache redacted and the header serials cleared.
+
+        ``redact_serials()`` only covers the register caches; ``inverter_serial_number`` and
+        ``data_adapter_serial_number`` live on the Plant itself (populated from the PDU envelope),
+        so a dumped Plant still leaks both unless they're redacted here too. The original is left
+        untouched (#212/#214 share-safe-export guarantee).
+        """
+        from givenergy_modbus.model.register import Converter
+
+        return self.model_copy(
+            update={
+                "register_caches": {addr: cache.redact_serials() for addr, cache in self.register_caches.items()},
+                "inverter_serial_number": Converter.redact_serial(self.inverter_serial_number) or "",
+                "data_adapter_serial_number": Converter.redact_serial(self.data_adapter_serial_number) or "",
+            }
+        )
+
     def update(self, pdu: ClientIncomingMessage, *, received_at: datetime | None = None):
         """Update the Plant state from a PDU message.
 

--- a/givenergy_modbus/model/register.py
+++ b/givenergy_modbus/model/register.py
@@ -105,6 +105,25 @@ class Converter:
         return s
 
     @staticmethod
+    def redact_serial_strict(s: str | None) -> str:
+        """Fail-closed serial redaction for share-safe exports.
+
+        Behaves like :meth:`redact_serial` for recognised GE serials (keep the prefix +
+        manufacture date, zero the unit digits), but **blanks** anything that isn't a recognised
+        serial. ``redact_serial`` is fail-open — it returns an unrecognised shape unchanged — which
+        would leak a vendor-specific or non-standard identifier verbatim through a share-safe
+        export. This blanks those. Returns "" for empty/unrecognised input.
+        """
+        if not s:
+            return ""
+        redacted = Converter.redact_serial(s)
+        if redacted and redacted != s:
+            return redacted  # recognised and not yet redacted → date-preserving redaction
+        if _SERIAL_PATTERN.fullmatch(s) or _EMS_SERIAL_PATTERN.fullmatch(s):
+            return s  # recognised but already redacted → unchanged
+        return ""  # unrecognised identifier in a serial location → fail closed
+
+    @staticmethod
     def fstr(val, fmt) -> str | None:
         """Render a value using a format string."""
         if val is not None:

--- a/givenergy_modbus/model/register_cache.py
+++ b/givenergy_modbus/model/register_cache.py
@@ -67,6 +67,11 @@ def _get_serial_groups() -> "list[tuple[str, int, int]]":
     # (CH… → HC…), recoverable to the real serial, so it must not leak in a shared
     # export. Appended explicitly, like the BMU serials, since no LUT Def carries it.
     groups.append(("HR", 8, 5))
+    # Meter product serial (MR 60-61, FC 0x16). The MeterProductRegisterGetter walk above
+    # doesn't reach it (meter isn't a walked module and its Def is C.string), and it's a short
+    # 2-register identifier that doesn't match the GE serial pattern — so redact_serials() blanks
+    # it rather than pattern-redacting (audit H2). Appended explicitly here.
+    groups.append(("MR", 60, 2))
     _SERIAL_GROUPS = groups
     return _SERIAL_GROUPS
 
@@ -163,7 +168,7 @@ class RegisterCache(defaultdict[Register, int]):
         """
         from givenergy_modbus.model.register import Converter
 
-        _reg_cls: dict[str, type[Register]] = {"HR": HR, "IR": IR}
+        _reg_cls: dict[str, type[Register]] = {"HR": HR, "IR": IR, "MR": MR}
         result = RegisterCache(dict(self))
         for reg_type, base, count in _get_serial_groups():
             reg_cls = _reg_cls.get(reg_type)
@@ -171,6 +176,13 @@ class RegisterCache(defaultdict[Register, int]):
                 continue
             regs = [reg_cls(base + i) for i in range(count)]
             if not all(isinstance(self.get(r), int) for r in regs):
+                continue
+            # Meter identifiers (MR) are short, non-GE-pattern values that redact_serial can't
+            # match — blank them entirely so a shared export doesn't leak the meter identity.
+            # (Zeroing an already-zero group is a no-op, so this stays idempotent.)
+            if reg_type == "MR":
+                for reg in regs:
+                    result[reg] = 0
                 continue
             raw = b"".join((self[r] & 0xFFFF).to_bytes(2, "big") for r in regs)
             serial_str = raw.decode("latin1").replace("\x00", "").upper()

--- a/givenergy_modbus/model/register_cache.py
+++ b/givenergy_modbus/model/register_cache.py
@@ -68,10 +68,13 @@ def _get_serial_groups() -> "list[tuple[str, int, int]]":
     # export. Appended explicitly, like the BMU serials, since no LUT Def carries it.
     groups.append(("HR", 8, 5))
     # Meter product serial (MR 60-61, FC 0x16). The MeterProductRegisterGetter walk above
-    # doesn't reach it (meter isn't a walked module and its Def is C.string), and it's a short
-    # 2-register identifier that doesn't match the GE serial pattern — so redact_serials() blanks
-    # it rather than pattern-redacting (audit H2). Appended explicitly here.
-    groups.append(("MR", 60, 2))
+    # doesn't reach it (meter isn't a walked module and its Def is C.string), so add it
+    # explicitly. It's a short non-GE-pattern identifier; redact_serials() blanks it via the
+    # fail-closed strict redaction (audit H2). Guarded against a future auto-discovery duplicate.
+    mr_key = ("MR", 60, 2)
+    if mr_key not in seen:
+        seen.add(mr_key)
+        groups.append(mr_key)
     _SERIAL_GROUPS = groups
     return _SERIAL_GROUPS
 
@@ -177,17 +180,12 @@ class RegisterCache(defaultdict[Register, int]):
             regs = [reg_cls(base + i) for i in range(count)]
             if not all(isinstance(self.get(r), int) for r in regs):
                 continue
-            # Meter identifiers (MR) are short, non-GE-pattern values that redact_serial can't
-            # match — blank them entirely so a shared export doesn't leak the meter identity.
-            # (Zeroing an already-zero group is a no-op, so this stays idempotent.)
-            if reg_type == "MR":
-                for reg in regs:
-                    result[reg] = 0
-                continue
             raw = b"".join((self[r] & 0xFFFF).to_bytes(2, "big") for r in regs)
             serial_str = raw.decode("latin1").replace("\x00", "").upper()
-            redacted = Converter.redact_serial(serial_str)
-            if redacted is None or redacted == serial_str:
+            # Fail closed: a recognised serial is date-redacted, anything else (vendor/meter/
+            # unknown format) is blanked — a known serial location must never leak verbatim.
+            redacted = Converter.redact_serial_strict(serial_str)
+            if redacted == serial_str:
                 continue
             redacted_bytes = redacted.encode("latin1").ljust(count * 2, b"\x00")[: count * 2]
             for i, reg in enumerate(regs):

--- a/givenergy_modbus/model/register_cache.py
+++ b/givenergy_modbus/model/register_cache.py
@@ -158,13 +158,12 @@ class RegisterCache(defaultdict[Register, int]):
 
         Identifies every register group tagged as ``Converter.serial`` in the model
         LUTs (plus BMU serial groups, which are decoded manually), decodes each group
-        to a string, applies ``Converter.redact_serial`` (zeroing the trailing unit
-        digits), and re-encodes back into register values.
-
-        Groups that are only partially present in the cache, or whose decoded string
-        doesn't match a known serial pattern, are left unchanged.  Any register
-        whose value is not a plain integer (e.g. explicitly set to ``None``) causes
-        the group to be skipped rather than crash.
+        to a string, and **fails closed** (the share-safe-export boundary, #212/#214): a
+        recognised serial is date-redacted (prefix + manufacture date kept, unit digits
+        zeroed); anything else — an unrecognised format, or a *partially* present group
+        that can't be fully decoded — has its present registers blanked, so no fragment
+        of a known identifier ever leaks. A fully-absent group is left untouched (no
+        absent registers are injected).
 
         Produces the same ``AAYYWWA000``-style placeholders as :class:`FrameRedactor`,
         so a redacted export is indistinguishable from a redacted capture.
@@ -173,15 +172,25 @@ class RegisterCache(defaultdict[Register, int]):
 
         _reg_cls: dict[str, type[Register]] = {"HR": HR, "IR": IR, "MR": MR}
         result = RegisterCache(dict(self))
+        covered: set[Register] = set()  # registers owned by a fully-present (properly redacted) group
+        partial_fragments: list[Register] = []
+        # First pass — redact every fully-present group. Serial groups can overlap (e.g. the LV
+        # battery serial IR(110-114) and BMU#0 serial IR(114-118) share IR(114)), so record which
+        # registers a full group owns before deciding what to blank.
         for reg_type, base, count in _get_serial_groups():
             reg_cls = _reg_cls.get(reg_type)
             if reg_cls is None:
                 continue
             regs = [reg_cls(base + i) for i in range(count)]
-            if not all(isinstance(self.get(r), int) for r in regs):
+            present = [r for r in regs if isinstance(self.get(r), int)]
+            if not present:
+                continue  # group entirely absent — nothing to redact, don't inject registers
+            if len(present) < count:
+                partial_fragments.extend(present)  # handled in the second pass
                 continue
             raw = b"".join((self[r] & 0xFFFF).to_bytes(2, "big") for r in regs)
             serial_str = raw.decode("latin1").replace("\x00", "").upper()
+            covered.update(regs)
             # Fail closed: a recognised serial is date-redacted, anything else (vendor/meter/
             # unknown format) is blanked — a known serial location must never leak verbatim.
             redacted = Converter.redact_serial_strict(serial_str)
@@ -190,6 +199,12 @@ class RegisterCache(defaultdict[Register, int]):
             redacted_bytes = redacted.encode("latin1").ljust(count * 2, b"\x00")[: count * 2]
             for i, reg in enumerate(regs):
                 result[reg] = int.from_bytes(redacted_bytes[i * 2 : i * 2 + 2], "big")
+        # Second pass — a partially-present group can't be decoded, but each present register is a
+        # fragment of a known identifier. Fail closed by blanking it, unless a fully-present group
+        # already owns (and redacted) that register.
+        for reg in partial_fragments:
+            if reg not in covered:
+                result[reg] = 0
         return result
 
     def to_timeslot(self, start: Register, end: Register) -> "TimeSlot | None":

--- a/givenergy_modbus/model/register_cache.py
+++ b/givenergy_modbus/model/register_cache.py
@@ -157,13 +157,20 @@ class RegisterCache(defaultdict[Register, int]):
         """Return a copy of this cache with all known serial-number registers redacted.
 
         Identifies every register group tagged as ``Converter.serial`` in the model
-        LUTs (plus BMU serial groups, which are decoded manually), decodes each group
-        to a string, and **fails closed** (the share-safe-export boundary, #212/#214): a
-        recognised serial is date-redacted (prefix + manufacture date kept, unit digits
-        zeroed); anything else — an unrecognised format, or a *partially* present group
-        that can't be fully decoded — has its present registers blanked, so no fragment
-        of a known identifier ever leaks. A fully-absent group is left untouched (no
-        absent registers are injected).
+        LUTs (plus BMU serial groups, which are decoded manually), decodes each fully-
+        present group, and date-redacts values that match a known GE serial pattern
+        (prefix + manufacture date kept, unit digits zeroed).
+
+        **Fails open for HR/IR groups by necessity.** Serial groups are applied without
+        device-type context and overlap: the BMU serial groups (e.g. IR(114-118)) are
+        real serials only on HV BMU stacks, but on an LV battery those addresses hold the
+        battery serial's last register (IR114) and ordinary data (IR115 = usb_device_inserted).
+        With no way to tell a non-GE serial from non-serial data, anything that doesn't
+        match a serial pattern is left **unchanged** — blanking it would destroy legitimate
+        data and corrupt overlapping serials. The share-safe-export guarantee (#212/#214)
+        is enforced fail-closed where it is unambiguous: the inverter/dongle header serials
+        (:meth:`Plant.redact`) and the meter product identifier (MR, a distinct register
+        namespace, blanked below).
 
         Produces the same ``AAYYWWA000``-style placeholders as :class:`FrameRedactor`,
         so a redacted export is indistinguishable from a redacted capture.
@@ -172,39 +179,27 @@ class RegisterCache(defaultdict[Register, int]):
 
         _reg_cls: dict[str, type[Register]] = {"HR": HR, "IR": IR, "MR": MR}
         result = RegisterCache(dict(self))
-        covered: set[Register] = set()  # registers owned by a fully-present (properly redacted) group
-        partial_fragments: list[Register] = []
-        # First pass — redact every fully-present group. Serial groups can overlap (e.g. the LV
-        # battery serial IR(110-114) and BMU#0 serial IR(114-118) share IR(114)), so record which
-        # registers a full group owns before deciding what to blank.
         for reg_type, base, count in _get_serial_groups():
             reg_cls = _reg_cls.get(reg_type)
             if reg_cls is None:
                 continue
             regs = [reg_cls(base + i) for i in range(count)]
-            present = [r for r in regs if isinstance(self.get(r), int)]
-            if not present:
-                continue  # group entirely absent — nothing to redact, don't inject registers
-            if len(present) < count:
-                partial_fragments.extend(present)  # handled in the second pass
+            if not all(isinstance(self.get(r), int) for r in regs):
+                continue
+            # Meter product identifier (MR): a short non-GE value in a distinct register
+            # namespace that can't overlap HR/IR data — safe to blank outright.
+            if reg_type == "MR":
+                for reg in regs:
+                    result[reg] = 0
                 continue
             raw = b"".join((self[r] & 0xFFFF).to_bytes(2, "big") for r in regs)
             serial_str = raw.decode("latin1").replace("\x00", "").upper()
-            covered.update(regs)
-            # Fail closed: a recognised serial is date-redacted, anything else (vendor/meter/
-            # unknown format) is blanked — a known serial location must never leak verbatim.
-            redacted = Converter.redact_serial_strict(serial_str)
-            if redacted == serial_str:
-                continue
+            redacted = Converter.redact_serial(serial_str)
+            if redacted is None or redacted == serial_str:
+                continue  # not a recognised serial — leave unchanged (may be non-serial data)
             redacted_bytes = redacted.encode("latin1").ljust(count * 2, b"\x00")[: count * 2]
             for i, reg in enumerate(regs):
                 result[reg] = int.from_bytes(redacted_bytes[i * 2 : i * 2 + 2], "big")
-        # Second pass — a partially-present group can't be decoded, but each present register is a
-        # fragment of a known identifier. Fail closed by blanking it, unless a fully-present group
-        # already owns (and redacted) that register.
-        for reg in partial_fragments:
-            if reg not in covered:
-                result[reg] = 0
         return result
 
     def to_timeslot(self, start: Register, end: Register) -> "TimeSlot | None":

--- a/givenergy_modbus/model/register_cache.py
+++ b/givenergy_modbus/model/register_cache.py
@@ -184,13 +184,16 @@ class RegisterCache(defaultdict[Register, int]):
             if reg_cls is None:
                 continue
             regs = [reg_cls(base + i) for i in range(count)]
-            if not all(isinstance(self.get(r), int) for r in regs):
-                continue
-            # Meter product identifier (MR): a short non-GE value in a distinct register
-            # namespace that can't overlap HR/IR data — safe to blank outright.
+            # Meter product identifier (MR): a short non-GE value in a distinct register namespace
+            # that can't overlap HR/IR data — safe to fail closed. Blank whatever is present (a
+            # full or partial fragment) before the HR/IR completeness check, without injecting
+            # absent registers.
             if reg_type == "MR":
                 for reg in regs:
-                    result[reg] = 0
+                    if isinstance(self.get(reg), int):
+                        result[reg] = 0
+                continue
+            if not all(isinstance(self.get(r), int) for r in regs):
                 continue
             raw = b"".join((self[r] & 0xFFFF).to_bytes(2, "big") for r in regs)
             serial_str = raw.decode("latin1").replace("\x00", "").upper()

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -2072,3 +2072,19 @@ def test_plant_redact_handles_empty_serials():
     redacted = plant.redact()
     assert redacted.inverter_serial_number == ""
     assert redacted.data_adapter_serial_number == ""
+
+
+def test_plant_redact_fails_closed_on_unrecognised_header_serial():
+    """redact() blanks an unrecognised header serial rather than leaking it (audit H2, fail-closed).
+
+    Converter.redact_serial is fail-open (returns unrecognised shapes unchanged); the share-safe
+    redact() must not pass a vendor/non-standard identifier through verbatim.
+    """
+    plant = Plant()
+    plant.inverter_serial_number = "UNKNOWN123"  # valid charset, matches no GE pattern
+    plant.data_adapter_serial_number = "ODD-SERIAL"
+
+    redacted = plant.redact()
+
+    assert redacted.inverter_serial_number == ""
+    assert redacted.data_adapter_serial_number == ""

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -2033,3 +2033,42 @@ def test_inverter_serial_ignores_stale_0x32_capability():
     batt.inverter_serial_number = "ZZ9999Z999"
     plant.update(batt)
     assert plant.inverter_serial_number == "", "a stale 0x32 inverter_address must not let a battery clobber it"
+
+
+def test_plant_redact_clears_header_serials_and_redacts_caches():
+    """Plant.redact() redacts every cache AND the out-of-cache header serials (audit H2).
+
+    inverter_serial_number / data_adapter_serial_number live on the Plant, not in any cache, so
+    redacting caches alone still leaks them in a shared dump. redact() returns a copy with both
+    the caches and the header serials redacted, leaving the original untouched.
+    """
+
+    def _enc(serial, base):
+        padded = serial.encode("latin1").ljust(10, b"\x00")[:10]
+        return {HR(base + i): int.from_bytes(padded[i * 2 : i * 2 + 2], "big") for i in range(5)}
+
+    plant = Plant()
+    plant.inverter_serial_number = "CH2414G047"
+    plant.data_adapter_serial_number = "WF2414G047"
+    plant.register_caches[0x11] = RegisterCache(_enc("SA2114G123", 13))  # inverter serial HR(13-17)
+
+    redacted = plant.redact()
+
+    assert redacted.inverter_serial_number == "CH2414G000"
+    assert redacted.data_adapter_serial_number == "WF2414G000"
+    raw = b"".join((redacted.register_caches[0x11][HR(13 + i)] & 0xFFFF).to_bytes(2, "big") for i in range(5))
+    assert raw.decode("latin1").replace("\x00", "").upper() == "SA2114G000"
+    # original untouched
+    assert plant.inverter_serial_number == "CH2414G047"
+    orig = b"".join((plant.register_caches[0x11][HR(13 + i)] & 0xFFFF).to_bytes(2, "big") for i in range(5))
+    assert orig.decode("latin1").replace("\x00", "").upper() == "SA2114G123"
+
+
+def test_plant_redact_handles_empty_serials():
+    """redact() with empty header serials returns empty, not an error (audit H2 — the `or ''` path)."""
+    plant = Plant()
+    plant.inverter_serial_number = ""
+    plant.data_adapter_serial_number = ""
+    redacted = plant.redact()
+    assert redacted.inverter_serial_number == ""
+    assert redacted.data_adapter_serial_number == ""

--- a/tests/model/test_register.py
+++ b/tests/model/test_register.py
@@ -153,6 +153,17 @@ def test_redact_serial_passthrough_and_empty():
     assert Converter.redact_serial("CE2231G000") == "CE2231G000"
 
 
+def test_redact_serial_strict_fails_closed():
+    """redact_serial_strict redacts recognised serials and blanks everything else (fail-closed)."""
+    assert Converter.redact_serial_strict("CE2231G454") == "CE2231G000"  # recognised, redacted
+    assert Converter.redact_serial_strict("EMS2522018") == "EMS2522000"  # recognised EMS form
+    assert Converter.redact_serial_strict("CE2231G000") == "CE2231G000"  # recognised, already redacted
+    assert Converter.redact_serial_strict("UNKNOWN123") == ""  # valid charset, unknown pattern → blank
+    assert Converter.redact_serial_strict("AB12") == ""  # short non-GE identifier → blank
+    assert Converter.redact_serial_strict("") == ""
+    assert Converter.redact_serial_strict(None) == ""
+
+
 def test_battery_max_power():
     from givenergy_modbus.model.inverter import _battery_max_power
 

--- a/tests/model/test_register_cache.py
+++ b/tests/model/test_register_cache.py
@@ -348,3 +348,14 @@ def test_redact_serials_leaves_partial_group_unchanged():
     assert result[HR(13)] == 0x5341
     assert result[HR(14)] == 0x3231
     assert HR(15) not in result, "absent registers must not be injected"
+
+
+def test_redact_serials_blanks_partial_meter_identifier():
+    """A partial meter identifier is still blanked — MR is a distinct namespace with no overlap.
+
+    Unlike HR/IR (where a partial group can't be distinguished from non-serial data), MR can't
+    overlap ordinary registers, so a present fragment is always sensitive and safe to blank.
+    """
+    result = RegisterCache({MR(60): 0x4142}).redact_serials()  # "AB" fragment; MR(61) absent
+    assert result[MR(60)] == 0
+    assert MR(61) not in result, "absent MR register must not be injected"

--- a/tests/model/test_register_cache.py
+++ b/tests/model/test_register_cache.py
@@ -231,15 +231,34 @@ def test_redact_serials_is_idempotent():
     assert dict(once) == dict(twice)
 
 
-def test_redact_serials_fails_closed_on_unrecognised_serial():
-    """A known serial location holding an unrecognised format is blanked, not leaked (audit H2).
+def test_redact_serials_leaves_unrecognised_shape_unchanged():
+    """A value in an HR/IR serial group that matches no GE pattern is left unchanged (fail-open).
 
-    redact_serials() is the share-safe boundary, so it fails closed: a value in a C.serial
-    register group that matches neither GE pattern is zeroed rather than passed through verbatim.
+    Serial groups are applied without device-type context and overlap (BMU groups overlap LV
+    battery data), so a non-matching value can't be distinguished from non-serial data — blanking
+    it would destroy legitimate data. The fail-closed guarantee lives at the header-serial and MR
+    boundaries instead. See redact_serials() docstring.
     """
-    registers = _encode_serial("ZZZZZZZZZZ", IR, 110)  # battery serial group; valid charset, no GE pattern
+    registers = _encode_serial("ZZZZZZZZZZ", IR, 110)
     result = RegisterCache(registers).redact_serials()
-    assert all(result[IR(110 + i)] == 0 for i in range(5)), "unrecognised serial must be blanked"
+    assert dict(result) == dict(RegisterCache(registers))
+
+
+def test_redact_serials_preserves_overlapping_non_serial_data():
+    """A full LV battery bank redacts the serial but preserves overlapping non-serial data.
+
+    Regression for the overlap found in review: the globally-applied BMU serial group IR(114-118)
+    overlaps the LV battery serial (IR114) and real data (IR115 = usb_device_inserted). Redacting
+    must zero only the battery serial's unit digits and leave IR(115) intact.
+    """
+    registers = _encode_serial("CE2231A123", IR, 110)  # battery serial IR(110-114)
+    registers[IR(115)] = 8  # usb_device_inserted — legitimate non-serial data
+
+    result = RegisterCache(registers).redact_serials()
+
+    redacted_serial = b"".join((result[IR(110 + i)] & 0xFFFF).to_bytes(2, "big") for i in range(5))
+    assert redacted_serial.decode("latin1").replace("\x00", "").upper() == "CE2231A000"
+    assert result[IR(115)] == 8, "overlapping non-serial data must be preserved"
 
 
 def test_redact_serials_absent_group_not_injected():
@@ -318,16 +337,14 @@ def test_redact_serials_byte_swapped_aio_serial_hr8():
     assert raw.decode("latin1").replace("\x00", "").upper() == "HC2114G000"
 
 
-def test_redact_serials_partial_group_is_blanked():
-    """A partially-present serial group has its present registers blanked, not leaked (audit H2).
+def test_redact_serials_leaves_partial_group_unchanged():
+    """A partially-present serial group is left unchanged and no absent registers are injected.
 
-    A cache can hold only some registers of a known identifier location; the present fragment is
-    still sensitive. redact_serials() zeroes the present registers without injecting the absent
-    ones.
+    Without all registers the group can't be decoded; like the unrecognised-shape case, the cache
+    redaction fails open here to avoid destroying data it can't positively identify as a serial.
     """
-    # Only the first two registers of the inverter serial group HR(13-17) are present.
-    registers = {HR(13): 0x5341, HR(14): 0x3231}  # "SA21" fragment
+    registers = {HR(13): 0x5341, HR(14): 0x3231}  # "SA21" fragment of the inverter serial group
     result = RegisterCache(registers).redact_serials()
-    assert result[HR(13)] == 0
-    assert result[HR(14)] == 0
+    assert result[HR(13)] == 0x5341
+    assert result[HR(14)] == 0x3231
     assert HR(15) not in result, "absent registers must not be injected"

--- a/tests/model/test_register_cache.py
+++ b/tests/model/test_register_cache.py
@@ -231,11 +231,15 @@ def test_redact_serials_is_idempotent():
     assert dict(once) == dict(twice)
 
 
-def test_redact_serials_unrecognised_shape_passes_through():
-    """A serial that doesn't match either known pattern is left unchanged."""
-    registers = _encode_serial("ZZZZZZZZZZ", IR, 110)
+def test_redact_serials_fails_closed_on_unrecognised_serial():
+    """A known serial location holding an unrecognised format is blanked, not leaked (audit H2).
+
+    redact_serials() is the share-safe boundary, so it fails closed: a value in a C.serial
+    register group that matches neither GE pattern is zeroed rather than passed through verbatim.
+    """
+    registers = _encode_serial("ZZZZZZZZZZ", IR, 110)  # battery serial group; valid charset, no GE pattern
     result = RegisterCache(registers).redact_serials()
-    assert dict(result) == dict(RegisterCache(registers))
+    assert all(result[IR(110 + i)] == 0 for i in range(5)), "unrecognised serial must be blanked"
 
 
 def test_redact_serials_absent_group_not_injected():

--- a/tests/model/test_register_cache.py
+++ b/tests/model/test_register_cache.py
@@ -316,3 +316,18 @@ def test_redact_serials_byte_swapped_aio_serial_hr8():
     result = RegisterCache(registers).redact_serials()
     raw = b"".join((result[HR(8 + i)] & 0xFFFF).to_bytes(2, "big") for i in range(5))
     assert raw.decode("latin1").replace("\x00", "").upper() == "HC2114G000"
+
+
+def test_redact_serials_partial_group_is_blanked():
+    """A partially-present serial group has its present registers blanked, not leaked (audit H2).
+
+    A cache can hold only some registers of a known identifier location; the present fragment is
+    still sensitive. redact_serials() zeroes the present registers without injecting the absent
+    ones.
+    """
+    # Only the first two registers of the inverter serial group HR(13-17) are present.
+    registers = {HR(13): 0x5341, HR(14): 0x3231}  # "SA21" fragment
+    result = RegisterCache(registers).redact_serials()
+    assert result[HR(13)] == 0
+    assert result[HR(14)] == 0
+    assert HR(15) not in result, "absent registers must not be injected"

--- a/tests/model/test_register_cache.py
+++ b/tests/model/test_register_cache.py
@@ -283,3 +283,32 @@ def test_redact_serials_bmu_serial_redacted():
     for reg, val in expected.items():
         assert result[reg] == val, f"{reg} mismatch"
     assert result[IR(0)] == 7  # untouched
+
+
+def test_redact_serials_meter_mr_group():
+    """The meter product serial (MR 60-61) is blanked in a share-safe export (audit H2).
+
+    The meter identifier is a short 2-register value that doesn't match the GE serial pattern,
+    so it can't be pattern-redacted — redact_serials() zeroes it instead, so a shared export
+    doesn't leak the meter identity.
+    """
+    val = "AB12".encode("latin1")  # 4-char meter identifier across MR(60-61)
+    registers = {MR(60): int.from_bytes(val[0:2], "big"), MR(61): int.from_bytes(val[2:4], "big")}
+
+    result = RegisterCache(registers).redact_serials()
+
+    assert result[MR(60)] == 0
+    assert result[MR(61)] == 0
+
+
+def test_redact_serials_byte_swapped_aio_serial_hr8():
+    """A byte-swapped AIO serial at HR(8-12) is redacted via RegisterCache.redact_serials() (audit H2).
+
+    AIO firmware stores the unit serial byte-swapped (CH… → HC…) at HR(8-12); HC2114G047 matches
+    the standard pattern, so it must redact to HC2114G000. Closes the coverage gap vs the
+    FrameRedactor path (already covered in test_capture.py).
+    """
+    registers = _encode_serial("HC2114G047", HR, 8)
+    result = RegisterCache(registers).redact_serials()
+    raw = b"".join((result[HR(8 + i)] & 0xFFFF).to_bytes(2, "big") for i in range(5))
+    assert raw.decode("latin1").replace("\x00", "").upper() == "HC2114G000"


### PR DESCRIPTION
Batch 2 of the security audit (#224) — **H2 redaction integrity, the sole remaining High**. Restores the #212/#214 share-safe-export guarantee.

## Fixes

| Item | Change | Test |
|---|---|---|
| **Meter serial leak** | `MR(60-61)` was never redacted — the LUT walk skips the meter module, its Def is `C.string`, and `redact_serials()` only mapped HR/IR. Added an explicit `("MR", 60, 2)` group + mapped `MR`. It's a 2-register identifier that doesn't match the GE 10-char pattern, so it's **blanked** rather than pattern-redacted. | `test_redact_serials_meter_mr_group` |
| **Plant header serials** | `inverter_serial_number` / `data_adapter_serial_number` live on the `Plant` (from the PDU envelope), outside any cache — so redacting caches alone still leaked them. New **`Plant.redact()`** returns a copy with caches redacted *and* both header serials redacted; original untouched. | `test_plant_redact_clears_header_serials_and_redacts_caches` |
| **Byte-swap coverage** | Regression test for a byte-swapped AIO serial (`HC2114G047`) through `RegisterCache.redact_serials()` HR(8-12) — the FrameRedactor path was already covered. | `test_redact_serials_byte_swapped_aio_serial_hr8` |

## One design call worth flagging

The audit assumed the meter serial could be `redact_serial`-pattern-redacted, but it's only **4 chars** (`MR(60-61)`) and matches neither GE pattern (`[A-Z]{2}\d{4}[A-Z]\d{3}` / EMS). So I **zero it** instead — for a share-safe export, blanking a short meter identifier is the conservative choice.

## Deferred follow-ups (noted, tracked against #224)

- **FrameRedactor capture path** doesn't redact `MR` — its `reg_type` is HR/IR only (it types frames by function code), a separate surface from the `redact_serials()` export this PR targets. The audit's H2 fix plan is scoped to `redact_serials()`.
- **Auto-discovery**: both serial-group builders still hardcode `(inverter, battery, ems, gateway)`; walking all `RegisterGetter` subclasses would prevent a future getter being silently missed (as meter was). The audit lists this as "Consider".

Full suite + tox py311–314 + lint + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
