### PR TITLE
feat(battery): map IR(95) Im_Avg as i_battery — signed per-pack current

### DIFF
--- a/givenergy_modbus/model/battery.py
+++ b/givenergy_modbus/model/battery.py
@@ -59,7 +59,10 @@ class BatteryRegisterGetter(RegisterGetter):
         "status_7": Def((DT.duint8, 0), None, IR(93)),
         "warning_1": Def((DT.duint8, 0), None, IR(94)),
         "warning_2": Def((DT.duint8, 1), None, IR(94)),
-        # IR(95) unused
+        # IR(95) "Im_Avg" (v4.1.6 doc): average pack current, signed, 0.01 A.
+        # Field evidence (#238, two LV systems) confirms it tracks operating state;
+        # observed sign convention is +ve = discharge / -ve = charge.
+        "i_battery": Def(DT.int16, DT.centi, IR(95), min=-300.0, max=300.0),
         "num_cycles": Def(DT.uint16, None, IR(96)),
         "num_cells": Def(DT.uint16, None, IR(97)),
         "bms_firmware_version": Def(DT.uint16, None, IR(98)),

--- a/tests/model/test_battery.py
+++ b/tests/model/test_battery.py
@@ -1,4 +1,5 @@
 from givenergy_modbus.model.battery import Battery
+from givenergy_modbus.model.register import IR
 from givenergy_modbus.model.register_cache import RegisterCache
 
 
@@ -9,6 +10,7 @@ def test_from_registers(register_cache):
         "cap_design": 160.0,
         "cap_design2": 160.0,
         "cap_calibrated": 190.97,
+        "i_battery": 0.0,
         "num_cells": 16,
         "num_cycles": 12,
         "cap_remaining": 18.04,
@@ -59,6 +61,7 @@ def test_from_registers_actual_data(register_cache_battery_daytime_discharging):
         "cap_design": 160.0,
         "cap_design2": 160.0,
         "cap_calibrated": 195.13,
+        "i_battery": 0.0,
         "num_cells": 16,
         "num_cycles": 23,
         "cap_remaining": 131.42,
@@ -113,6 +116,7 @@ def test_from_registers_unsure_data(register_cache_battery_unsure):
         "cap_design": 0.0,
         "cap_design2": 0.0,
         "cap_remaining": 0.0,
+        "i_battery": 0.0,
         "num_cells": 0,
         "num_cycles": 0,
         "serial_number": "",
@@ -155,6 +159,19 @@ def test_from_registers_unsure_data(register_cache_battery_unsure):
     }
 
 
+def test_i_battery_signed_centi():
+    """IR(95) 'Im_Avg' decodes as a signed 0.01 A current (#238).
+
+    A negative charge current and a heavy discharge current, both from the
+    field report on real LV hardware, round-trip through int16 + centi scaling.
+    """
+    charging = Battery.from_register_cache(RegisterCache({IR(95): 65536 - 203}))
+    assert charging.i_battery == -2.03
+
+    discharging = Battery.from_register_cache(RegisterCache({IR(95): 4183}))
+    assert discharging.i_battery == 41.83
+
+
 def test_empty():
     """Ensure we can instantiate from empty data."""
     b1 = Battery()
@@ -173,6 +190,7 @@ def test_empty():
             "cap_design": None,
             "cap_design2": None,
             "cap_remaining": None,
+            "i_battery": None,
             "num_cells": None,
             "num_cycles": None,
             "serial_number": None,

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -1326,6 +1326,7 @@ def test_from_actual():
         "cap_design": 160.0,
         "cap_design2": 160.0,
         "cap_calibrated": 192.02,
+        "i_battery": 0.0,
         "num_cells": 16,
         "num_cycles": 116,
         "cap_remaining": 110.71,


### PR DESCRIPTION
## Summary

#238 reported IR(95) returning dynamic, signed values on real LV battery hardware (two systems, packs at 0x32/0x33) despite the register being marked unused in `BatteryRegisterGetter`.

Checking against our v4.1.6 register-reference inventory confirms the finding outright: the LV BMU table lists IR(95) as **`Im_Avg` — average battery current, signed, 0.01 A**. The reporter's values fit exactly: 4183 during a forced EV-charging discharge reads as 41.83 A; the small negatives (−25, −203) as light charging.

## Changes

- Map IR(95) as `i_battery` on the `Battery` model: `int16` + centi scaling, ±300 A bounds (matching the inverter-side `i_battery` field's bounds).
- Code comment records the doc name, scale, and the field-observed sign convention (positive = discharge), since the doc itself doesn't state it.
- Regression test round-trips the actual reported field values through the signed decode.
- Full-dump test fixtures gain the new key (all fixture captures have IR(95) = 0).

The reporter's secondary observations also check out and need no change: IR(96) tracking cycle count matches our `num_cycles` mapping, and IR(91) = 3600 is the packed status byte-pair (0x0E10 → `status_3`=14 / `status_4`=16) already present in our fixtures.

Closes #238. Feeds the #48 register audit.

## Testing

- `prek` hooks green on changed files
- `tox` fully green: py311–py314, format, lint, build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Battery current measurement is now available through a new field. This enables real-time monitoring of battery current, accurately capturing both positive discharge and negative charge states. Current readings span from −300.0 to 300.0 centi-amps, providing comprehensive battery system diagnostics and enhanced visibility into battery performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->