### PR TITLE
feat(release): hand-authored release-notes file leads the generated section

### DIFF
--- a/docs/release-notes/v2.2.0.md
+++ b/docs/release-notes/v2.2.0.md
@@ -48,6 +48,29 @@ chain (actions pinned to commit SHAs, least-privilege workflow permissions).
   but the typed-device API is the supported path going forward — new device
   types will appear there first.
 
+### Home Assistant
+
+The Home Assistant integration
+([givenergy-hass](https://github.com/dewet22/givenergy-hass)) ships its 1.2.0
+line on 2.2, and it is the most visible beneficiary of the typed device model.
+All-in-One systems now surface each removable battery module as its own HA
+device — parented to the inverter, identified by the module's serial, with its
+24 per-cell voltages and temperatures as diagnostic sensors — so the
+cell-balance heatmap and pack-health views work at module granularity,
+validated end-to-end on a real four-module unit. The 2.2 identity fixes also
+resolve a long-standing All-in-One collision where the inverter device could
+merge into one of its own battery modules.
+
+Beyond the device model, 1.2.0 adds always-positive Grid Power Import/Export
+sensors that suit the Energy Dashboard's two-sensor grid option directly,
+hardens debug-capture access behind admin tokens and single-capture signed
+links (following a security review of the integration that found no
+exploitable vulnerabilities), and inherits the library's rejection of the
+dongle's transient all-zero register blocks — last-good values are kept rather
+than zeros reaching your sensors. There's no migration on upgrade; AIO owners
+who ran an early 1.2.0 pre-release should remove and re-add the integration
+once to clear stale entities.
+
 ### givenergy-cli
 
 The CLI ([givenergy-cli](https://github.com/dewet22/givenergy-cli)) tracks 2.2
@@ -58,15 +81,3 @@ beyond read-only, gated behind an explicit `--allow-writes` flag. Diagnostic
 exports are share-safe by default, with serial numbers redacted. Nothing
 changes for users beyond a normal upgrade — the graph-shaped Plant and the
 register renames were absorbed inside the CLI.
-
-### Home Assistant
-
-The Home Assistant integration
-([givenergy-hass](https://github.com/dewet22/givenergy-hass)) builds its 1.2.0
-line on 2.2: the typed per-device model surfaces each All-in-One battery module
-as its own Home Assistant device with per-cell voltages and temperatures, and
-the inverter-serial fixes resolve a device-identity collision on AIO systems
-where the inverter could merge with a battery module. There's no migration for
-HA users — updating the integration brings the library along; AIO owners who
-ran an early 1.2.0 pre-release should remove and re-add the integration once to
-clear stale entities.

--- a/docs/release-notes/v2.2.0.md
+++ b/docs/release-notes/v2.2.0.md
@@ -27,15 +27,17 @@ across the whole detect→refresh lifecycle.
 
 ### Security
 
-This release carries the results of a full security audit of the library, its
-threat model and its CI pipeline — conducted end-to-end by Anthropic's
-Mythos/Fable model, with every finding either fixed or closed with documented
-analysis (#223, #224). It delivered: a published `SECURITY.md` and threat model,
-fail-closed serial redaction, write-path input validation (bools and
-non-integral values are rejected before they reach a register), hardening of
-the decode layer against malformed frames and tampered cache files, an opt-in
-strict CRC mode (`ReadRegistersResponse.strict_crc`), and a hardened CI supply
-chain (actions pinned to commit SHAs, least-privilege workflow permissions).
+This release carries the library's share of a coordinated security audit that
+swept all three GivEnergy repositories — the modbus library, the Home Assistant
+integration, and the CLI — conducted end-to-end by Anthropic's Mythos/Fable
+model, with every finding either fixed or closed with documented analysis
+(#223, #224). On the library side it delivered: a published `SECURITY.md` and
+threat model, fail-closed serial redaction, write-path input validation (bools
+and non-integral values are rejected before they reach a register), hardening
+of the decode layer against malformed frames and tampered cache files, an
+opt-in strict CRC mode (`ReadRegistersResponse.strict_crc`), and a hardened CI
+supply chain (actions pinned to commit SHAs, least-privilege workflow
+permissions).
 
 ### Breaking changes & migration from 2.1
 

--- a/docs/release-notes/v2.2.0.md
+++ b/docs/release-notes/v2.2.0.md
@@ -1,0 +1,46 @@
+2.2 reshapes how a system is modelled and hardens the library end to end. The
+headline is the graph-shaped Plant (#106): instead of a flat model interrogated
+through scattered `is_*`/`has_*` predicates, a Plant now enumerates its hardware
+as typed devices — inverter, batteries, EMS, gateway, AIO battery modules — each
+addressable in its own right. The same release line absorbed a full security
+audit and a series of device-identity fixes, so serial numbers are now reliable
+across the whole detect→refresh lifecycle.
+
+### Highlights
+
+- **Typed-device enumeration — `Plant.devices`** (#106): walk a system's hardware
+  as typed devices rather than reading raw register caches or model predicates.
+- **Reliable device identity**: serial reconciliation via `Plant.serial_index`
+  (#106), a single authoritative `Plant.inverter_serial` accessor that stays
+  correct from first detect through every refresh (#227), and a fix for
+  peripheral responses clobbering the inverter serial (givenergy-hass#95).
+- **Per-module AIO battery data** exposed as enumerable devices (#192).
+- **Share-safe diagnostics**: `RegisterCache.redact_serials()` and `Plant.redact()`
+  produce exports with serial numbers redacted, for attaching to issues (#212).
+- **Model-aware write commands** for three-phase inverters and EMS plants
+  (#75, #203), routed through per-model safe-register checks.
+- **Frozen-BMS detection** via a content-staleness primitive, so consumers can
+  tell live data from a stuck cache (#91).
+
+### Security
+
+This release carries the results of a full security audit of the library, its
+threat model and its CI pipeline — conducted end-to-end by Anthropic's
+Mythos/Fable model, with every finding either fixed or closed with documented
+analysis (#223, #224). It delivered: a published `SECURITY.md` and threat model,
+fail-closed serial redaction, write-path input validation (bools and
+non-integral values are rejected before they reach a register), hardening of
+the decode layer against malformed frames and tampered cache files, an opt-in
+strict CRC mode (`ReadRegistersResponse.strict_crc`), and a hardened CI supply
+chain (actions pinned to commit SHAs, least-privilege workflow permissions).
+
+### Breaking changes & migration from 2.1
+
+- `first_battery_serial_number` has been removed (#191) — it was unreliable on
+  real hardware. Use the typed-device enumeration or `Plant.serial_index`.
+- For inverter identity, prefer the new `Plant.inverter_serial`;
+  `Plant.inverter_serial_number` remains but is now a fallback surface and a
+  candidate for deprecation in a future release.
+- Topology checks built on flat predicates or raw register caches keep working,
+  but the typed-device API is the supported path going forward — new device
+  types will appear there first.

--- a/docs/release-notes/v2.2.0.md
+++ b/docs/release-notes/v2.2.0.md
@@ -44,3 +44,15 @@ chain (actions pinned to commit SHAs, least-privilege workflow permissions).
 - Topology checks built on flat predicates or raw register caches keep working,
   but the typed-device API is the supported path going forward — new device
   types will appear there first.
+
+### Home Assistant
+
+The Home Assistant integration
+([givenergy-hass](https://github.com/dewet22/givenergy-hass)) builds its 1.2.0
+line on 2.2: the typed per-device model surfaces each All-in-One battery module
+as its own Home Assistant device with per-cell voltages and temperatures, and
+the inverter-serial fixes resolve a device-identity collision on AIO systems
+where the inverter could merge with a battery module. There's no migration for
+HA users — updating the integration brings the library along; AIO owners who
+ran an early 1.2.0 pre-release should remove and re-add the integration once to
+clear stale entities.

--- a/docs/release-notes/v2.2.0.md
+++ b/docs/release-notes/v2.2.0.md
@@ -48,6 +48,17 @@ chain (actions pinned to commit SHAs, least-privilege workflow permissions).
   but the typed-device API is the supported path going forward — new device
   types will appear there first.
 
+### givenergy-cli
+
+The CLI ([givenergy-cli](https://github.com/dewet22/givenergy-cli)) tracks 2.2
+in its 1.5 line: the TUI gains Glance/Flow/Analyst views mirroring the Home
+Assistant dashboards, warm starts become near-instant by caching the detected
+topology, and a new Controls view sends inverter writes — the CLI's first step
+beyond read-only, gated behind an explicit `--allow-writes` flag. Diagnostic
+exports are share-safe by default, with serial numbers redacted. Nothing
+changes for users beyond a normal upgrade — the graph-shaped Plant and the
+register renames were absorbed inside the CLI.
+
 ### Home Assistant
 
 The Home Assistant integration

--- a/docs/release-notes/v2.2.0.md
+++ b/docs/release-notes/v2.2.0.md
@@ -18,7 +18,10 @@ across the whole detect→refresh lifecycle.
 - **Share-safe diagnostics**: `RegisterCache.redact_serials()` and `Plant.redact()`
   produce exports with serial numbers redacted, for attaching to issues (#212).
 - **Model-aware write commands** for three-phase inverters and EMS plants
-  (#75, #203), routed through per-model safe-register checks.
+  (#75, #203): model-specific command mixins route writes to the correct
+  registers for the hardware, with write safety enforced by the global
+  allowlist at the PDU layer. Per-model allowlists are laid out as groundwork
+  but not yet enforced.
 - **Frozen-BMS detection** via a content-staleness primitive, so consumers can
   tell live data from a stuck cache (#91).
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -325,6 +325,11 @@ def cmd_generate(args) -> None:
     header) to stdout — the release workflow captures stdout as the GitHub Release
     description. With `--preview`, only prints; does not modify the file.
     """
+    # Accept tag-style input (`generate v2.2.0`) — an easy slip when copying from a git
+    # tag. Normalising keeps the `## [2.2.0]` header standard and the notes-file lookup
+    # (v<version>.md) from silently missing on a doubled prefix.
+    args.version = args.version.removeprefix("v")
+
     commits = _git_commits_since_last_tag()
     sections = _classify_commits(commits)
     body = _render_body(sections)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -13,6 +13,14 @@ from pathlib import Path
 
 CHANGELOG = Path(__file__).parent.parent / "CHANGELOG.md"
 
+# Optional hand-authored narrative per release: docs/release-notes/v<version>.md.
+# When present, `generate` leads the section with it — finals after a long rc line
+# otherwise ship a near-empty body (commits since the last rc only; the 2.1.0
+# release description was a single bullet while all the substance sat in rc
+# sections). The file carries the human story into both CHANGELOG.md and the
+# GitHub Release description without making either hand-maintained.
+RELEASE_NOTES_DIR = Path(__file__).parent.parent / "docs" / "release-notes"
+
 _SECTION_ORDER: list[str] = [
     "✨ Added",
     "🔄 Changed",
@@ -321,6 +329,12 @@ def cmd_generate(args) -> None:
     sections = _classify_commits(commits)
     body = _render_body(sections)
     today = date.today().isoformat()
+
+    notes_file = RELEASE_NOTES_DIR / f"v{args.version}.md"
+    if notes_file.is_file():
+        notes = notes_file.read_text(encoding="utf-8").strip()
+        if notes:
+            body = f"{notes}\n\n{body}" if body else f"{notes}\n"
 
     if args.preview:
         print(f"## [{args.version}] - {today}\n")

--- a/tests/scripts/test_release.py
+++ b/tests/scripts/test_release.py
@@ -424,6 +424,30 @@ def test_cmd_generate_without_notes_file_is_unchanged(tmp_path, monkeypatch, cap
     assert out.startswith(f"### {ADDED}")
 
 
+def test_cmd_generate_normalises_leading_v_in_version(tmp_path, monkeypatch, capsys):
+    """`generate v1.1.0` (tag-style, an easy manual slip) behaves exactly like `generate 1.1.0`.
+
+    Without normalisation it would look up vv1.1.0.md (silently missing the notes file)
+    and write a non-standard `## [v1.1.0]` header.
+    """
+    cl_path = tmp_path / "CHANGELOG.md"
+    cl_path.write_text("# Changelog\n\n## [1.0.0] - 2026-01-01\n\n### ✨ Added\n\n- initial\n", encoding="utf-8")
+    notes_dir = tmp_path / "release-notes"
+    notes_dir.mkdir()
+    (notes_dir / "v1.1.0.md").write_text("Narrative.\n", encoding="utf-8")
+    monkeypatch.setattr(release, "CHANGELOG", cl_path)
+    monkeypatch.setattr(release, "RELEASE_NOTES_DIR", notes_dir)
+    monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+
+    with patch.object(release, "_git_commits_since_last_tag", return_value=[("aaaa", "feat: shiny")]):
+        release.cmd_generate(_generate_args("v1.1.0"))
+
+    written = cl_path.read_text(encoding="utf-8")
+    assert "## [1.1.0]" in written
+    assert "## [v1.1.0]" not in written
+    assert "Narrative." in written, "tag-style version must still find the notes file"
+
+
 def test_cmd_generate_empty_commit_list_warns_but_writes(tmp_path, monkeypatch, capsys):
     cl_path = tmp_path / "CHANGELOG.md"
     cl_path.write_text(

--- a/tests/scripts/test_release.py
+++ b/tests/scripts/test_release.py
@@ -361,6 +361,69 @@ def test_cmd_generate_preview_does_not_modify_file(tmp_path, monkeypatch, capsys
     assert "- shiny" in out
 
 
+def test_cmd_generate_prepends_release_notes_file(tmp_path, monkeypatch, capsys):
+    """A hand-authored docs/release-notes/v<version>.md leads the section body.
+
+    Finals after a long rc line otherwise ship a near-empty section (commits since the
+    last rc) — the 2.1.0 release body was a single bullet. The notes file carries the
+    human narrative into both CHANGELOG.md and the GitHub Release description.
+    """
+    cl_path = tmp_path / "CHANGELOG.md"
+    cl_path.write_text("# Changelog\n\n## [1.0.0] - 2026-01-01\n\n### ✨ Added\n\n- initial\n", encoding="utf-8")
+    notes_dir = tmp_path / "release-notes"
+    notes_dir.mkdir()
+    (notes_dir / "v1.1.0.md").write_text("The big 1.1 narrative.\n\nWith a second paragraph.\n", encoding="utf-8")
+    monkeypatch.setattr(release, "CHANGELOG", cl_path)
+    monkeypatch.setattr(release, "RELEASE_NOTES_DIR", notes_dir)
+    monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+
+    with patch.object(release, "_git_commits_since_last_tag", return_value=[("aaaa", "feat: shiny")]):
+        release.cmd_generate(_generate_args("1.1.0"))
+
+    out = capsys.readouterr().out
+    assert out.startswith("The big 1.1 narrative.")
+    assert out.index("narrative") < out.index("- shiny"), "notes lead, generated entries follow"
+    written = cl_path.read_text(encoding="utf-8")
+    assert "The big 1.1 narrative." in written
+    assert written.index("## [1.1.0]") < written.index("narrative") < written.index("- shiny")
+
+
+def test_cmd_generate_preview_includes_release_notes(tmp_path, monkeypatch, capsys):
+    cl_path = tmp_path / "CHANGELOG.md"
+    original = "# Changelog\n\n## [1.0.0] - 2026-01-01\n\n### ✨ Added\n\n- initial\n"
+    cl_path.write_text(original, encoding="utf-8")
+    notes_dir = tmp_path / "release-notes"
+    notes_dir.mkdir()
+    (notes_dir / "v1.1.0.md").write_text("Preview narrative.\n", encoding="utf-8")
+    monkeypatch.setattr(release, "CHANGELOG", cl_path)
+    monkeypatch.setattr(release, "RELEASE_NOTES_DIR", notes_dir)
+    monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+
+    with patch.object(release, "_git_commits_since_last_tag", return_value=[("aaaa", "feat: shiny")]):
+        release.cmd_generate(_generate_args("1.1.0", preview=True))
+
+    assert cl_path.read_text(encoding="utf-8") == original, "preview must not write"
+    out = capsys.readouterr().out
+    assert "Preview narrative." in out
+    assert "- shiny" in out
+
+
+def test_cmd_generate_without_notes_file_is_unchanged(tmp_path, monkeypatch, capsys):
+    """No notes file for the version → behaviour identical to before (no leading blank)."""
+    cl_path = tmp_path / "CHANGELOG.md"
+    cl_path.write_text("# Changelog\n\n## [1.0.0] - 2026-01-01\n\n### ✨ Added\n\n- initial\n", encoding="utf-8")
+    notes_dir = tmp_path / "release-notes"  # deliberately not created
+    monkeypatch.setattr(release, "CHANGELOG", cl_path)
+    monkeypatch.setattr(release, "RELEASE_NOTES_DIR", notes_dir)
+    monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+
+    with patch.object(release, "_git_commits_since_last_tag", return_value=[("aaaa", "feat: shiny")]):
+        release.cmd_generate(_generate_args("1.1.0"))
+
+    out = capsys.readouterr().out
+    assert out.startswith(f"### {ADDED}")
+
+
 def test_cmd_generate_empty_commit_list_warns_but_writes(tmp_path, monkeypatch, capsys):
     cl_path = tmp_path / "CHANGELOG.md"
     cl_path.write_text(


### PR DESCRIPTION
Targets `v2.2` directly — this is release-line tooling plus the v2.2.0 narrative, not 2.1-line material.

### The gap
`release.py generate` only collects commits since the last tag, so a final cut after a long rc line ships a near-empty CHANGELOG section and GitHub Release body — the 2.1.0 release description was a single bullet while all the substance sat buried in rc/beta sections.

### The mechanism
When `docs/release-notes/v<version>.md` exists, `generate` now prepends its content to the rendered body — in both the real write and `--preview`. The narrative therefore lands in the CHANGELOG section *and* the GitHub Release description at cut time, while the generator remains the single writer of CHANGELOG.md. Absent file → behaviour unchanged. Covered by three new tests (notes lead the body; preview includes them; no-file path identical to before).

### The payload
`docs/release-notes/v2.2.0.md` — the 2.2.0 narrative: graph-shaped Plant (#106), device-identity fixes (#227, hass#95), per-module AIO batteries (#192), share-safe redaction (#212), the full Mythos/Fable security audit (#223/#224), and migration notes from 2.1 (including the `first_battery_serial_number` removal, #191). Consumer blurbs from the cli and hass agents follow as a separate commit once their replies arrive — their go/no-go on rc6 hardware validation also gates the final cut.

Verified end-to-end: `release.py generate 2.2.0 --preview` renders the narrative followed by the generated entries; tox green py311–314.

🤖 Generated with [Claude Code](https://claude.com/claude-code)