### PR TITLE
ci: security-audit batch 5 — supply-chain hardening + inbox de-advertise (#224)

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -15,6 +15,11 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+# Least privilege: this workflow only reads the repo (tests + Codecov upload via
+# CODECOV_TOKEN); it never writes contents, issues, or PRs.
+permissions:
+  contents: read
+
 jobs:
   test:
     # Canonical per-PR check: the 3.11 floor + ruff + mypy + bandit + build + docs.
@@ -27,13 +32,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
           enable-cache: true
           python-version: '3.14'
       - name: Build & test with tox
         run: uv run --group test tox -e py311,format,lint,build
-      - uses: codecov/codecov-action@v7
+      - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
@@ -50,7 +55,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
           enable-cache: true
           python-version: '3.14'
@@ -72,7 +77,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
           enable-cache: true
           python-version: '3.14'

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -7,6 +7,11 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+# Least privilege: this workflow only reads the repo and publishes to Test PyPI
+# via TEST_PYPI_API_TOKEN; it never writes repo contents.
+permissions:
+  contents: read
+
 jobs:
   publish_dev_build:
     strategy:
@@ -19,7 +24,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
           enable-cache: true
           python-version: ${{ matrix.python-version }}
@@ -29,7 +34,7 @@ jobs:
           uv version --short
           uv build
       - name: Publish to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         with:
           user: __token__
           password: ${{ secrets.TEST_PYPI_API_TOKEN}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,8 @@ jobs:
       contents: write
       # Required for PyPI trusted publishing via OIDC (no API token).
       id-token: write
+      # Required for the GITHUB_TOKEN-based docs deploy (peaceiris/actions-gh-pages).
+      pages: write
 
     steps:
       - name: Checkout
@@ -56,7 +58,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7.6.0
         with:
           enable-cache: true
 
@@ -118,7 +120,7 @@ jobs:
 
       - name: Create GitHub Release
         if: inputs.republish_tag == ''
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
         with:
           tag_name: v${{ steps.version.outputs.version }}
           name: v${{ steps.version.outputs.version }}
@@ -128,7 +130,7 @@ jobs:
           prerelease: ${{ steps.version.outputs.prerelease == 'true' }}
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # v1.14.0
         with:
           skip-existing: true
 
@@ -185,10 +187,14 @@ jobs:
 
       - name: Publish documentation
         if: steps.version.outputs.prerelease != 'true' && inputs.republish_tag == ''
-        # Pinned to v4.1.0 rather than @v4 because the floating major tag still
-        # resolves to a Node 20 build of the action; v4.1.0 (2026-05-12) is the
-        # first release using Node 24. Revisit once peaceiris re-points @v4.
-        uses: peaceiris/actions-gh-pages@v4.1.0
+        # SHA-pinned to v4.1.0: the floating @v4 tag still resolves to a Node 20
+        # build; v4.1.0 (2026-05-12) is the first release on Node 24. Revisit once
+        # peaceiris re-points @v4.
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453  # v4.1.0
         with:
-          personal_token: ${{ secrets.PERSONAL_TOKEN }}
+          # GITHUB_TOKEN (+ pages: write on the job) replaces the long-lived
+          # PERSONAL_TOKEN — the action only needs contents:write to push to the
+          # gh-pages branch. If a future release regresses Pages deploy, revert to
+          # personal_token: ${{ secrets.PERSONAL_TOKEN }}.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,21 +12,7 @@ This agent owns `givenergy-modbus` only. Two sibling repositories exist, each wi
 - **`givenergy-hass`** — the Home Assistant custom component to control a local plant
 - **`givenergy-cli`** — a command-line interface to perform common interactive tasks
 
-When a change in this component requires corresponding work in a sister repo, communicate via the **shared coordination inbox** at `/tmp/givenergy-coordination/`.
-
-### Coordination inbox protocol
-
-- **Shared directory:** `/tmp/givenergy-coordination`
-- **Filename format:** `<unix-epoch>-<recipient>-<description>.md`
-  - `recipient` is one of `cli`, `modbus`, or `hass`
-  - `description` is a brief slug, optionally referencing an issue (e.g. `mock-pdu-logging-#42`)
-  - Example: `1780409632-modbus-mock-pdu-logging.md`
-- **Writing a message:** create a new file; never mutate an existing one
-- **Replying:** create a new file with the current epoch, the original sender as addressee, and a description prefixed with `re-`. Only reply if actionable, save on pleasantries.
-- **Content:** describe the expected outcome at the API boundary — not how to implement it; include enough context to act without this conversation's history. It does not need to be overly verbose since agents share a lot of common knowledge across  these repos.
-- **Scanning:** after every turn, scan the inbox for new files through the stop hook and script defined in `.claude/settings.json`; make a decision whether to immediately act on the message, park it for when the current work winds up, or handing off to a subagent. Check with the user if any uncertainty.
-
-The old `.claude/handoffs/` and bare `/tmp` locations are superseded by this inbox.
+When a change in this component requires corresponding work in a sister repo, file a GitHub issue on that repo describing the API-boundary outcome the change depends on (durable contract). Ephemeral in-flight coordination between the maintainer's local agents is handled out-of-band via their agent config, not through this repo.
 
 ## GitHub identity — bot vs your voice
 


### PR DESCRIPTION
Final remediation batch from the security audit (#224), following #225/#228/#229/#230. **No library code** — CI supply-chain hardening (M5) plus de-advertising the cross-repo coordination inbox (H3).

### M5 — CI supply chain
- **SHA-pin every third-party action** (with `# vX.Y.Z` comments; Dependabot watches `github-actions` and will bump the SHAs):
  - `pypa/gh-action-pypi-publish` — was a *mutable* `@release/v1` **branch** ref inside the `id-token: write` publish job (highest priority) — pinned in `release.yml` + `preview.yml`.
  - `peaceiris/actions-gh-pages@v4.1.0`, `softprops/action-gh-release@v3`, `codecov/codecov-action@v7`, `astral-sh/setup-uv@v7`.
  - GitHub-owned `actions/*` and `github/codeql-action` left at version tags (not in scope; lower risk).
- **PERSONAL_TOKEN → GITHUB_TOKEN** on the peaceiris docs-deploy step, plus `pages: write` on the `release` job. The action only needs `contents: write` to push `gh-pages`. ⚠️ This only runs at a real release, so it can't be validated by PR CI — **if Pages deploy regresses, revert that step to `personal_token: ${{ secrets.PERSONAL_TOKEN }}`**.
- **Least-privilege `permissions: contents: read`** added to `dev.yml` and `preview.yml` (neither had a block; both run on tokens/secrets, not OIDC). Exercised by this PR's own `dev.yml` run.

### H3 — coordination inbox
The `/tmp/givenergy-coordination` inbox protocol was duplicated in public AGENTS.md and advertised a prompt-injection surface. This PR **trims it from AGENTS.md**, leaving a pointer to the GitHub-issue mechanism for durable cross-repo contracts. The ephemeral-inbox convention has been **relocated off `/tmp` to the maintainer's user-owned config dir and hardened** (treat-as-untrusted + UID-scoped Stop hook) centrally — out of the public repos.

### Verification
- All three workflow files parse; all third-party `uses:` now SHA-pinned; `prek` clean.
- `dev.yml`/`preview.yml` permission blocks validated by this PR's CI run.
- No register/command code → no register-safety gate.

Part of #224. Cherry-pick to `v2.2` to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)