### PR TITLE
feat(api): public accessors for a field's backing registers + per-register freshness

### DIFF
--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -23,7 +23,7 @@ from givenergy_modbus.model.inverter import (
 )
 from givenergy_modbus.model.inverter_threephase import ThreePhaseInverter, select_inverter
 from givenergy_modbus.model.meter import Meter, MeterRegisterGetter
-from givenergy_modbus.model.register import HR, IR, Converter, RegisterGetter, is_valid_serial
+from givenergy_modbus.model.register import HR, IR, Converter, Register, RegisterGetter, is_valid_serial
 from givenergy_modbus.model.register_cache import RegisterCache
 from givenergy_modbus.pdu import (
     ClientIncomingMessage,
@@ -759,6 +759,33 @@ class Plant(GivEnergyBaseModel):
         if effective_now.tzinfo is None:
             effective_now = effective_now.replace(tzinfo=UTC)
         return (effective_now - ts).total_seconds()
+
+    def register_age(
+        self,
+        device_address: int,
+        register: Register,
+        *,
+        now: datetime | None = None,
+    ) -> float | None:
+        """Seconds since the freshest stamped block *containing* ``register`` was committed (#247).
+
+        Unlike ``block_age()``, the caller doesn't need to know block boundaries or the
+        stamped count — every stamped window for the device whose [base, base+count) span
+        covers the register is considered, and the freshest wins. None if no stamped
+        window covers it. Pair with ``RegisterGetter.registers_of()`` to reason about a
+        model attribute's freshness.
+        """
+        effective_now = now or datetime.now(UTC)
+        if effective_now.tzinfo is None:
+            effective_now = effective_now.replace(tzinfo=UTC)
+        best: datetime | None = None
+        for (dev, reg_type, base, count), ts in self.register_block_updated_at.items():
+            if dev == device_address and reg_type == register.reg_type and base <= register.index < base + count:
+                if best is None or ts > best:
+                    best = ts
+        if best is None:
+            return None
+        return (effective_now - best).total_seconds()
 
     def _track_content_change(
         self,

--- a/givenergy_modbus/model/register.py
+++ b/givenergy_modbus/model/register.py
@@ -338,6 +338,18 @@ class RegisterGetter:
         defn = cls.REGISTER_LUT.get(name)
         return defn.precision if defn is not None else None
 
+    @classmethod
+    def registers_of(cls, name: str) -> "tuple[Register, ...]":
+        """The Register instances backing a named attribute, in wire order (#247).
+
+        Empty tuple for attributes not in the LUT (computed/aggregate values), so
+        callers can iterate unconditionally. Pair with ``Register.reg_type`` /
+        ``Register.index`` and ``Plant.register_age()`` to reason about the freshness
+        of an attribute's underlying data without reaching into private surfaces.
+        """
+        defn = cls.REGISTER_LUT.get(name)
+        return defn.registers if defn is not None else ()
+
     def get(self, key: str, default: Any = None) -> Any:
         """Return a named register's value, after pre- and post-conversion."""
         try:
@@ -538,6 +550,20 @@ class Register:
 
     def __init__(self, idx):
         self._idx = idx
+
+    @property
+    def index(self) -> int:
+        """Numeric register index — the public form of ``_idx`` (#247)."""
+        return self._idx
+
+    @property
+    def reg_type(self) -> str:
+        """Register type name ("HR"/"IR"/"MR") — public form of ``_type`` (#247).
+
+        Matches the ``reg_type`` string accepted by ``Plant.block_age()``, so consumers
+        don't need ``type(reg).__name__``.
+        """
+        return self._type
 
     def __str__(self):
         return "%s_%d" % (self._type, int(self._idx))

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -2274,3 +2274,71 @@ def test_plant_redact_fails_closed_on_unrecognised_header_serial():
 
     assert redacted.inverter_serial_number == ""
     assert redacted.data_adapter_serial_number == ""
+
+
+def test_register_age_finds_containing_window(plant: Plant):
+    """register_age() resolves the freshest stamped window containing the register (#247).
+
+    Consumers shouldn't need to know block boundaries or stamped counts — that's the
+    private-reach the hass integration had to do before this existed.
+    """
+    from givenergy_modbus.model.register import IR
+
+    t = datetime(2026, 6, 11, 12, 0, 0, tzinfo=UTC)
+    plant.update(_make_ir_pdu({5: 2367, 42: 3685}, base_register=0), received_at=t)
+    now = datetime(2026, 6, 11, 12, 0, 30, tzinfo=UTC)
+    # IR(42) sits inside the stamped IR(0,60) window.
+    assert plant.register_age(0x32, IR(42), now=now) == 30.0
+    # Outside any stamped window → None; wrong device → None.
+    assert plant.register_age(0x32, IR(180), now=now) is None
+    assert plant.register_age(0x99, IR(42), now=now) is None
+
+
+def test_register_age_freshest_of_overlapping_windows(plant: Plant):
+    """With overlapping stamped windows, the freshest containing one wins (#247)."""
+    from givenergy_modbus.model.register import IR
+
+    t0 = datetime(2026, 6, 11, 12, 0, 0, tzinfo=UTC)
+    t1 = datetime(2026, 6, 11, 12, 0, 20, tzinfo=UTC)
+    plant.update(_make_ir_pdu({5: 2367}, base_register=0), received_at=t0)  # IR(0,60) @ t0
+    plant.update(_make_ir_pdu({5: 2368}, base_register=0, register_count=10), received_at=t1)  # IR(0,10) @ t1
+    now = datetime(2026, 6, 11, 12, 0, 30, tzinfo=UTC)
+    # IR(5) is covered by both; the fresher IR(0,10) stamp wins.
+    assert plant.register_age(0x32, IR(5), now=now) == 10.0
+    # IR(42) is only covered by the older full-width window.
+    assert plant.register_age(0x32, IR(42), now=now) == 30.0
+
+
+def test_register_age_pairs_with_registers_of(plant: Plant):
+    """The advertised composition: registers_of() → register_age() for attribute freshness (#247)."""
+    from givenergy_modbus.model.inverter import SinglePhaseInverterRegisterGetter
+
+    t = datetime(2026, 6, 11, 12, 0, 0, tzinfo=UTC)
+    plant.update(_make_ir_pdu({42: 3685}, base_register=0), received_at=t)
+    regs = SinglePhaseInverterRegisterGetter.registers_of("p_load_demand")
+    assert regs, "p_load_demand must be register-backed"
+    now = datetime(2026, 6, 11, 12, 0, 15, tzinfo=UTC)
+    ages = [plant.register_age(0x32, r, now=now) for r in regs]
+    assert ages == [15.0]
+
+
+def test_register_age_normalises_naive_now(plant: Plant):
+    """A timezone-naive now is treated as UTC, matching block_age()'s posture (#208/#247)."""
+    from givenergy_modbus.model.register import IR
+
+    t = datetime(2026, 6, 11, 12, 0, 0, tzinfo=UTC)
+    plant.update(_make_ir_pdu({5: 2367}, base_register=0), received_at=t)
+    assert plant.register_age(0x32, IR(5), now=datetime(2026, 6, 11, 12, 0, 7)) == 7.0
+
+
+def test_register_age_keeps_freshest_when_older_window_seen_later(plant: Plant):
+    """A staler containing window encountered after a fresher one must not displace it (#247)."""
+    from givenergy_modbus.model.register import IR
+
+    t_new = datetime(2026, 6, 11, 12, 0, 20, tzinfo=UTC)
+    t_old = datetime(2026, 6, 11, 12, 0, 0, tzinfo=UTC)
+    # Stamp the fresher narrow window FIRST so iteration meets the older one second.
+    plant.update(_make_ir_pdu({5: 2368}, base_register=0, register_count=10), received_at=t_new)
+    plant.update(_make_ir_pdu({5: 2367}, base_register=0), received_at=t_old)  # IR(0,60), older
+    now = datetime(2026, 6, 11, 12, 0, 30, tzinfo=UTC)
+    assert plant.register_age(0x32, IR(5), now=now) == 10.0

--- a/tests/model/test_register.py
+++ b/tests/model/test_register.py
@@ -632,3 +632,25 @@ def test_model_precision_of_across_models():
     assert Battery.precision_of("soc") == 0  # uint16
     assert Battery.precision_of("v_out") == 3  # uint32 -> milli
     assert Battery.precision_of("serial_number") is None  # string
+
+
+def test_register_public_index_and_reg_type():
+    """Register.index / Register.reg_type are the public forms of _idx / _type (#247)."""
+    assert HR(13).index == 13
+    assert HR(13).reg_type == "HR"
+    assert IR(95).index == 95
+    assert IR(95).reg_type == "IR"
+    from givenergy_modbus.model.register import MR
+
+    assert MR(60).index == 60
+    assert MR(60).reg_type == "MR"
+
+
+def test_registers_of_mirrors_lut():
+    """RegisterGetter.registers_of() returns the backing registers in wire order (#247)."""
+    from givenergy_modbus.model.inverter import SinglePhaseInverterRegisterGetter as G
+
+    regs = G.registers_of("serial_number")
+    assert [(r.reg_type, r.index) for r in regs] == [("HR", 13), ("HR", 14), ("HR", 15), ("HR", 16), ("HR", 17)]
+    # Unknown / computed attributes yield an empty tuple, so callers can iterate unconditionally.
+    assert G.registers_of("no_such_attribute") == ()


### PR DESCRIPTION
## Summary

Closes #247 — an API-boundary request from the hass integration's sensor-staleness work (givenergy-hass#152/#158), which currently reaches into private surfaces (`REGISTER_LUT[key].registers`, `r._idx`, `type(r).__name__`, and a manual scan of `plant.register_block_updated_at`).

## Changes

- **`Register.index` / `Register.reg_type`** — public forms of `_idx` / `_type`; `reg_type` returns the same "HR"/"IR"/"MR" string `Plant.block_age()` accepts.
- **`RegisterGetter.registers_of(name)`** — the backing registers in wire order, mirroring the existing `precision_of()`; returns `()` for computed/unknown attributes so callers can iterate unconditionally.
- **`Plant.register_age(device_address, register)`** — seconds since the freshest stamped window *containing* the register was committed, or `None` if uncovered. Unlike `block_age()`, the caller doesn't need to know block boundaries or stamped counts.

The advertised composition (`registers_of()` → `register_age()`) is covered by a dedicated test, along with overlapping-window freshest-wins and never-seen/wrong-device cases.

No behaviour changes — purely additive surface.

## Testing

- `tox` fully green (py311–py314, format, lint, build)
- 957 tests pass (5 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)