### PR TITLE
feat(plant): add unified inverter_serial accessor (#227)

### DIFF
--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -20,7 +20,7 @@ from givenergy_modbus.model.inverter import (
 )
 from givenergy_modbus.model.inverter_threephase import ThreePhaseInverter, select_inverter
 from givenergy_modbus.model.meter import Meter, MeterRegisterGetter
-from givenergy_modbus.model.register import HR, IR, Converter, RegisterGetter
+from givenergy_modbus.model.register import HR, IR, Converter, RegisterGetter, is_valid_serial
 from givenergy_modbus.model.register_cache import RegisterCache
 from givenergy_modbus.pdu import (
     ClientIncomingMessage,
@@ -748,6 +748,10 @@ class Plant(GivEnergyBaseModel):
         3. the ``inverter_serial_number`` envelope field — populated at ``detect()`` and the only
            home on a persisted/bare plant carrying no register caches.
 
+        A register block is only accepted if it decodes to a valid serial (``is_valid_serial`` —
+        the same coherence gate ``_commit_bank`` ingestion uses), so a malformed/partial block in a
+        restored or tampered cache falls through to the envelope rather than outranking it.
+
         Deliberately never reads the 0x32 battery cache, so a bare or pre-detect plant can't
         surface a battery pack's serial as the inverter's. Reads via ``.get()`` so it never
         mutates the (defaultdict) caches. Once consumers move to this accessor, the envelope
@@ -766,7 +770,12 @@ class Plant(GivEnergyBaseModel):
             if any(v is None for v in raw):
                 continue  # fail closed on a partially-present serial block
             serial = Converter.serial(*cast("list[int]", raw))
-            if serial:
+            # Coherence gate (same as _commit_bank ingestion): a complete block can still
+            # decode to garbage — an interior zero register strips to a short string
+            # (SA12\x00\x00G047 -> "SA12G047"), and a persisted/tampered cache can hold spaces
+            # or other malformed data. is_valid_serial() requires a clean 10-char serial, so
+            # such a block falls through to a known-good envelope serial rather than outranking it.
+            if serial and is_valid_serial(serial):
                 return serial
         return self.inverter_serial_number
 

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -1,7 +1,7 @@
 import logging
 import warnings
 from datetime import UTC, datetime
-from typing import Any, ClassVar
+from typing import Any, ClassVar, cast
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
@@ -20,7 +20,7 @@ from givenergy_modbus.model.inverter import (
 )
 from givenergy_modbus.model.inverter_threephase import ThreePhaseInverter, select_inverter
 from givenergy_modbus.model.meter import Meter, MeterRegisterGetter
-from givenergy_modbus.model.register import HR, IR, RegisterGetter
+from givenergy_modbus.model.register import HR, IR, Converter, RegisterGetter
 from givenergy_modbus.model.register_cache import RegisterCache
 from givenergy_modbus.pdu import (
     ClientIncomingMessage,
@@ -734,6 +734,41 @@ class Plant(GivEnergyBaseModel):
             cache = self.register_caches.get(self.capabilities.inverter_address, RegisterCache())
             return select_inverter(self.capabilities.device_type, cache)
         return SinglePhaseInverter.from_register_cache(self.register_caches[0x32])
+
+    @property
+    def inverter_serial(self) -> str:
+        """Single authoritative inverter serial, robust across the whole plant lifecycle (#227).
+
+        Resolves the earliest-available inverter identity by trying, in order:
+
+        1. HR(13-17) in the capability-selected inverter cache (``inverter_address`` — 0x31 for
+           AC/HYBRID_GEN1, else 0x11);
+        2. HR(13-17) in the 0x11 cache — ``detect()``'s ``HR(0,60)`` identity read lands here for
+           every model, so this covers the detect→first-refresh window before 0x31 is populated;
+        3. the ``inverter_serial_number`` envelope field — populated at ``detect()`` and the only
+           home on a persisted/bare plant carrying no register caches.
+
+        Deliberately never reads the 0x32 battery cache, so a bare or pre-detect plant can't
+        surface a battery pack's serial as the inverter's. Reads via ``.get()`` so it never
+        mutates the (defaultdict) caches. Once consumers move to this accessor, the envelope
+        field can be deprecated.
+        """
+        addresses = [0x11]
+        # Prefer the device's own register home (0x31 for AC/HYBRID_GEN1); 0x32 is the battery
+        # pack and never a valid inverter address, so a stale pre-#119 0x32 capability is ignored.
+        if self.capabilities is not None and self.capabilities.inverter_address in (0x11, 0x31):
+            addresses.insert(0, self.capabilities.inverter_address)
+        for addr in dict.fromkeys(addresses):  # de-dup, preserve order
+            cache = self.register_caches.get(addr)
+            if cache is None:
+                continue
+            raw = [cache.get(HR(n)) for n in range(13, 18)]  # .get(): never mutate the defaultdict
+            if any(v is None for v in raw):
+                continue  # fail closed on a partially-present serial block
+            serial = Converter.serial(*cast("list[int]", raw))
+            if serial:
+                return serial
+        return self.inverter_serial_number
 
     @property
     def number_batteries(self) -> int:

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -2050,6 +2050,61 @@ def test_inverter_serial_ignores_stale_0x32_capability():
     assert plant.inverter_serial_number == "", "a stale 0x32 inverter_address must not let a battery clobber it"
 
 
+# ---------------------------------------------------------------------------
+# Unified inverter-serial accessor: Plant.inverter_serial (#227)
+# ---------------------------------------------------------------------------
+
+
+def _serial_to_hr(serial: str, base: int = 13) -> dict[Register, int]:
+    """Encode a serial into HR(base..) registers (two ASCII bytes each), mirroring HR13-17."""
+    b = serial.encode("latin1")
+    return {HR(base + i): int.from_bytes(b[2 * i : 2 * i + 2], "big") for i in range(len(b) // 2)}
+
+
+def test_inverter_serial_reads_capability_inverter_address_cache():
+    """Plant.inverter_serial decodes HR13-17 from the capability-selected inverter cache (0x31)."""
+    plant = Plant(capabilities=PlantCapabilities(device_type=Model.AC, inverter_address=0x31))
+    plant.register_caches[0x31] = RegisterCache(_serial_to_hr("SA2114G047"))
+    assert plant.inverter_serial == "SA2114G047"
+
+
+def test_inverter_serial_falls_back_to_0x11_in_detect_window():
+    """A 0x31 model with an empty 0x31 cache falls back to the 0x11 cache (#227).
+
+    In the detect→first-refresh window, detect()'s HR(0,60) identity read has landed HR13-17 in
+    the 0x11 cache even though 0x31 is not yet populated.
+    """
+    plant = Plant(capabilities=PlantCapabilities(device_type=Model.AC, inverter_address=0x31))
+    # 0x31 absent in this window; 0x11 populated by detect()
+    plant.register_caches[0x11] = RegisterCache(_serial_to_hr("SA2114G047"))
+    assert plant.inverter_serial == "SA2114G047"
+
+
+def test_inverter_serial_never_reads_0x32_battery_cache():
+    """A bare plant must not surface the 0x32 battery serial as the inverter's (#227)."""
+    plant = Plant()  # no capabilities; model_post_init seeds an (empty) 0x32 cache
+    plant.register_caches[0x32] = RegisterCache(_serial_to_hr("ZZ9999Z999"))
+    assert plant.inverter_serial == "", "0x32 is the battery pack, never the inverter"
+
+
+def test_inverter_serial_falls_back_to_envelope_field():
+    """The envelope serial is the final fallback when no register cache is populated (#227).
+
+    It is earliest-available at detect() and the only home on persisted/bare state.
+    """
+    plant = Plant()
+    plant.inverter_serial_number = "CH2414G047"
+    assert plant.inverter_serial == "CH2414G047"
+
+
+def test_inverter_serial_prefers_registers_when_populated():
+    """A populated inverter register cache is authoritative over the envelope field (#227)."""
+    plant = Plant(capabilities=PlantCapabilities(device_type=Model.HYBRID, inverter_address=0x11))
+    plant.register_caches[0x11] = RegisterCache(_serial_to_hr("RG1234G567"))
+    plant.inverter_serial_number = "CH2414G047"
+    assert plant.inverter_serial == "RG1234G567"
+
+
 def test_plant_redact_clears_header_serials_and_redacts_caches():
     """Plant.redact() redacts every cache AND the out-of-cache header serials (audit H2).
 

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -2105,6 +2105,22 @@ def test_inverter_serial_prefers_registers_when_populated():
     assert plant.inverter_serial == "RG1234G567"
 
 
+def test_inverter_serial_skips_partial_serial_block():
+    """A cache holding only part of HR13-17 is skipped (fail closed), not decoded partially (#227)."""
+    plant = Plant(capabilities=PlantCapabilities(device_type=Model.HYBRID, inverter_address=0x11))
+    plant.register_caches[0x11] = RegisterCache({HR(13): 0x4348, HR(14): 0x3234})  # only 2 of 5
+    plant.inverter_serial_number = "CH2414G047"
+    assert plant.inverter_serial == "CH2414G047", "a partial serial block must fall through, not decode"
+
+
+def test_inverter_serial_skips_all_zero_serial_registers():
+    """HR13-17 present but all-zero decodes to empty → fall through to the envelope, not '' (#227)."""
+    plant = Plant(capabilities=PlantCapabilities(device_type=Model.HYBRID, inverter_address=0x11))
+    plant.register_caches[0x11] = RegisterCache({HR(n): 0 for n in range(13, 18)})
+    plant.inverter_serial_number = "CH2414G047"
+    assert plant.inverter_serial == "CH2414G047"
+
+
 def test_plant_redact_clears_header_serials_and_redacts_caches():
     """Plant.redact() redacts every cache AND the out-of-cache header serials (audit H2).
 

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -2121,6 +2121,22 @@ def test_inverter_serial_skips_all_zero_serial_registers():
     assert plant.inverter_serial == "CH2414G047"
 
 
+def test_inverter_serial_skips_malformed_complete_block():
+    """A complete block decoding to a malformed (non-10-char) serial falls through (#227, Codex).
+
+    An interior zero register (HR15=0x0000 → "SA12G047" after the null strip) — or spaces /
+    garbage in a restored or tampered cache — passes the not-empty check but is not a valid
+    serial, so it must not outrank a known-good envelope serial. Gated by is_valid_serial().
+    """
+    plant = Plant(capabilities=PlantCapabilities(device_type=Model.HYBRID, inverter_address=0x11))
+    # S A 1 2 \x00 \x00 G 0 4 7 → "SA12G047" (8 chars) after the null strip
+    plant.register_caches[0x11] = RegisterCache(
+        {HR(13): 0x5341, HR(14): 0x3132, HR(15): 0x0000, HR(16): 0x4730, HR(17): 0x3437}
+    )
+    plant.inverter_serial_number = "CH2414G047"
+    assert plant.inverter_serial == "CH2414G047"
+
+
 def test_plant_redact_clears_header_serials_and_redacts_caches():
     """Plant.redact() redacts every cache AND the out-of-cache header serials (audit H2).
 


### PR DESCRIPTION
Closes #227.

`Plant.inverter_serial_number` (PDU envelope) and `Plant.inverter.serial_number` (registers HR13-17) both expose the inverter serial, but neither is correct across the whole plant lifecycle:
- the **envelope** is empty until `detect()` (then stays correct after the #226 clobber fix);
- the **register** accessor reads `capabilities.inverter_address` — `0x31` for AC/HYBRID_GEN1, which is **empty in the detect→first-refresh window** — and reads the **`0x32` battery cache** on a bare plant.

### What this adds
A single authoritative accessor, **`Plant.inverter_serial`**, resolving the earliest-available identity in order:
1. HR13-17 in the capability-selected inverter cache (`0x31`/`0x11`);
2. HR13-17 in the **`0x11` cache** — `detect()`'s `HR(0,60)` identity read lands here for *every* model, so this covers the detect→refresh window before `0x31` is populated;
3. the **`inverter_serial_number` envelope field** — populated at `detect()` and the only home on persisted/bare state.

It **never reads the `0x32` battery cache**, so a bare or pre-detect plant can't surface a battery pack's serial as the inverter's. It reads via `.get()` so it never mutates the (defaultdict) caches. A stale pre-#119 `inverter_address=0x32` capability is ignored (only `0x11`/`0x31` qualify, matching the hass#95 gate).

This is the prerequisite the issue asks for: once consumers migrate to `Plant.inverter_serial`, the envelope field can be deprecated (tracked separately — not in this PR).

### Verification
- TDD: 5 new tests covering each tier (capability cache, 0x11 fallback in the detect window, never-0x32, envelope fallback, register-over-envelope precedence); the 4 existing `inverter_serial_number` envelope-gating tests still pass.
- `tox` green py311–314 (incl. mypy). Read-only accessor — no register-write code, no register-safety gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)