### PR TITLE
docs(changelog): backfill the 2.1.6 section onto v2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,21 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - ghbot convention, permission allowlist, and inbox hooks ([5224099](https://github.com/dewet22/givenergy-modbus/commit/5224099f4002286f6eac645b64cc9fec1f87d949))
 
+## [2.1.6] - 2026-06-09
+
+### ✨ Added
+
+- RegisterCache.redact_serials() — share-safe cache export (#212, #214) ([7ce7c66](https://github.com/dewet22/givenergy-modbus/commit/7ce7c66afedb06d5e83c038f2abfa750c9401ad0))
+
+### 🔄 Changed
+
+- ⚠️ Breaking: remove unreliable first_battery_serial_number (#191) (#218) ([f08af87](https://github.com/dewet22/givenergy-modbus/commit/f08af87d9258bdb17f28b90c2af770445af47f80))
+
+### 🔧 Maintenance
+
+- ghbot convention, permission allowlist, and inbox hooks ([9dde868](https://github.com/dewet22/givenergy-modbus/commit/9dde868285ef5c0e85ca24cf6595078b4db63537))
+- bump codecov/codecov-action from 6 to 7 (#217) ([9014003](https://github.com/dewet22/givenergy-modbus/commit/90140030eeac49e90f30c9a4071e54f780b72689))
+
 ## [2.1.5] - 2026-06-07
 
 ### ✨ Added


### PR DESCRIPTION
Pre-promotion tidy-up surfaced by diffing `main` against `v2.2`.

2.1.6 was cut on the main line while v2.2 developed in parallel, so v2.2's CHANGELOG never carried its `## [2.1.6]` section. The four commits it packaged (redact_serials #212/#214, the `first_battery_serial_number` removal #191/#218, the ghbot convention, codecov 6→7 #217) are all present on v2.2 — documented under the rc1/rc2 headings — so this is purely a missing changelog *heading*, not missing code.

This copies the section verbatim from main (byte-identical, verified) and places it just above `## [2.1.5]`, keeping the 2.1.x lineage contiguous below the 2.2 prereleases. So once v2.2 is promoted to main, the changelog history reads completely.

History only, no code change; the `v2.1.6` tag and PyPI release are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)