### PR TITLE
fix(commands): security-audit batch 3 — write-path assurance (#224)

### DIFF
--- a/SECURITY-AUDIT-2026-06-10.md
+++ b/SECURITY-AUDIT-2026-06-10.md
@@ -71,6 +71,19 @@ Severity scale: **High** = fix soon, real attacker value or undercuts a stated g
 
 ### M1 — Write responses don't verify the echoed value
 
+> **Amended 2026-06-10 (Batch 3 analysis): dropped — unattributable on this bus topology.**
+> Write-response correlation is by shape hash (`device_address` + `register`; the GE framing
+> carries no usable transaction ID), and the dongle fans out responses to **all** connected TCP
+> clients (#196, confirmed universal). Another actor's write echo for the same register (cloud,
+> app, another client) therefore resolves our future: a value mismatch usually means "caught
+> someone else's echo", not "device clamped our write", and a match can mask a real clamp — the
+> signal carries no reliable information, and a WARNING would routinely misfire during normal
+> multi-actor operation. The forged-ack scenario was already void per the amended threat model
+> (an on-path attacker forges the value *and* the unauthenticated CRC). Adding `value` to the
+> shape hash would convert every legitimate clamp into a timeout/retry storm. The cache already
+> reflects the device's echoed reality (`plant.py` routes the echo into the inverter cache);
+> **read-back-after-write is the sound consumer pattern.**
+
 - **Where:** `givenergy_modbus/pdu/write_registers.py` (`_extra_shape_hash_keys` covers
   `device_address` + `register`, not `value`); `givenergy_modbus/client/client.py`
   (`send_request_and_await_response` checks only `response.error`)
@@ -79,9 +92,8 @@ Severity scale: **High** = fix soon, real attacker value or undercuts a stated g
   is 50 when the device wrote 0. Given the hardware-safety posture, the echoed value should be
   checked.
 - **Fix plan:**
-  - [ ] Compare `response.value` to the requested value in the write path; log WARNING (or
-        raise, behind an option) on mismatch. (Including `value` in the shape hash is the
-        stricter alternative but changes response-correlation semantics — decide explicitly.)
+  - [x] ~~Compare `response.value` to the requested value in the write path~~ — dropped per the
+        amendment above; no runtime check is sound without echo attribution.
 
 ### M2 — Log injection via device-supplied strings; serials logged unredacted
 

--- a/givenergy_modbus/client/commands.py
+++ b/givenergy_modbus/client/commands.py
@@ -308,6 +308,10 @@ def set_export_priority(priority: ExportPriority) -> list[TransparentRequest]:
     Determines where surplus energy goes: battery first, grid first, or load first.
     Confirmed writable on Model.AC via direct portal observations (hass#52).
     """
+    # bool subclasses int, so ExportPriority(True) would resolve to GRID_FIRST and pass as an
+    # IntEnum — silently selecting a write mode. Reject it before the enum conversion (audit L1).
+    if isinstance(priority, bool):
+        raise ValueError(f"Export priority must be an ExportPriority, not bool (got {priority!r})")
     try:
         priority = ExportPriority(priority)
     except ValueError as e:

--- a/givenergy_modbus/client/commands.py
+++ b/givenergy_modbus/client/commands.py
@@ -113,15 +113,19 @@ class RegisterMap:
 
 
 def _as_int(val: int, name: str) -> int:
-    """Coerce a numeric command argument to int, rejecting bool (audit L1).
+    """Validate a numeric command argument as an integral number (audit L1).
 
-    bool subclasses int, so a plain ``int(val)`` coercion would silently turn True/False
-    into 1/0 *before* the PDU-level bool guard can see it — e.g. ``set_active_power_rate(True)``
-    writing 1. Numeric helpers route their caller input through this instead.
+    Fails loud on the silent-coercion caller-error class: bool subclasses int (True would
+    write 1 or select slot 1's registers), a non-integral float would truncate (2.9 selecting
+    slot 2), and a string is type confusion. Integral floats (50.0) are unambiguous and
+    accepted. Numeric helpers route caller input through this instead of bare ``int(val)``.
     """
-    if isinstance(val, bool):
-        raise ValueError(f"{name} must be an int, not bool")
-    return int(val)
+    if isinstance(val, bool) or not isinstance(val, int | float):
+        raise ValueError(f"{name} must be a number, not {type(val).__name__}")
+    i = int(val)
+    if i != val:
+        raise ValueError(f"{name} must be integral, got {val!r}")
+    return i
 
 
 @deprecated("Call Client.detect() then load_config()/refresh() instead — see PlantNotDetected.")
@@ -359,6 +363,7 @@ def set_pause_slot(slot: TimeSlot | None) -> list[TransparentRequest]:
 
 def set_smart_load_slot_start(idx: int, t: dt_time | None) -> list[TransparentRequest]:
     """Set the start time of Smart Load slot *idx* (1-based, 1–10), or clear it if t is None."""
+    idx = _as_int(idx, "idx")
     if not (1 <= idx <= 10):
         raise ValueError(f"Smart Load slot index must be 1–10 (got {idx})")
     return _set_slot_endpoint(RegisterMap.SMART_LOAD_SLOT_1_START + (idx - 1) * 2, t)
@@ -366,6 +371,7 @@ def set_smart_load_slot_start(idx: int, t: dt_time | None) -> list[TransparentRe
 
 def set_smart_load_slot_end(idx: int, t: dt_time | None) -> list[TransparentRequest]:
     """Set the end time of Smart Load slot *idx* (1-based, 1–10), or clear it if t is None."""
+    idx = _as_int(idx, "idx")
     if not (1 <= idx <= 10):
         raise ValueError(f"Smart Load slot index must be 1–10 (got {idx})")
     return _set_slot_endpoint(RegisterMap.SMART_LOAD_SLOT_1_START + (idx - 1) * 2 + 1, t)
@@ -399,6 +405,7 @@ def set_ems_plant(enabled: bool) -> list[TransparentRequest]:
 
 
 def _export_slot_registers(idx: int) -> tuple[int, int]:
+    idx = _as_int(idx, "idx")  # True == 1 would silently select slot 1's registers
     if not 1 <= idx <= 3:
         raise ValueError(f"Export slot index ({idx}) must be in [1-3]")
     return getattr(RegisterMap, f"EXPORT_SLOT_{idx}_START"), getattr(RegisterMap, f"EXPORT_SLOT_{idx}_END")
@@ -468,6 +475,7 @@ def set_ems_discharge_slot_end(idx: int, t: dt_time | None) -> list[TransparentR
 
 def set_ems_charge_target_soc(idx: int, target_soc: int) -> list[TransparentRequest]:
     """Set the SoC target (0-100%) for EMS plant charge slot idx (1-3)."""
+    idx = _as_int(idx, "idx")
     if not 1 <= idx <= 3:
         raise ValueError(f"EMS charge slot index ({idx}) must be in [1-3]")
     return [
@@ -477,6 +485,7 @@ def set_ems_charge_target_soc(idx: int, target_soc: int) -> list[TransparentRequ
 
 def set_ems_discharge_target_soc(idx: int, target_soc: int) -> list[TransparentRequest]:
     """Set the SoC target (0-100%) for EMS plant discharge slot idx (1-3)."""
+    idx = _as_int(idx, "idx")
     if not 1 <= idx <= 3:
         raise ValueError(f"EMS discharge slot index ({idx}) must be in [1-3]")
     return [
@@ -508,6 +517,7 @@ def set_ems_export_slot_end(idx: int, t: dt_time | None) -> list[TransparentRequ
 
 def set_ems_export_target_soc(idx: int, target_soc: int) -> list[TransparentRequest]:
     """Set the SoC target (0-100%) for EMS plant export slot idx (1-3)."""
+    idx = _as_int(idx, "idx")
     if not 1 <= idx <= 3:
         raise ValueError(f"EMS export slot index ({idx}) must be in [1-3]")
     return [
@@ -533,6 +543,7 @@ def _set_slot_endpoint(hr: int, t: dt_time | None) -> list[TransparentRequest]:
 
 
 def _resolve_slot_registers(discharge: bool, idx: int, slot_map: SlotMap) -> tuple[int, int]:
+    idx = _as_int(idx, "idx")  # True == 1 would silently select slot 1's registers
     slots = slot_map.discharge_slots if discharge else slot_map.charge_slots
     n = len(slots)
     if not 1 <= idx <= n:

--- a/givenergy_modbus/client/commands.py
+++ b/givenergy_modbus/client/commands.py
@@ -135,7 +135,7 @@ def refresh_plant_data(complete: bool, number_batteries: int = 1, max_batteries:
 def disable_charge_target() -> list[TransparentRequest]:
     """Removes SOC limit and target 100% charging."""
     return [
-        WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE_TARGET, False),
+        WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE_TARGET, 0),
         WriteHoldingRegisterRequest(RegisterMap.CHARGE_TARGET_SOC, 100),
     ]
 
@@ -148,19 +148,19 @@ def set_charge_target(target_soc: int) -> list[TransparentRequest]:
     if target_soc == 100:
         ret.extend(disable_charge_target())
     else:
-        ret.append(WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE_TARGET, True))
+        ret.append(WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE_TARGET, 1))
         ret.append(WriteHoldingRegisterRequest(RegisterMap.CHARGE_TARGET_SOC, target_soc))
     return ret
 
 
 def set_enable_charge(enabled: bool) -> list[TransparentRequest]:
     """Enable the battery to charge, depending on the mode and slots set."""
-    return [WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE, enabled)]
+    return [WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE, 1 if enabled else 0)]
 
 
 def set_enable_discharge(enabled: bool) -> list[TransparentRequest]:
     """Enable the battery to discharge, depending on the mode and slots set."""
-    return [WriteHoldingRegisterRequest(RegisterMap.ENABLE_DISCHARGE, enabled)]
+    return [WriteHoldingRegisterRequest(RegisterMap.ENABLE_DISCHARGE, 1 if enabled else 0)]
 
 
 def set_inverter_reboot() -> list[TransparentRequest]:
@@ -283,7 +283,7 @@ def set_active_power_rate(target: int) -> list[TransparentRequest]:
 
 def set_enable_rtc(enabled: bool) -> list[TransparentRequest]:
     """Enable the Real Time Clock register to persist settings to EEPROM."""
-    return [WriteHoldingRegisterRequest(RegisterMap.ENABLE_RTC, enabled)]
+    return [WriteHoldingRegisterRequest(RegisterMap.ENABLE_RTC, 1 if enabled else 0)]
 
 
 def set_export_priority(priority: ExportPriority) -> list[TransparentRequest]:
@@ -304,7 +304,7 @@ def set_enable_eps(enabled: bool) -> list[TransparentRequest]:
 
     Confirmed writable on Model.AC via direct portal observations (hass#52).
     """
-    return [WriteHoldingRegisterRequest(RegisterMap.ENABLE_EPS, bool(enabled))]
+    return [WriteHoldingRegisterRequest(RegisterMap.ENABLE_EPS, 1 if enabled else 0)]
 
 
 def set_battery_charge_limit_ac(val: int) -> list[TransparentRequest]:
@@ -368,22 +368,22 @@ def set_smart_load_slot(idx: int, slot: "TimeSlot | None") -> list[TransparentRe
 
 def set_ac_charge(enabled: bool) -> list[TransparentRequest]:
     """Enable AC charging on three-phase inverters."""
-    return [WriteHoldingRegisterRequest(RegisterMap.AC_CHARGE_ENABLE, enabled)]
+    return [WriteHoldingRegisterRequest(RegisterMap.AC_CHARGE_ENABLE, 1 if enabled else 0)]
 
 
 def set_force_charge(enabled: bool) -> list[TransparentRequest]:
     """Enable forced battery charging on three-phase inverters."""
-    return [WriteHoldingRegisterRequest(RegisterMap.FORCE_CHARGE_ENABLE, enabled)]
+    return [WriteHoldingRegisterRequest(RegisterMap.FORCE_CHARGE_ENABLE, 1 if enabled else 0)]
 
 
 def set_force_discharge(enabled: bool) -> list[TransparentRequest]:
     """Enable forced battery discharging on three-phase inverters."""
-    return [WriteHoldingRegisterRequest(RegisterMap.FORCE_DISCHARGE_ENABLE, enabled)]
+    return [WriteHoldingRegisterRequest(RegisterMap.FORCE_DISCHARGE_ENABLE, 1 if enabled else 0)]
 
 
 def set_ems_plant(enabled: bool) -> list[TransparentRequest]:
     """Enable EMS plant control."""
-    return [WriteHoldingRegisterRequest(RegisterMap.EMS_PLANT_ENABLE, enabled)]
+    return [WriteHoldingRegisterRequest(RegisterMap.EMS_PLANT_ENABLE, 1 if enabled else 0)]
 
 
 def _export_slot_registers(idx: int) -> tuple[int, int]:

--- a/givenergy_modbus/client/commands.py
+++ b/givenergy_modbus/client/commands.py
@@ -112,6 +112,18 @@ class RegisterMap:
     EMS_EXPORT_POWER_LIMIT = 2071
 
 
+def _as_int(val: int, name: str) -> int:
+    """Coerce a numeric command argument to int, rejecting bool (audit L1).
+
+    bool subclasses int, so a plain ``int(val)`` coercion would silently turn True/False
+    into 1/0 *before* the PDU-level bool guard can see it — e.g. ``set_active_power_rate(True)``
+    writing 1. Numeric helpers route their caller input through this instead.
+    """
+    if isinstance(val, bool):
+        raise ValueError(f"{name} must be an int, not bool")
+    return int(val)
+
+
 @deprecated("Call Client.detect() then load_config()/refresh() instead — see PlantNotDetected.")
 def refresh_plant_data(complete: bool, number_batteries: int = 1, max_batteries: int = 5) -> list[TransparentRequest]:
     """Removed: built a fixed 0x32-addressed poll that timed out on non-0x32 models.
@@ -225,7 +237,7 @@ def set_battery_soc_reserve(val: int) -> list[TransparentRequest]:
     GivTCP's independent choice for the same register — treat as the working
     assumption until a portal capture contradicts it.
     """
-    val = int(val)
+    val = _as_int(val, "val")
     if not 4 <= val <= 100:
         raise ValueError(f"Minimum SOC / shallow charge ({val}) must be in [4-100]%")
     return [WriteHoldingRegisterRequest(RegisterMap.BATTERY_SOC_RESERVE, val)]
@@ -238,7 +250,7 @@ def set_battery_reserve_soc(val: int) -> list[TransparentRequest]:
     Bounds [4-100]% are unconfirmed (no GivTCP cross-reference exists for this register);
     treat as the working assumption until a live three-phase capture confirms them.
     """
-    val = int(val)
+    val = _as_int(val, "val")
     if not 4 <= val <= 100:
         raise ValueError(f"Battery reserve SOC ({val}) must be in [4-100]%")
     return [WriteHoldingRegisterRequest(RegisterMap.BATTERY_RESERVE_SOC, val)]
@@ -246,7 +258,7 @@ def set_battery_reserve_soc(val: int) -> list[TransparentRequest]:
 
 def set_battery_charge_limit(val: int) -> list[TransparentRequest]:
     """Set the battery charge power limit as a percentage of rated charge power (0–50)."""
-    val = int(val)
+    val = _as_int(val, "val")
     if not 0 <= val <= 50:
         raise ValueError(f"Specified Charge Limit ({val}%) is not in [0-50]%")
     return [WriteHoldingRegisterRequest(RegisterMap.BATTERY_CHARGE_LIMIT, val)]
@@ -254,7 +266,7 @@ def set_battery_charge_limit(val: int) -> list[TransparentRequest]:
 
 def set_battery_discharge_limit(val: int) -> list[TransparentRequest]:
     """Set the battery discharge power limit as a percentage of rated discharge power (0–50)."""
-    val = int(val)
+    val = _as_int(val, "val")
     if not 0 <= val <= 50:
         raise ValueError(f"Specified Discharge Limit ({val}%) is not in [0-50]%")
     return [WriteHoldingRegisterRequest(RegisterMap.BATTERY_DISCHARGE_LIMIT, val)]
@@ -267,7 +279,7 @@ def set_battery_power_reserve(val: int) -> list[TransparentRequest]:
     GivTCP's independent choice for the same register — treat as the working
     assumption until a portal capture contradicts it.
     """
-    val = int(val)
+    val = _as_int(val, "val")
     if not 4 <= val <= 100:
         raise ValueError(f"Battery power reserve ({val}) must be in [4-100]%")
     return [WriteHoldingRegisterRequest(RegisterMap.BATTERY_DISCHARGE_MIN_POWER_RESERVE, val)]
@@ -275,7 +287,7 @@ def set_battery_power_reserve(val: int) -> list[TransparentRequest]:
 
 def set_active_power_rate(target: int) -> list[TransparentRequest]:
     """Set the inverter's active power output as a percentage of its rated capacity."""
-    target = int(target)
+    target = _as_int(target, "target")
     if not 0 <= target <= 100:
         raise ValueError(f"Active power rate ({target}) must be in [0-100]%")
     return [WriteHoldingRegisterRequest(RegisterMap.ACTIVE_POWER_RATE, target)]
@@ -309,7 +321,7 @@ def set_enable_eps(enabled: bool) -> list[TransparentRequest]:
 
 def set_battery_charge_limit_ac(val: int) -> list[TransparentRequest]:
     """Set the battery AC charge power limit as a percentage."""
-    val = int(val)
+    val = _as_int(val, "val")
     if not 1 <= val <= 100:
         raise ValueError(f"Specified AC Charge Limit ({val}%) is not in [1-100]%")
     return [WriteHoldingRegisterRequest(RegisterMap.BATTERY_CHARGE_LIMIT_AC, val)]
@@ -317,7 +329,7 @@ def set_battery_charge_limit_ac(val: int) -> list[TransparentRequest]:
 
 def set_battery_discharge_limit_ac(val: int) -> list[TransparentRequest]:
     """Set the battery AC discharge power limit as a percentage."""
-    val = int(val)
+    val = _as_int(val, "val")
     if not 1 <= val <= 100:
         raise ValueError(f"Specified AC Discharge Limit ({val}%) is not in [1-100]%")
     return [WriteHoldingRegisterRequest(RegisterMap.BATTERY_DISCHARGE_LIMIT_AC, val)]
@@ -414,7 +426,7 @@ def set_export_slot(idx: int, slot: TimeSlot | None) -> list[TransparentRequest]
 
 def _ems_target_soc(val: int) -> int:
     """Validate an EMS SoC target percentage (0-100)."""
-    val = int(val)
+    val = _as_int(val, "val")
     if not 0 <= val <= 100:
         raise ValueError(f"EMS target SoC ({val}) must be in [0-100]")
     return val
@@ -509,7 +521,7 @@ def set_ems_export_power_limit(watts: int) -> list[TransparentRequest]:
     Bounded to a 16-bit holding register (0-65535) so an out-of-range value fails
     here rather than later at PDU-encode time as InvalidPduState.
     """
-    watts = int(watts)
+    watts = _as_int(watts, "watts")
     if not 0 <= watts <= 0xFFFF:
         raise ValueError(f"EMS export power limit ({watts}) must be in [0-65535] watts")
     return [WriteHoldingRegisterRequest(RegisterMap.EMS_EXPORT_POWER_LIMIT, watts)]

--- a/givenergy_modbus/pdu/write_registers.py
+++ b/givenergy_modbus/pdu/write_registers.py
@@ -195,7 +195,10 @@ class WriteHoldingRegister(TransparentMessage, ABC):
         if not isinstance(register, int):
             raise ValueError(f"Register type {type(register)} is unacceptable")
         self.register = register
-        if not isinstance(value, int):
+        # bool subclasses int, so it would pass the isinstance check below and silently write
+        # 0/1 — a bool reaching a numeric register (e.g. ACTIVE_POWER_RATE) is a caller bug.
+        # Boolean command helpers pass int(enabled) explicitly (audit L1).
+        if isinstance(value, bool) or not isinstance(value, int):
             raise ValueError(f"Register value {type(value)} is unacceptable")
         self.value = value
 

--- a/tests/client/test_commands.py
+++ b/tests/client/test_commands.py
@@ -775,3 +775,47 @@ def test_numeric_helpers_reject_bool(helper):
         helper(True)
     with pytest.raises(ValueError, match="bool"):
         helper(False)
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        pytest.param(
+            lambda: commands.set_charge_slot_start(True, dt_time(1, 0), SINGLE_PHASE_SLOTS), id="charge_slot_start"
+        ),
+        pytest.param(
+            lambda: commands.set_discharge_slot_end(True, dt_time(1, 0), SINGLE_PHASE_SLOTS), id="discharge_slot_end"
+        ),
+        pytest.param(lambda: commands.set_export_slot_start(True, dt_time(1, 0)), id="export_slot_start"),
+        pytest.param(lambda: commands.set_smart_load_slot_start(True, dt_time(1, 0)), id="smart_load_slot_start"),
+        pytest.param(lambda: commands.set_smart_load_slot_end(True, dt_time(1, 0)), id="smart_load_slot_end"),
+        pytest.param(lambda: commands.set_ems_charge_target_soc(True, 50), id="ems_charge_target_soc"),
+        pytest.param(lambda: commands.set_ems_discharge_target_soc(True, 50), id="ems_discharge_target_soc"),
+        pytest.param(lambda: commands.set_ems_export_target_soc(True, 50), id="ems_export_target_soc"),
+    ],
+)
+def test_slot_index_arguments_reject_bool(call):
+    """Slot/index selector arguments reject bool (audit L1 follow-up).
+
+    True == 1 passes the `1 <= idx` bounds checks and silently selects slot 1's REGISTER —
+    the same caller-error class as bool values, but worse on a write API: it picks the wrong
+    register rather than the wrong value.
+    """
+    with pytest.raises(ValueError, match="bool"):
+        call()
+
+
+def test_numeric_arguments_reject_non_integral_and_str():
+    """_as_int-guarded arguments reject non-integral floats and strings (fail loud, audit L1).
+
+    2.9 as a slot index would silently truncate to slot 2 (wrong-register selection); "100"
+    as a value is type confusion. Integral floats (50.0) stay accepted — they're unambiguous.
+    """
+    with pytest.raises(ValueError, match="integral"):
+        commands.set_export_slot_start(2.9, dt_time(1, 0))
+    with pytest.raises(ValueError, match="integral"):
+        commands.set_battery_soc_reserve(50.5)
+    with pytest.raises(ValueError, match="number"):
+        commands.set_battery_soc_reserve("100")
+    # Integral float remains accepted and resolves identically to the int.
+    assert commands.set_battery_soc_reserve(50.0) == commands.set_battery_soc_reserve(50)

--- a/tests/client/test_commands.py
+++ b/tests/client/test_commands.py
@@ -749,3 +749,29 @@ def test_refresh_plant_data_is_a_raising_stub():
     with pytest.warns(DeprecationWarning):
         with pytest.raises(PlantNotDetected, match="detect()"):
             commands.refresh_plant_data(True)
+
+
+@pytest.mark.parametrize(
+    "helper",
+    [
+        commands.set_battery_soc_reserve,
+        commands.set_battery_reserve_soc,
+        commands.set_battery_charge_limit,
+        commands.set_battery_discharge_limit,
+        commands.set_battery_power_reserve,
+        commands.set_active_power_rate,
+        commands.set_battery_charge_limit_ac,
+        commands.set_battery_discharge_limit_ac,
+        commands.set_ems_export_power_limit,
+    ],
+)
+def test_numeric_helpers_reject_bool(helper):
+    """Numeric command helpers reject bool before their int() coercion (audit L1).
+
+    These helpers coerce with int(value) before constructing the request, so the PDU-level
+    bool guard never sees the bool — set_active_power_rate(True) would silently write 1.
+    """
+    with pytest.raises(ValueError, match="bool"):
+        helper(True)
+    with pytest.raises(ValueError, match="bool"):
+        helper(False)

--- a/tests/client/test_commands.py
+++ b/tests/client/test_commands.py
@@ -819,3 +819,27 @@ def test_numeric_arguments_reject_non_integral_and_str():
         commands.set_battery_soc_reserve("100")
     # Integral float remains accepted and resolves identically to the int.
     assert commands.set_battery_soc_reserve(50.0) == commands.set_battery_soc_reserve(50)
+
+
+def test_set_export_priority_rejects_bool():
+    """set_export_priority rejects bool before the enum conversion (audit L1 follow-up).
+
+    ExportPriority(True) resolves to GRID_FIRST (1) and would pass as an IntEnum — silently
+    selecting a write mode. A bool here is a caller error and must fail loudly. Valid enum
+    members (and their int values) still work.
+    """
+    with pytest.raises(ValueError, match="bool"):
+        commands.set_export_priority(True)
+    with pytest.raises(ValueError, match="bool"):
+        commands.set_export_priority(False)
+    # Valid members / ints unaffected.
+    assert commands.set_export_priority(ExportPriority.GRID_FIRST) == [
+        WriteHoldingRegisterRequest(RegisterMap.EXPORT_PRIORITY, ExportPriority.GRID_FIRST)
+    ]
+    assert commands.set_export_priority(2) == [WriteHoldingRegisterRequest(RegisterMap.EXPORT_PRIORITY, 2)]
+
+
+def test_set_battery_pause_mode_rejects_bool():
+    """set_battery_pause_mode passes the raw value, so the PDU bool guard rejects True/False."""
+    with pytest.raises(ValueError, match="bool|unacceptable"):
+        commands.set_battery_pause_mode(True)

--- a/tests/client/test_commands.py
+++ b/tests/client/test_commands.py
@@ -15,13 +15,13 @@ from givenergy_modbus.pdu import WriteHoldingRegisterRequest
 async def test_configure_charge_target():
     """Ensure we can set and disable a charge target."""
     assert commands.set_charge_target(45) == [
-        WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE, True),
-        WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE_TARGET, True),
+        WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE, 1),
+        WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE_TARGET, 1),
         WriteHoldingRegisterRequest(RegisterMap.CHARGE_TARGET_SOC, 45),
     ]
     assert commands.set_charge_target(100) == [
-        WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE, True),
-        WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE_TARGET, False),
+        WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE, 1),
+        WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE_TARGET, 0),
         WriteHoldingRegisterRequest(RegisterMap.CHARGE_TARGET_SOC, 100),
     ]
 
@@ -33,29 +33,29 @@ async def test_configure_charge_target():
         commands.set_charge_target(101)
 
     assert commands.disable_charge_target() == [
-        WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE_TARGET, False),
+        WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE_TARGET, 0),
         WriteHoldingRegisterRequest(RegisterMap.CHARGE_TARGET_SOC, 100),
     ]
 
 
 async def test_set_charge():
     """Ensure we can toggle charging."""
-    assert commands.set_enable_charge(True) == [WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE, True)]
-    assert commands.set_enable_charge(False) == [WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE, False)]
+    assert commands.set_enable_charge(True) == [WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE, 1)]
+    assert commands.set_enable_charge(False) == [WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE, 0)]
     with pytest.warns(DeprecationWarning):
-        assert commands.enable_charge() == [WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE, True)]
+        assert commands.enable_charge() == [WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE, 1)]
     with pytest.warns(DeprecationWarning):
-        assert commands.disable_charge() == [WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE, False)]
+        assert commands.disable_charge() == [WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE, 0)]
 
 
 async def test_set_discharge():
     """Ensure we can toggle discharging."""
-    assert commands.set_enable_discharge(True) == [WriteHoldingRegisterRequest(RegisterMap.ENABLE_DISCHARGE, True)]
-    assert commands.set_enable_discharge(False) == [WriteHoldingRegisterRequest(RegisterMap.ENABLE_DISCHARGE, False)]
+    assert commands.set_enable_discharge(True) == [WriteHoldingRegisterRequest(RegisterMap.ENABLE_DISCHARGE, 1)]
+    assert commands.set_enable_discharge(False) == [WriteHoldingRegisterRequest(RegisterMap.ENABLE_DISCHARGE, 0)]
     with pytest.warns(DeprecationWarning):
-        assert commands.enable_discharge() == [WriteHoldingRegisterRequest(RegisterMap.ENABLE_DISCHARGE, True)]
+        assert commands.enable_discharge() == [WriteHoldingRegisterRequest(RegisterMap.ENABLE_DISCHARGE, 1)]
     with pytest.warns(DeprecationWarning):
-        assert commands.disable_discharge() == [WriteHoldingRegisterRequest(RegisterMap.ENABLE_DISCHARGE, False)]
+        assert commands.disable_discharge() == [WriteHoldingRegisterRequest(RegisterMap.ENABLE_DISCHARGE, 0)]
 
 
 async def test_set_battery_discharge_mode():
@@ -253,7 +253,7 @@ async def test_set_mode_dynamic():
     assert commands.set_mode_dynamic() == [
         WriteHoldingRegisterRequest(RegisterMap.BATTERY_POWER_MODE, 1),
         WriteHoldingRegisterRequest(RegisterMap.BATTERY_SOC_RESERVE, 4),
-        WriteHoldingRegisterRequest(RegisterMap.ENABLE_DISCHARGE, False),
+        WriteHoldingRegisterRequest(RegisterMap.ENABLE_DISCHARGE, 0),
     ]
 
 
@@ -261,7 +261,7 @@ async def test_set_mode_storage():
     """Ensure we can set the inverter to a storage mode with discharge slots."""
     assert commands.set_mode_storage(TimeSlot.from_components(1, 2, 3, 4)) == [
         WriteHoldingRegisterRequest(RegisterMap.BATTERY_POWER_MODE, 1),
-        WriteHoldingRegisterRequest(RegisterMap.ENABLE_DISCHARGE, True),
+        WriteHoldingRegisterRequest(RegisterMap.ENABLE_DISCHARGE, 1),
         WriteHoldingRegisterRequest(RegisterMap.DISCHARGE_SLOT_1_START, 102),
         WriteHoldingRegisterRequest(RegisterMap.DISCHARGE_SLOT_1_END, 304),
         WriteHoldingRegisterRequest(RegisterMap.DISCHARGE_SLOT_2_START, 0),
@@ -270,7 +270,7 @@ async def test_set_mode_storage():
 
     assert commands.set_mode_storage(TimeSlot.from_components(5, 6, 7, 8), TimeSlot.from_components(9, 10, 11, 12)) == [
         WriteHoldingRegisterRequest(RegisterMap.BATTERY_POWER_MODE, 1),
-        WriteHoldingRegisterRequest(RegisterMap.ENABLE_DISCHARGE, True),
+        WriteHoldingRegisterRequest(RegisterMap.ENABLE_DISCHARGE, 1),
         WriteHoldingRegisterRequest(RegisterMap.DISCHARGE_SLOT_1_START, 506),
         WriteHoldingRegisterRequest(RegisterMap.DISCHARGE_SLOT_1_END, 708),
         WriteHoldingRegisterRequest(RegisterMap.DISCHARGE_SLOT_2_START, 910),
@@ -279,7 +279,7 @@ async def test_set_mode_storage():
 
     assert commands.set_mode_storage(TimeSlot.from_repr(1314, 1516), discharge_for_export=True) == [
         WriteHoldingRegisterRequest(RegisterMap.BATTERY_POWER_MODE, 0),
-        WriteHoldingRegisterRequest(RegisterMap.ENABLE_DISCHARGE, True),
+        WriteHoldingRegisterRequest(RegisterMap.ENABLE_DISCHARGE, 1),
         WriteHoldingRegisterRequest(RegisterMap.DISCHARGE_SLOT_1_START, 1314),
         WriteHoldingRegisterRequest(RegisterMap.DISCHARGE_SLOT_1_END, 1516),
         WriteHoldingRegisterRequest(RegisterMap.DISCHARGE_SLOT_2_START, 0),
@@ -340,8 +340,8 @@ async def test_set_active_power_rate():
 
 
 async def test_set_enable_rtc():
-    assert commands.set_enable_rtc(True) == [WriteHoldingRegisterRequest(RegisterMap.ENABLE_RTC, True)]
-    assert commands.set_enable_rtc(False) == [WriteHoldingRegisterRequest(RegisterMap.ENABLE_RTC, False)]
+    assert commands.set_enable_rtc(True) == [WriteHoldingRegisterRequest(RegisterMap.ENABLE_RTC, 1)]
+    assert commands.set_enable_rtc(False) == [WriteHoldingRegisterRequest(RegisterMap.ENABLE_RTC, 0)]
 
 
 async def test_set_export_priority():
@@ -359,8 +359,8 @@ async def test_set_export_priority():
 
 
 async def test_set_enable_eps():
-    assert commands.set_enable_eps(True) == [WriteHoldingRegisterRequest(RegisterMap.ENABLE_EPS, True)]
-    assert commands.set_enable_eps(False) == [WriteHoldingRegisterRequest(RegisterMap.ENABLE_EPS, False)]
+    assert commands.set_enable_eps(True) == [WriteHoldingRegisterRequest(RegisterMap.ENABLE_EPS, 1)]
+    assert commands.set_enable_eps(False) == [WriteHoldingRegisterRequest(RegisterMap.ENABLE_EPS, 0)]
     # HR317 must be in the lower-level PDU allowlist, or encode() raises InvalidPduState.
     commands.set_enable_eps(True)[0].encode()
 
@@ -476,21 +476,21 @@ async def test_set_pause_slot():
 
 
 async def test_set_ac_charge():
-    assert commands.set_ac_charge(True) == [WriteHoldingRegisterRequest(RegisterMap.AC_CHARGE_ENABLE, True)]
-    assert commands.set_ac_charge(False) == [WriteHoldingRegisterRequest(RegisterMap.AC_CHARGE_ENABLE, False)]
+    assert commands.set_ac_charge(True) == [WriteHoldingRegisterRequest(RegisterMap.AC_CHARGE_ENABLE, 1)]
+    assert commands.set_ac_charge(False) == [WriteHoldingRegisterRequest(RegisterMap.AC_CHARGE_ENABLE, 0)]
 
 
 async def test_set_force_charge():
-    assert commands.set_force_charge(True) == [WriteHoldingRegisterRequest(RegisterMap.FORCE_CHARGE_ENABLE, True)]
+    assert commands.set_force_charge(True) == [WriteHoldingRegisterRequest(RegisterMap.FORCE_CHARGE_ENABLE, 1)]
 
 
 async def test_set_force_discharge():
-    assert commands.set_force_discharge(True) == [WriteHoldingRegisterRequest(RegisterMap.FORCE_DISCHARGE_ENABLE, True)]
+    assert commands.set_force_discharge(True) == [WriteHoldingRegisterRequest(RegisterMap.FORCE_DISCHARGE_ENABLE, 1)]
 
 
 async def test_set_ems_plant():
-    assert commands.set_ems_plant(True) == [WriteHoldingRegisterRequest(RegisterMap.EMS_PLANT_ENABLE, True)]
-    assert commands.set_ems_plant(False) == [WriteHoldingRegisterRequest(RegisterMap.EMS_PLANT_ENABLE, False)]
+    assert commands.set_ems_plant(True) == [WriteHoldingRegisterRequest(RegisterMap.EMS_PLANT_ENABLE, 1)]
+    assert commands.set_ems_plant(False) == [WriteHoldingRegisterRequest(RegisterMap.EMS_PLANT_ENABLE, 0)]
 
 
 @pytest.mark.parametrize("idx", [1, 2, 3])

--- a/tests/client/test_inverter_commands.py
+++ b/tests/client/test_inverter_commands.py
@@ -81,15 +81,15 @@ def test_mixin_classvar_does_not_leak_into_model_dump():
 def test_inverter_set_charge_target_emits_correct_writes():
     inv = _single_phase()
     assert inv.set_charge_target(80) == [
-        WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE, True),
-        WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE_TARGET, True),
+        WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE, 1),
+        WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE_TARGET, 1),
         WriteHoldingRegisterRequest(RegisterMap.CHARGE_TARGET_SOC, 80),
     ]
 
 
 def test_inverter_set_enable_charge_emits_single_write():
     assert _single_phase().set_enable_charge(False) == [
-        WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE, False),
+        WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE, 0),
     ]
 
 
@@ -177,7 +177,7 @@ def test_inverter_set_export_priority_emits_correct_write():
 
 def test_inverter_set_enable_eps_emits_correct_write():
     assert _single_phase().set_enable_eps(True) == [
-        WriteHoldingRegisterRequest(RegisterMap.ENABLE_EPS, True),
+        WriteHoldingRegisterRequest(RegisterMap.ENABLE_EPS, 1),
     ]
 
 
@@ -205,7 +205,7 @@ def test_single_phase_does_not_inherit_three_phase_commands():
 def test_three_phase_command_delegates_to_primitive(method_name, register):
     inv = _three_phase()
     requests = getattr(inv, method_name)(True)
-    assert requests == [WriteHoldingRegisterRequest(register, True)]
+    assert requests == [WriteHoldingRegisterRequest(register, 1)]
     # Encode round-trip — catches a missing entry in pdu.write_registers.WRITE_SAFE_REGISTERS.
     requests[0].encode()
 
@@ -230,7 +230,7 @@ def test_single_phase_does_not_inherit_ems_commands():
 
 def test_ems_set_ems_plant_emits_correct_write():
     requests = _ems().set_ems_plant(True)
-    assert requests == [WriteHoldingRegisterRequest(RegisterMap.EMS_PLANT_ENABLE, True)]
+    assert requests == [WriteHoldingRegisterRequest(RegisterMap.EMS_PLANT_ENABLE, 1)]
     # Encode round-trip — catches a missing entry in pdu.write_registers.WRITE_SAFE_REGISTERS.
     requests[0].encode()
 
@@ -314,3 +314,17 @@ def test_ems_target_soc_validation_holds_through_mixin(method_name):
         getattr(em, method_name)(4, 50)  # index out of range
     with pytest.raises(ValueError, match=r"\[0-100\]"):
         getattr(em, method_name)(1, 150)  # SoC out of range
+
+
+def test_mixin_write_safe_registers_is_subset_of_pdu_set():
+    """The mixin's documentation-level set must never contain a register the PDU layer rejects.
+
+    The PDU-level WRITE_SAFE_REGISTERS is the enforced allowlist; the mixin set is the
+    documented universally-applicable subset (per-model allowlists deferred to #106/#203).
+    Lagging additions are by design; an entry the PDU layer would reject is drift (audit L2).
+    """
+    from givenergy_modbus.client.commands import _InverterCommands
+    from givenergy_modbus.pdu.write_registers import WRITE_SAFE_REGISTERS as PDU_SET
+
+    rogue = _InverterCommands.WRITE_SAFE_REGISTERS - PDU_SET
+    assert not rogue, f"mixin WRITE_SAFE_REGISTERS contains registers the PDU layer rejects: {sorted(rogue)}"

--- a/tests/test_pdu.py
+++ b/tests/test_pdu.py
@@ -462,3 +462,19 @@ def test_heartbeat_str_escapes_serial():
     s = str(hb)
     assert "\n" not in s, f"raw control char leaked into __str__: {s!r}"
     assert "\\n" in s, f"serial should be repr-escaped: {s!r}"
+
+
+def test_write_request_rejects_bool_value():
+    """A bool write value is rejected, not silently coerced to 0/1 (audit L1).
+
+    bool subclasses int, so isinstance(value, int) alone accepts True/False — a bool reaching
+    a numeric register (e.g. ACTIVE_POWER_RATE) is almost certainly a caller bug. Boolean
+    command helpers pass int(enabled) explicitly.
+    """
+    with pytest.raises(ValueError, match="unacceptable"):
+        WriteHoldingRegisterRequest(register=20, value=True)
+    with pytest.raises(ValueError, match="unacceptable"):
+        WriteHoldingRegisterRequest(register=20, value=False)
+    # Plain ints still accepted.
+    assert WriteHoldingRegisterRequest(register=20, value=1).value == 1
+    assert WriteHoldingRegisterRequest(register=20, value=0).value == 0


### PR DESCRIPTION
Batch 3 of the security audit (#224) — write-path assurance. Narrow by design: nothing changes *what* can be written, only local input validation and a drift-pinning test. **Register-safety review: passed** (its one suggestion — `1 if enabled else 0` over `int(enabled)` — adopted; details below).

## Changes

| Item | Change | Test |
|---|---|---|
| **L1** | `WriteHoldingRegisterRequest` rejects `bool` values — bool ⊂ int, so `True`/`False` previously slipped the guard and silently wrote 0/1; a bool reaching a numeric register (e.g. ACTIVE_POWER_RATE) is a caller bug that now fails loudly. The nine boolean command helpers pass `1 if enabled else 0`. | `test_write_request_rejects_bool_value` |
| **L2** | New test pinning `_InverterCommands.WRITE_SAFE_REGISTERS ⊆` the PDU-level enforced set. The mixin set is **kept**, not deleted — it's documented per-model groundwork (deferred to #106/#203) and exactly the shape Pillar A's model-aware write policy builds on; zero refs in givenergy-hass/cli (verified). | `test_mixin_write_safe_registers_is_subset_of_pdu_set` |
| **M1** | **Dropped — documented in the audit** (inline amendment, same style as H1/H3). Write-response correlation is by shape hash (no transaction ID in the GE framing) and the dongle fans out responses to *all* connected TCP clients (#196) — so another actor's write echo for the same register resolves our future. A value mismatch usually means "caught someone else's echo", not "device clamped our write", and a match can mask a real clamp: the signal is unattributable, and a WARNING would misfire routinely during normal cloud+app+hass concurrency. Read-back-after-write is the sound consumer pattern. | n/a (analysis) |

## Register-safety notes

- Wire bytes are **identical** for all in-contract calls (`struct.pack('!H', True) == pack('!H', 1)` — verified in review).
- `1 if enabled else 0` (rather than `int(enabled)`) preserves the previous truthy-clamping semantics (`set_enable_eps(2)` still writes 1) without widening accepted types (no silent `int(1.7)` truncation).
- Decoded responses always carry plain ints from the codec, so the shared `__init__` guard is response-safe.
- IntEnum command values (`ExportPriority`, `BatteryPauseMode`) are unaffected (`isinstance(IntEnum, bool)` is False).

## Consumer note

External callers constructing `WriteHoldingRegisterRequest(reg, True)` **directly** now get `ValueError` (fail-closed; flagged in the Changelog trailer). The public command helpers keep accepting `bool` parameters unchanged.

Full suite (838) + tox py311–314 + lint + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced input validation to reject invalid data types (such as booleans and non-numeric values) in numeric parameters, preventing type-related errors and improving robustness.

* **Tests**
  * Added comprehensive test coverage for input validation to ensure only valid numeric types are accepted for command parameters.

* **Documentation**
  * Updated security audit documentation to reflect refined findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->