### PR TITLE
fix: security-audit batch 4 — adversarial-input & decode-boundary hardening (#224)

### DIFF
--- a/givenergy_modbus/client/commands.py
+++ b/givenergy_modbus/client/commands.py
@@ -654,6 +654,10 @@ def reset_discharge_slot_2(slot_map: SlotMap = SINGLE_PHASE_SLOTS) -> list[Trans
 
 def set_system_date_time(dt: datetime) -> list[TransparentRequest]:
     """Set the date & time of the inverter."""
+    if dt.year < 2000:
+        # The year register stores `year - 2000`; a pre-2000 year underflows to a negative
+        # value and a confusing encode-time InvalidPduState. Reject it clearly up front (L6).
+        raise ValueError(f"System date year ({dt.year}) must be >= 2000")
     return [
         WriteHoldingRegisterRequest(RegisterMap.SYSTEM_TIME_YEAR, dt.year - 2000),
         WriteHoldingRegisterRequest(RegisterMap.SYSTEM_TIME_MONTH, dt.month),

--- a/givenergy_modbus/framer.py
+++ b/givenergy_modbus/framer.py
@@ -101,8 +101,12 @@ class Framer(ABC):
     ``docs/architecture.md`` § References.
     """
 
-    _buffer: bytes = b""
     pdu_class: type[BasePDU]
+
+    def __init__(self) -> None:
+        # Per-instance receive buffer. Held as instance state (not a class-level default)
+        # so two framers never share accumulation, even transiently (L6).
+        self._buffer: bytes = b""
 
     async def decode(self, data: bytes) -> AsyncIterator[BasePDU | ExceptionBase]:
         """Receive incoming network data and attempt to decode frames into messages.
@@ -220,6 +224,7 @@ class ClientFramer(Framer):
     """Framer implementation for client-side use."""
 
     def __init__(self):
+        super().__init__()
         self.pdu_class = ClientIncomingMessage
 
 
@@ -227,4 +232,5 @@ class ServerFramer(Framer):
     """Framer implementation for server-side use."""
 
     def __init__(self):
+        super().__init__()
         self.pdu_class = ServerIncomingMessage

--- a/givenergy_modbus/model/register.py
+++ b/givenergy_modbus/model/register.py
@@ -50,7 +50,12 @@ class Converter:
             # Passing 60 as minutes to TimeSlot.from_repr raises ValueError, so treat it as unset.
             if start_time == 60 or end_time == 60:
                 return None
-            return TimeSlot.from_repr(start_time, end_time)
+            try:
+                return TimeSlot.from_repr(start_time, end_time)
+            except ValueError:
+                # Any other out-of-range / corrupt value (e.g. a tampered cache) degrades to
+                # unset rather than crashing a consumer — matches the enum/lookup posture (M4).
+                return None
 
     @staticmethod
     def bool(val: int) -> "bool":
@@ -170,7 +175,12 @@ class Converter:
     def datetime(year, month, day, hour, min, sec) -> "datetime | None":
         """Compose a datetime from 6 registers."""
         if None not in [year, month, day, hour, min, sec]:
-            return datetime(year + 2000, month, day, hour, min, sec)
+            try:
+                return datetime(year + 2000, month, day, hour, min, sec)
+            except ValueError:
+                # Device-supplied out-of-range components (month=0, hour=24, …) degrade to
+                # None rather than crashing a consumer — matches the enum/lookup posture (M4).
+                return None
         return None
 
     @staticmethod

--- a/givenergy_modbus/model/register_cache.py
+++ b/givenergy_modbus/model/register_cache.py
@@ -114,11 +114,14 @@ class RegisterCache(defaultdict[Register, int]):
                     _logger.warning("Skipping unrecognised register key %r", k)
                     continue
                 try:
-                    ret[lookup[reg](int(idx))] = v
-                except (KeyError, ValueError):
-                    # KeyError: unknown register prefix (e.g. a future namespace
-                    # we don't know about yet). ValueError: idx wasn't an int.
-                    # Either way, skip the entry rather than aborting the load.
+                    ret[lookup[reg](int(idx))] = int(v)
+                except (KeyError, ValueError, TypeError):
+                    # KeyError: unknown register prefix (e.g. a future namespace we don't
+                    # know about yet). ValueError: idx wasn't an int, or the value wasn't
+                    # coercible (a string in a tampered cache JSON). TypeError: value was a
+                    # non-scalar (list/dict). Skip the entry rather than aborting the load,
+                    # and rather than storing a value that crashes a consumer later (M4).
+                    _logger.warning("Skipping unloadable register entry %r=%r", k, v)
                     continue
             return ret
 

--- a/givenergy_modbus/model/register_cache.py
+++ b/givenergy_modbus/model/register_cache.py
@@ -115,12 +115,17 @@ class RegisterCache(defaultdict[Register, int]):
                     continue
                 try:
                     register = lookup[reg](int(idx))
-                    value = int(v)
-                    if value != v or not (0 <= value <= 0xFFFF):
-                        # Fail closed: a register is an unsigned 16-bit word. A fractional
-                        # number (silently truncated by int()) or an out-of-range value would
-                        # later raise OverflowError in to_bytes() deep in a consumer (M4).
-                        raise ValueError(f"register value {v!r} is not an unsigned 16-bit int")
+                    if v is None:
+                        # None is the codebase's legitimate "unset" sentinel (e.g. a missing
+                        # slot endpoint); preserve it so it round-trips through JSON.
+                        value = None
+                    else:
+                        value = int(v)
+                        if value != v or not (0 <= value <= 0xFFFF):
+                            # Fail closed: a register is an unsigned 16-bit word. A fractional
+                            # number (silently truncated by int()) or an out-of-range value
+                            # would later raise OverflowError in to_bytes() in a consumer (M4).
+                            raise ValueError(f"register value {v!r} is not an unsigned 16-bit int")
                     ret[register] = value
                 except (KeyError, ValueError, TypeError):
                     # KeyError: unknown register prefix (e.g. a future namespace we don't know

--- a/givenergy_modbus/model/register_cache.py
+++ b/givenergy_modbus/model/register_cache.py
@@ -114,13 +114,20 @@ class RegisterCache(defaultdict[Register, int]):
                     _logger.warning("Skipping unrecognised register key %r", k)
                     continue
                 try:
-                    ret[lookup[reg](int(idx))] = int(v)
+                    register = lookup[reg](int(idx))
+                    value = int(v)
+                    if value != v or not (0 <= value <= 0xFFFF):
+                        # Fail closed: a register is an unsigned 16-bit word. A fractional
+                        # number (silently truncated by int()) or an out-of-range value would
+                        # later raise OverflowError in to_bytes() deep in a consumer (M4).
+                        raise ValueError(f"register value {v!r} is not an unsigned 16-bit int")
+                    ret[register] = value
                 except (KeyError, ValueError, TypeError):
-                    # KeyError: unknown register prefix (e.g. a future namespace we don't
-                    # know about yet). ValueError: idx wasn't an int, or the value wasn't
-                    # coercible (a string in a tampered cache JSON). TypeError: value was a
-                    # non-scalar (list/dict). Skip the entry rather than aborting the load,
-                    # and rather than storing a value that crashes a consumer later (M4).
+                    # KeyError: unknown register prefix (e.g. a future namespace we don't know
+                    # about yet). ValueError: idx wasn't an int, or the value wasn't a coercible
+                    # in-range integer (a string / fractional / out-of-range value in a tampered
+                    # cache JSON). TypeError: value was a non-scalar (list/dict). Skip the entry
+                    # rather than aborting the load or storing a value that crashes a consumer.
                     _logger.warning("Skipping unloadable register entry %r=%r", k, v)
                     continue
             return ret

--- a/givenergy_modbus/model/register_cache.py
+++ b/givenergy_modbus/model/register_cache.py
@@ -119,6 +119,10 @@ class RegisterCache(defaultdict[Register, int]):
                         # None is the codebase's legitimate "unset" sentinel (e.g. a missing
                         # slot endpoint); preserve it so it round-trips through JSON.
                         value = None
+                    elif isinstance(v, bool):
+                        # bool is an int subclass, so 1 == True would slip past the range check;
+                        # reject JSON true/false rather than silently storing it as 1/0 (M4).
+                        raise ValueError(f"register value {v!r} is a bool, not an integer")
                     else:
                         value = int(v)
                         if value != v or not (0 <= value <= 0xFFFF):
@@ -127,12 +131,13 @@ class RegisterCache(defaultdict[Register, int]):
                             # would later raise OverflowError in to_bytes() in a consumer (M4).
                             raise ValueError(f"register value {v!r} is not an unsigned 16-bit int")
                     ret[register] = value
-                except (KeyError, ValueError, TypeError):
+                except (KeyError, ValueError, TypeError, OverflowError):
                     # KeyError: unknown register prefix (e.g. a future namespace we don't know
                     # about yet). ValueError: idx wasn't an int, or the value wasn't a coercible
-                    # in-range integer (a string / fractional / out-of-range value in a tampered
-                    # cache JSON). TypeError: value was a non-scalar (list/dict). Skip the entry
-                    # rather than aborting the load or storing a value that crashes a consumer.
+                    # in-range integer (a string / bool / fractional / out-of-range value in a
+                    # tampered cache JSON). TypeError: value was a non-scalar (list/dict).
+                    # OverflowError: int(float("inf")) from a non-standard JSON Infinity. Skip the
+                    # entry rather than aborting the load or storing a value that crashes a consumer.
                     _logger.warning("Skipping unloadable register entry %r=%r", k, v)
                     continue
             return ret

--- a/givenergy_modbus/pdu/base.py
+++ b/givenergy_modbus/pdu/base.py
@@ -79,8 +79,11 @@ class BasePDU(ABC):
             pdu.ensure_valid_state()
         except InvalidPduState:
             raise
-        # except Exception as e:
-        #     raise InvalidFrame(str(e), data)
+        except Exception as e:
+            # Complete the decode boundary for every caller (not just the framer's outer
+            # catch): any unexpected decode-time error — a truncated payload's struct.error,
+            # a converter ValueError — surfaces as InvalidFrame rather than leaking out (L6).
+            raise InvalidFrame(f"frame failed low-level decode: {type(e).__name__}: {e}", data)
 
         if not decoder.decoding_complete:
             _logger.error(

--- a/givenergy_modbus/pdu/base.py
+++ b/givenergy_modbus/pdu/base.py
@@ -53,36 +53,39 @@ class BasePDU(ABC):
         """Decode raw byte frame to populated PDU instance."""
         decoder = PayloadDecoder(data)
 
-        t_id = decoder.decode_16bit_uint()
-        if t_id != 0x5959:
-            raise InvalidFrame(f"Transaction ID 0x{t_id:04x} != 0x5959", data)
-
-        p_id = decoder.decode_16bit_uint()
-        if p_id != 0x0001:
-            raise InvalidFrame(f"Protocol ID 0x{p_id:04x} != 0x0001", data)
-
-        header_len = decoder.decode_16bit_uint()
-        remaining_frame_len = decoder.remaining_bytes  # includes 2 bytes for uid and function code
-        if header_len != remaining_frame_len:
-            raise InvalidFrame(f"Header length {header_len} != remaining frame length {remaining_frame_len}", data)
-
-        u_id = decoder.decode_8bit_uint()
-        if u_id not in (0x00, 0x01):
-            raise InvalidFrame(f"Unit ID 0x{u_id:02x} != 0x00/0x01", data)
-
-        function_code = decoder.decode_8bit_uint()
-        decoder_class = cls.lookup_main_function_decoder(function_code)
-
+        # The whole decode — header parsing included — runs inside the boundary so it is
+        # complete for *every* caller (not just the framer's outer catch). A sub-header
+        # truncation (e.g. a direct `decode_bytes(b"")`) raises struct.error from the very
+        # first `decode_16bit_uint()`; that and any other unexpected decode-time error
+        # (a truncated payload, a converter ValueError) surface as InvalidFrame. The explicit
+        # InvalidFrame header checks and InvalidPduState are re-raised verbatim (L6).
         try:
+            t_id = decoder.decode_16bit_uint()
+            if t_id != 0x5959:
+                raise InvalidFrame(f"Transaction ID 0x{t_id:04x} != 0x5959", data)
+
+            p_id = decoder.decode_16bit_uint()
+            if p_id != 0x0001:
+                raise InvalidFrame(f"Protocol ID 0x{p_id:04x} != 0x0001", data)
+
+            header_len = decoder.decode_16bit_uint()
+            remaining_frame_len = decoder.remaining_bytes  # includes 2 bytes for uid and function code
+            if header_len != remaining_frame_len:
+                raise InvalidFrame(f"Header length {header_len} != remaining frame length {remaining_frame_len}", data)
+
+            u_id = decoder.decode_8bit_uint()
+            if u_id not in (0x00, 0x01):
+                raise InvalidFrame(f"Unit ID 0x{u_id:02x} != 0x00/0x01", data)
+
+            function_code = decoder.decode_8bit_uint()
+            decoder_class = cls.lookup_main_function_decoder(function_code)
+
             pdu = decoder_class.decode_main_function(decoder)
             pdu.raw_frame = data
             pdu.ensure_valid_state()
-        except InvalidPduState:
+        except (InvalidFrame, InvalidPduState):
             raise
         except Exception as e:
-            # Complete the decode boundary for every caller (not just the framer's outer
-            # catch): any unexpected decode-time error — a truncated payload's struct.error,
-            # a converter ValueError — surfaces as InvalidFrame rather than leaking out (L6).
             raise InvalidFrame(f"frame failed low-level decode: {type(e).__name__}: {e}", data)
 
         if not decoder.decoding_complete:

--- a/givenergy_modbus/pdu/lan_config.py
+++ b/givenergy_modbus/pdu/lan_config.py
@@ -51,6 +51,10 @@ class LanConfigBroadcast(ClientIncomingMessage):
         """Return True if the remaining decoder bytes look like a LAN config broadcast."""
         return (
             len(remaining_after_serial) >= 8
+            # The 6 bytes preceding the null+comma are the zero padding of a real broadcast;
+            # requiring them avoids a crafted padding field false-positiving and dropping a
+            # valid transparent response (L6).
+            and not any(remaining_after_serial[: cls._DISC_NULL_OFFSET])
             and remaining_after_serial[cls._DISC_NULL_OFFSET] == 0x00
             and remaining_after_serial[cls._DISC_NULL_OFFSET + 1] == cls._DISC_COMMA
         )

--- a/givenergy_modbus/pdu/null.py
+++ b/givenergy_modbus/pdu/null.py
@@ -1,6 +1,7 @@
 import logging
 
 from givenergy_modbus.codec import PayloadDecoder
+from givenergy_modbus.exceptions import InvalidFrame
 from givenergy_modbus.pdu.transparent import TransparentResponse
 
 _logger = logging.getLogger(__name__)
@@ -27,6 +28,10 @@ class NullResponse(TransparentResponse):
 
     @classmethod
     def decode_transparent_function(cls, decoder: PayloadDecoder, **attrs) -> "NullResponse":
+        if decoder.remaining_bytes < 126:
+            # 62 nulls + check = 126 bytes; a shorter frame would overrun the decoder
+            # (struct.error) mid-loop. Fail the frame cleanly instead (L6).
+            raise InvalidFrame(f"Null frame too short: {decoder.remaining_bytes}b < 126b", decoder.remaining_payload)
         if decoder.remaining_bytes != 126:
             _logger.warning(
                 f"remaining bytes: {decoder.remaining_bytes}b 0x{decoder.remaining_payload.hex()} attrs: {attrs}"

--- a/givenergy_modbus/pdu/read_registers.py
+++ b/givenergy_modbus/pdu/read_registers.py
@@ -1,5 +1,6 @@
 import logging
 from abc import ABC
+from typing import ClassVar
 
 from crccheck.crc import CrcModbus
 
@@ -72,6 +73,12 @@ class ReadRegistersRequest(ReadRegistersMessage, TransparentRequest, ABC):
 class ReadRegistersResponse(ReadRegistersMessage, TransparentResponse, ABC):
     """Handles all messages that respond with a range of registers."""
 
+    #: Opt-in strict CRC enforcement. Lenient by default (a mismatch is logged at WARNING and
+    #: the data accepted, preserving firmware-quirk tolerance). Set to True on the class to make
+    #: a CRC mismatch raise :class:`InvalidPduState` instead — for consumers that prefer to drop
+    #: a corrupted/malformed frame rather than ingest it (audit H1).
+    strict_crc: ClassVar[bool] = False
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.register_values: list[int] = kwargs.get("register_values", [])
@@ -103,16 +110,17 @@ class ReadRegistersResponse(ReadRegistersMessage, TransparentResponse, ABC):
         self._validate_check_code()
 
     def _validate_check_code(self) -> None:
-        """Log-only CRC check of a decoded response against the received bytes.
+        """CRC check of a decoded response against the received bytes.
 
         Recomputes the unified CRC (CRC16/Modbus over `raw_frame[26:-2]` — the
         device-address byte onward, mirroring `TransparentMessage._update_check_code`'s
         `payload[18:]`, byte-swapped) and compares to the decoded `check`. Confirmed valid
         for every frame in the real All-in-One corpus (#158: 102/102, incl. error
-        responses). Deliberately **non-fatal**: incoming inverter frames are the source of
-        truth, so a mismatch is logged at WARNING for visibility (a corrupted/malformed frame,
-        not authenticated tampering — the CRC is unauthenticated) but never rejects the data.
-        Only runs when `raw_frame` is present (i.e. on decoded frames).
+        responses). **Lenient by default**: incoming inverter frames are the source of truth,
+        so a mismatch is logged at WARNING for visibility (a corrupted/malformed frame, not
+        authenticated tampering — the CRC is unauthenticated) but the data is still accepted.
+        Set :attr:`strict_crc` on the class to raise :class:`InvalidPduState` on mismatch
+        instead. Only runs when `raw_frame` is present (i.e. on decoded frames).
         """
         raw_frame = getattr(self, "raw_frame", None)
         if not raw_frame or len(raw_frame) < 28:
@@ -120,6 +128,13 @@ class ReadRegistersResponse(ReadRegistersMessage, TransparentResponse, ABC):
         computed = CrcModbus().process(raw_frame[26:-2]).final()
         expected = ((computed & 0xFF) << 8) | ((computed >> 8) & 0xFF)
         if expected != self.check:
+            if self.strict_crc:
+                raise InvalidPduState(
+                    f"Response failed CRC integrity check: "
+                    f"wire=0x{self.check:04x} computed=0x{expected:04x} — frame corrupted or "
+                    f"malformed in transit (strict_crc enabled)",
+                    self,
+                )
             _logger.warning(
                 f"Response failed CRC integrity check on {self}: "
                 f"wire=0x{self.check:04x} computed=0x{expected:04x} — data accepted (non-fatal), "

--- a/tests/client/test_commands.py
+++ b/tests/client/test_commands.py
@@ -323,6 +323,15 @@ async def test_set_system_time():
     ]
 
 
+async def test_set_system_time_rejects_pre_2000_year():
+    """A pre-2000 year must be rejected with a clear ValueError (audit L6).
+
+    Otherwise it underflows to a negative register and a confusing encode-time InvalidPduState.
+    """
+    with pytest.raises(ValueError, match="2000"):
+        commands.set_system_date_time(datetime(1999, 12, 31, 23, 59, 59))
+
+
 async def test_set_inverter_reboot():
     """Ensure set_inverter_reboot emits the correct requests."""
     assert commands.set_inverter_reboot() == [

--- a/tests/model/test_register.py
+++ b/tests/model/test_register.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from datetime import datetime
 
 import pytest
 
@@ -102,6 +103,21 @@ def test_converter_timeslot_sentinel():
     # raw value 60 is a hardware sentinel for "unset"; minutes=60 would raise ValueError
     assert Converter.timeslot(60, 2359) is None
     assert Converter.timeslot(0, 60) is None
+
+
+def test_converter_timeslot_degrades_on_invalid_value():
+    """Adversarial / corrupt register values must degrade to None, not raise (audit M4)."""
+    # minutes 99 / hour 25 are out of range but not the 60 sentinel — previously raised ValueError
+    assert Converter.timeslot(1099, 1200) is None
+    assert Converter.timeslot(1030, 2530) is None
+
+
+def test_converter_datetime_degrades_on_invalid_value():
+    """A device-supplied month=0 / hour=24 must degrade to None, not raise (audit M4)."""
+    assert Converter.datetime(24, 13, 1, 0, 0, 0) is None  # month 13
+    assert Converter.datetime(24, 1, 1, 24, 0, 0) is None  # hour 24
+    # a fully valid set still composes
+    assert Converter.datetime(24, 6, 10, 12, 0, 0) == datetime(2024, 6, 10, 12, 0, 0)
 
 
 def test_converter_bitfield():

--- a/tests/model/test_register_cache.py
+++ b/tests/model/test_register_cache.py
@@ -35,6 +35,18 @@ def test_from_json_skips_unknown_register_prefix():
     assert RegisterCache.from_json('{"XR(0)": 1, "ZR(2)": 3}') == {}
 
 
+def test_from_json_skips_non_integer_value():
+    """A non-integer value in tampered cache JSON must be skipped, not propagate (audit M4).
+
+    Previously a string value stored unchecked and blew up later in int()/.to_bytes deep
+    in a consumer. The entry is now dropped (with a warning), keeping valid entries.
+    """
+    # String value dropped, valid sibling retained.
+    assert RegisterCache.from_json('{"HR(1)": 2, "HR(2)": "evil", "IR(3)": 4}') == {HR(1): 2, IR(3): 4}
+    # Integer-as-string is coerced (JSON numbers arrive as int already; this covers loose input).
+    assert RegisterCache.from_json('{"HR(1)": "7"}') == {HR(1): 7}
+
+
 def test_to_from_json_actual_data(json_inverter_daytime_discharging_with_solar_generation):
     """Ensure we can unserialize a RegisterCache to and from JSON."""
     rc = RegisterCache.from_json(json_inverter_daytime_discharging_with_solar_generation)

--- a/tests/model/test_register_cache.py
+++ b/tests/model/test_register_cache.py
@@ -52,6 +52,16 @@ def test_from_json_skips_invalid_register_value():
     assert RegisterCache.from_json('{"HR(0)": 0, "HR(1)": 65535}') == {HR(0): 0, HR(1): 65535}
 
 
+def test_from_json_preserves_none_value():
+    """None is the codebase's 'unset' sentinel and must round-trip through JSON, not be dropped.
+
+    Dropping it would silently turn an explicit None into the defaultdict's 0 on later access.
+    """
+    rc = RegisterCache.from_json('{"HR(1)": null, "IR(3)": 4}')
+    assert rc == {HR(1): None, IR(3): 4}
+    assert rc.get(HR(1)) is None
+
+
 def test_to_from_json_actual_data(json_inverter_daytime_discharging_with_solar_generation):
     """Ensure we can unserialize a RegisterCache to and from JSON."""
     rc = RegisterCache.from_json(json_inverter_daytime_discharging_with_solar_generation)

--- a/tests/model/test_register_cache.py
+++ b/tests/model/test_register_cache.py
@@ -50,6 +50,11 @@ def test_from_json_skips_invalid_register_value():
     assert RegisterCache.from_json('{"HR(1)": -1, "HR(2)": 65536, "IR(3)": 5}') == {IR(3): 5}
     # In-range integers (including the 0/0xffff bounds) still load.
     assert RegisterCache.from_json('{"HR(0)": 0, "HR(1)": 65535}') == {HR(0): 0, HR(1): 65535}
+    # json.loads accepts the non-standard Infinity/-Infinity/NaN; int() of those raises
+    # OverflowError/ValueError — the entry must be skipped, not crash the load.
+    assert RegisterCache.from_json('{"HR(1)": Infinity, "HR(2)": -Infinity, "HR(3)": NaN, "IR(4)": 6}') == {IR(4): 6}
+    # JSON booleans are not register values — rejected, not silently stored as 1/0.
+    assert RegisterCache.from_json('{"HR(1)": true, "HR(2)": false, "IR(3)": 7}') == {IR(3): 7}
 
 
 def test_from_json_preserves_none_value():

--- a/tests/model/test_register_cache.py
+++ b/tests/model/test_register_cache.py
@@ -35,16 +35,21 @@ def test_from_json_skips_unknown_register_prefix():
     assert RegisterCache.from_json('{"XR(0)": 1, "ZR(2)": 3}') == {}
 
 
-def test_from_json_skips_non_integer_value():
-    """A non-integer value in tampered cache JSON must be skipped, not propagate (audit M4).
+def test_from_json_skips_invalid_register_value():
+    """A value that isn't a valid unsigned 16-bit int must be skipped, not propagate (audit M4).
 
-    Previously a string value stored unchecked and blew up later in int()/.to_bytes deep
-    in a consumer. The entry is now dropped (with a warning), keeping valid entries.
+    Previously such a value stored unchecked and blew up later in int()/.to_bytes (ValueError
+    or OverflowError) deep in a consumer. Each bad entry is now dropped (with a warning), and
+    valid entries are retained — a fail-closed posture for tampered cache JSON.
     """
     # String value dropped, valid sibling retained.
     assert RegisterCache.from_json('{"HR(1)": 2, "HR(2)": "evil", "IR(3)": 4}') == {HR(1): 2, IR(3): 4}
-    # Integer-as-string is coerced (JSON numbers arrive as int already; this covers loose input).
-    assert RegisterCache.from_json('{"HR(1)": "7"}') == {HR(1): 7}
+    # A fractional number is rejected rather than silently truncated.
+    assert RegisterCache.from_json('{"HR(1)": 1.5}') == {}
+    # Out-of-range values (negative, or above 0xffff) are rejected — they'd OverflowError later.
+    assert RegisterCache.from_json('{"HR(1)": -1, "HR(2)": 65536, "IR(3)": 5}') == {IR(3): 5}
+    # In-range integers (including the 0/0xffff bounds) still load.
+    assert RegisterCache.from_json('{"HR(0)": 0, "HR(1)": 65535}') == {HR(0): 0, HR(1): 65535}
 
 
 def test_to_from_json_actual_data(json_inverter_daytime_discharging_with_solar_generation):

--- a/tests/test_framer.py
+++ b/tests/test_framer.py
@@ -402,6 +402,30 @@ async def test_malformed_short_frame_yields_invalidframe_not_struct_error():
     assert "low-level decode" in str(yielded[0])
 
 
+async def test_framer_contains_unexpected_decode_exception():
+    """A leaked non-InvalidFrame exception from decode_bytes is still contained by the framer.
+
+    Defence-in-depth: the decode boundary now wraps errors as InvalidFrame itself, but the framer
+    keeps its own broad catch so the consumer can't be killed (#88 trust boundary). Exercised here
+    with a decoder that raises a raw error.
+    """
+
+    class _Boom:
+        @staticmethod
+        def decode_bytes(frame: bytes) -> BasePDU:
+            raise RuntimeError("boom")
+
+    frame_bytes = bytes.fromhex("5959000100020102") + b"x" * 10
+    framer = ClientFramer()
+    framer.pdu_class = _Boom  # type: ignore[assignment]
+    yielded = [msg async for msg in framer.decode(frame_bytes)]
+
+    assert len(yielded) == 1
+    assert isinstance(yielded[0], InvalidFrame)
+    assert "low-level decode" in str(yielded[0])
+    assert "RuntimeError" in str(yielded[0])
+
+
 async def test_headerless_garbage_bounds_buffer_growth(caplog):
     """Sustained no-marker traffic must not grow the framer buffer without bound.
 

--- a/tests/test_pdu.py
+++ b/tests/test_pdu.py
@@ -381,6 +381,67 @@ def test_read_registers_response_caps_decode_at_60():
     assert result.register_values == list(range(60))
 
 
+def test_null_response_short_frame_raises_invalid_frame():
+    """A truncated null frame must surface as InvalidFrame, not a raw struct.error (audit L6)."""
+    decoder = PayloadDecoder(b"\x00" * 40)  # < 126 bytes: too short for 62 nulls + check
+    with pytest.raises(InvalidFrame):
+        NullResponse.decode_transparent_function(decoder)
+
+
+def test_decode_bytes_wraps_unexpected_decode_error_as_invalid_frame():
+    """An unexpected decode error surfaces as InvalidFrame for every caller (audit L6).
+
+    A decode-time error other than InvalidPduState must not leak a raw struct.error out of
+    decode_bytes (the restored broad catch). An input-register response claims 60 registers but
+    carries only 2; decoding the register block overruns the buffer inside decode_main_function.
+    """
+    body = (
+        b"DA1234G567"  # data_adapter_serial (10)
+        + (0x8A).to_bytes(8, "big")  # padding (8)
+        + b"\x32"  # device_address
+        + b"\x04"  # transparent_function_code = input registers
+        + b"SA1234G567"  # inverter_serial (10)
+        + struct.pack(">HH", 0, 60)  # base_register=0, register_count=60
+        + struct.pack(">HH", 1, 2)  # only 2 register values supplied
+        + b"\x00\x00"  # check
+    )
+    tail = b"\x01\x02" + body  # uid + main function code (transparent = 2)
+    frame = b"\x59\x59\x00\x01" + len(tail).to_bytes(2, "big") + tail
+    with pytest.raises(InvalidFrame):
+        ClientIncomingMessage.decode_bytes(frame)
+
+
+def test_is_lan_config_rejects_nonzero_padding():
+    """The LAN-config discriminator requires the 6 preceding pad bytes to be zero (audit L6).
+
+    Otherwise a crafted padding field can false-positive and drop a valid response.
+    """
+    from givenergy_modbus.pdu.lan_config import LanConfigBroadcast
+
+    # Real shape: 6 zero bytes + 0x00 + ',' → recognised.
+    assert LanConfigBroadcast.is_lan_config(b"\x00\x00\x00\x00\x00\x00\x00,rest")
+    # A non-zero byte in the 6-byte pad prefix → not a LAN-config frame.
+    assert not LanConfigBroadcast.is_lan_config(b"\x00\x00\x2c\x00\x00\x00\x00,rest")
+
+
+def test_strict_crc_mode_raises_on_mismatch(monkeypatch):
+    """Opt-in strict CRC mode raises InvalidPduState on a mismatch (audit H1-better).
+
+    The lenient default only warns and accepts the data.
+    """
+    resp = ReadHoldingRegistersResponse(base_register=0, register_count=1, register_values=[0], check=0x0000)
+    resp.raw_frame = b"\x00" * 30  # CRC of raw_frame[26:-2] won't be 0x0000 → guaranteed mismatch
+
+    # Lenient default: warns, never raises.
+    assert ReadHoldingRegistersResponse.strict_crc is False
+    resp._validate_check_code()
+
+    # Strict: raises InvalidPduState on the same mismatch.
+    monkeypatch.setattr(ReadHoldingRegistersResponse, "strict_crc", True)
+    with pytest.raises(InvalidPduState, match="CRC"):
+        resp._validate_check_code()
+
+
 def test_request_crc_includes_device_address_matches_real_wire():
     """Request CRC must cover the device-address byte — pinned to a real GivTCP frame (#105).
 

--- a/tests/test_pdu.py
+++ b/tests/test_pdu.py
@@ -411,6 +411,16 @@ def test_decode_bytes_wraps_unexpected_decode_error_as_invalid_frame():
         ClientIncomingMessage.decode_bytes(frame)
 
 
+def test_decode_bytes_sub_header_truncation_raises_invalid_frame():
+    """A frame too short to hold the MBAP header surfaces as InvalidFrame (audit L6).
+
+    The boundary covers header parsing too, so a sub-header truncation can't leak a struct.error.
+    """
+    for short in (b"", b"\x59", b"\x59\x59\x00"):
+        with pytest.raises(InvalidFrame):
+            ClientIncomingMessage.decode_bytes(short)
+
+
 def test_is_lan_config_rejects_nonzero_padding():
     """The LAN-config discriminator requires the 6 preceding pad bytes to be zero (audit L6).
 

--- a/tests/test_pdu.py
+++ b/tests/test_pdu.py
@@ -421,6 +421,15 @@ def test_decode_bytes_sub_header_truncation_raises_invalid_frame():
             ClientIncomingMessage.decode_bytes(short)
 
 
+def test_decode_bytes_rejects_bad_protocol_and_unit_id():
+    """The protocol-ID and unit-ID header checks reject malformed frames as InvalidFrame."""
+    with pytest.raises(InvalidFrame, match="Protocol ID"):
+        ClientIncomingMessage.decode_bytes(b"\x59\x59\x00\x02")
+    # 5959 0001 <len=0002> <uid=ff> <fc=02>: header_len matches, but unit id 0xff is invalid.
+    with pytest.raises(InvalidFrame, match="Unit ID"):
+        ClientIncomingMessage.decode_bytes(b"\x59\x59\x00\x01\x00\x02\xff\x02")
+
+
 def test_is_lan_config_rejects_nonzero_padding():
     """The LAN-config discriminator requires the 6 preceding pad bytes to be zero (audit L6).
 


### PR DESCRIPTION
Fourth remediation batch from the security audit (#224), following #225, #228, #229. This is the robustness pass: nothing changes what can be written or which registers exist — it makes the parse/convert layer degrade gracefully instead of crashing a consumer fed a tampered cache JSON or a malformed wire frame.

### M4 — adversarial register values must not crash consumers
- `Converter.datetime` / `Converter.timeslot` wrap their construction in `try/except ValueError → None`, matching the existing enum/lookup posture (a device-supplied `month=0` / `hour=24` or an out-of-range timeslot degrades to unset rather than raising deep in a consumer).
- `register_object_hook` coerces values with `int(v)` and skips (with a warning) on failure, so a string value in a tampered cache JSON can't propagate until it blows up downstream.

### L6 — decode-boundary tidy-ups
- **`base.decode_bytes`**: restored the broad `except Exception → InvalidFrame` wrap so the decode boundary is complete for *every* caller (not just the framer's outer catch). `InvalidPduState` still propagates first.
- **`NullResponse`**: a short null frame (< 126b) now raises `InvalidFrame` instead of dying in `struct.error` mid-loop.
- **`Framer._buffer`**: moved off the class into `__init__` (per-instance state, no shared-default reliance on `bytes` immutability).
- **`is_lan_config`**: additionally requires the 6 preceding pad bytes to be zero, so a crafted padding field can't false-positive the LAN-config discriminator and drop a valid response (silent timeout). Verified against the real LAN-config fixture.
- **`set_system_date_time`**: rejects pre-2000 years with a clear `ValueError` instead of a confusing encode-time `InvalidPduState`.

### H1 (better) — opt-in strict CRC mode
`ReadRegistersResponse.strict_crc` (`ClassVar`, default `False`) makes a CRC mismatch raise `InvalidPduState`. The lenient default keeps the existing WARNING-and-accept behaviour shipped in #225 — firmware-quirk tolerance is preserved unless a consumer opts in.

### Verification
- TDD throughout; `tox` green across py311–py314 (lint, format, build).
- Register-safety review passed on the `commands.py` change (the date guard adds no register/bounds semantics).
- The framer's #88 defence-in-depth broad catch is retained and now covered by a dedicated test (the L6 wrap moved its trigger into `decode_bytes`).

Part of #224. Cherry-pick to `v2.2` to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)