### PR TITLE
feat(model): retire 0x31 read-alias — inverter addressing unified on 0x11

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -447,8 +447,11 @@ The serialised form is stable and includes a `schema_version` field:
 }
 ```
 
-`inverter_address` is derived from the model: `0x11` for most inverters, `0x31`
-for `AC` and `HYBRID_GEN1`. LV battery pack #1 lives at `0x32`, additional packs
-at `0x33`–`0x37`. State persisted before this mapping (which used `0x32` as the
-inverter address) reloads unchanged and self-heals on the next `detect()` via a
-one-off `PlantTopologyMismatch`.
+`inverter_address` is `0x11` for every model. (`AC` and `HYBRID_GEN1` hardware
+additionally answers at `0x31` — a facade over the same register file — which
+older library versions used as their polling address.) LV battery pack #1 lives
+at `0x32`, additional packs at `0x33`–`0x37`. Previously persisted state reloads
+unchanged and self-heals: a stored `0x31` keeps working against the hardware
+facade until the next `detect()` re-derives `0x11`, and a pre-existing `0x32`
+(the oldest mapping, where the inverter shared the battery address) surfaces as
+a one-off `PlantTopologyMismatch`.

--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -95,7 +95,7 @@ def _build_serial_register_groups() -> "list[tuple[str, int, int]]":
     # (#191: GivTCP-heritage, unused, unverifiable), but still redacted: AIO firmware
     # stores the unit serial here byte-swapped (CH… → HC…), recoverable to the real
     # serial, so it must not leak in shared captures. Appended unconditionally — no LUT
-    # Def carries it any more, and a duplicate (if a future field re-used HR 8) would
+    # Def carries it any more, and a duplicate (if a future field reused HR 8) would
     # only redact it twice, which is idempotent.
     groups.append(("HR", 8, 5))
     return groups
@@ -651,10 +651,9 @@ class Client:
             )
 
         # Step 1 — read the inverter's configuration block to get DTC and ARM firmware.
-        # 0x11 is the inverter's canonical address; discovery always reads there and the
-        # response is cached under 0x11 (issue #119). resolve_model() below maps the DTC to
-        # the model, from which PlantCapabilities derives the address used for later polling
-        # (0x11, or 0x31 for AC/HYBRID_GEN1).
+        # 0x11 is the inverter's canonical address for every model (#189); discovery reads
+        # there and the response is cached under 0x11 (issue #119). resolve_model() below maps
+        # the DTC to the model; PlantCapabilities derives the same 0x11 for later polling.
         await self.send_request_and_await_response(
             ReadHoldingRegistersRequest(base_register=0, register_count=60, device_address=0x11),
             timeout=timeout,
@@ -725,7 +724,7 @@ class Client:
         )
 
         # Step 4 — LV battery detection. Battery pack #1 is at 0x32, additional batteries at
-        # 0x33–0x37 (the inverter itself now lives at 0x11/0x31, not 0x32 — issue #119). All
+        # 0x33–0x37 (the inverter itself lives at 0x11, not 0x32 — issues #119/#189). All
         # slots are validated via Battery.is_valid(). Skipped for HV systems (handled at step 2)
         # and EMS plant controllers (don't expose IR at the inverter address — see #86).
         # Per-slot (not break-on-fail) for the same reasons as the meter sweep above: battery

--- a/givenergy_modbus/model/inverter.py
+++ b/givenergy_modbus/model/inverter.py
@@ -229,30 +229,23 @@ def resolve_model(raw_dtc: int, arm_fw: int) -> Model:
     return _DTC_PREFIX_TO_MODEL.get(prefix, Model(dtc))
 
 
-# Models whose inverter registers are served at device address 0x31 rather than
-# the 0x11 default. Mirrors GivTCP's detect() map: it forces 0x11 during
-# detection, then switches only AC and HYBRID_GEN1 to 0x31. 0x32 is battery
-# pack #1 and is never the inverter address.
-_INVERTER_ADDRESS_0X31_MODELS: frozenset[Model] = frozenset({Model.AC, Model.HYBRID_GEN1})
-
-
 def inverter_address_for(model: Model) -> int:
     """Return the modbus device address the inverter's registers are served at.
 
-    `0x11` is the inverter's canonical address for every model except AC and
-    HYBRID_GEN1, which expose their registers at `0x31` (GivTCP's map). EMS and
-    All-in-One controllers serve all their data — including the IR/HR(2040)
-    rollup — at `0x11`.
+    `0x11` is the canonical inverter address for all models. AC and HYBRID_GEN1
+    units additionally expose their registers at `0x31` — a facade over the same
+    register file (value-equality verified across 114 shared HR registers on a
+    live HYBRID_GEN1, and byte-identical HR banks on two live AC units; #189) —
+    but `0x11` is where the official app reads and writes, and where ``detect()``
+    always reads identity. EMS and All-in-One controllers likewise serve all
+    their data — including the IR/HR(2040) rollup — at `0x11`.
 
-    The `0x31` special-case is retained while live AC validation is pending
-    (see #189). For HYBRID_GEN1 it has been confirmed not to be load-bearing:
-    live hardware tests show `0x11` serves the full register banks (not
-    identity-only as previously stated), and value-equality between `0x11` and
-    `0x31` holds across 114 HR registers — they are the same register file at
-    two addresses. The official GivEnergy app reads and writes config at `0x11`
-    on this model, firmware-invariant across ARM 449 and 451.
+    Capabilities persisted before the `0x31` retirement may still carry an
+    explicit ``inverter_address`` of `0x31`; that keeps working (the hardware
+    facade still answers there) and self-heals to `0x11` on the next
+    ``detect()``.
     """
-    return 0x31 if model in _INVERTER_ADDRESS_0X31_MODELS else 0x11
+    return 0x11
 
 
 class UsbDevice(int, Enum):

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -156,11 +156,13 @@ def _coerce_model(value: Any) -> Model | None:
 def _derive_inverter_address(mapping: dict[str, Any]) -> None:
     """Fill in ``inverter_address`` from ``device_type`` when not pinned explicitly.
 
-    Mutates ``mapping`` in place. 0x11 for most models, 0x31 for AC/HYBRID_GEN1
-    (issue #119). Payloads that already carry an explicit ``inverter_address``
-    (e.g. persisted state via ``from_dict``) are left untouched — so a stored
-    pre-#119 ``0x32`` surfaces as a PlantTopologyMismatch on the next detect()
-    and self-heals rather than being silently rewritten.
+    Mutates ``mapping`` in place. 0x11 for all models since the 0x31 read-alias
+    retirement (#189; previously 0x31 for AC/HYBRID_GEN1 — issue #119). Payloads
+    that already carry an explicit ``inverter_address`` (e.g. persisted state via
+    ``from_dict``) are left untouched — a stored ``0x31`` keeps working against
+    the hardware facade and self-heals on the next detect(), while a stored
+    pre-#119 ``0x32`` surfaces as a PlantTopologyMismatch rather than being
+    silently rewritten.
     """
     if mapping.get("inverter_address") is not None:
         return
@@ -528,12 +530,14 @@ class Plant(GivEnergyBaseModel):
     def _getter_for_device_address(self, device_address: int) -> type[RegisterGetter] | None:
         """Return the RegisterGetter class appropriate for a given device address.
 
-        With capabilities the inverter lives at its model-specific address
-        (0x11, or 0x31 for AC/HYBRID_GEN1 — issue #119) and 0x32 is LV battery
+        With capabilities the inverter lives at ``capabilities.inverter_address``
+        (0x11 since #189; 0x31 may persist from pre-#189 state and the AC/
+        HYBRID_GEN1 hardware facade still answers there) and 0x32 is LV battery
         pack #1. Without capabilities we fall back to the legacy mapping where
         the inverter was cached at 0x32, and also treat 0x11/0x31 as inverter so
         replay/debug tooling (which feeds PDUs to a bare Plant) keeps validating
-        inverter banks that now arrive at their true wire address.
+        inverter banks at either wire address — including passive captures of
+        other consumers still polling the 0x31 facade.
         """
         if self.capabilities is not None:
             if device_address == self.capabilities.inverter_address:
@@ -614,10 +618,11 @@ class Plant(GivEnergyBaseModel):
         # battery (0x32-0x37), BCU/BMS (0x70+/0xA0) and AIO battery-module (0x50-0x53) responses
         # carry their own, so adopting it from every PDU let whichever device was polled last
         # clobber the real inverter serial — merging the AIO inverter HA device into a battery
-        # module downstream (givenergy-hass#95). The inverter is canonically addressed at
-        # 0x11/0x31 (inverter_address_for never yields anything else), so gate on that set — it
-        # excludes peripherals and the legacy 0x32 (battery pack #1) a pre-#119 persisted
-        # capability may still carry until detect() self-heals.
+        # module downstream (givenergy-hass#95). The inverter is canonically addressed at 0x11
+        # (#189), with 0x31 a hardware facade on AC/HYBRID_GEN1 that other bus consumers may
+        # still poll, so gate on that pair — it excludes peripherals and the legacy 0x32
+        # (battery pack #1) a pre-#119 persisted capability may still carry until detect()
+        # self-heals.
         if device_address in (0x11, 0x31):
             self.inverter_serial_number = pdu.inverter_serial_number
 
@@ -644,11 +649,12 @@ class Plant(GivEnergyBaseModel):
                 _logger.warning(f"Ignoring, likely corrupt: {pdu}")
             else:
                 # Writes target the inverter and the echo comes back on the write address
-                # (0x11), but the model reads caps.inverter_address (0x31 for AC/HYBRID_GEN1,
-                # 0x11 otherwise). 0x11 and 0x31 are the same device (a facade), so route the
-                # echo to where reads land — otherwise plant.inverter won't reflect the write
-                # until the next load_config(), and refresh() (IR-only) never will. The cache
-                # may not exist yet if the write precedes the first read at inverter_address.
+                # (0x11), and the model reads caps.inverter_address. Since #189 unified
+                # addressing on 0x11 the two normally coincide, but a pre-#189 persisted
+                # capability may still say 0x31 (the AC/HYBRID_GEN1 facade), so keep routing
+                # the echo to where reads land — otherwise plant.inverter won't reflect the
+                # write until the next load_config(), and refresh() (IR-only) never will. The
+                # cache may not exist yet if the write precedes the first read there.
                 target = self.capabilities.inverter_address if self.capabilities is not None else device_address
                 self.register_caches.setdefault(target, RegisterCache()).update({HR(pdu.register): pdu.value})
 
@@ -829,10 +835,11 @@ class Plant(GivEnergyBaseModel):
     def inverter(self) -> SinglePhaseInverter | ThreePhaseInverter:
         """Return the inverter model, dispatching on device type when capabilities are available.
 
-        Tolerates the inverter-address cache not yet existing — for AC/HYBRID_GEN1 the
-        address is 0x31, which detect() doesn't populate (it only reads identity at 0x11),
-        so this would otherwise KeyError between detect() and the first poll. Returns an
-        empty-cache model in that window, matching the .ems / .gateway accessors. (#119)
+        Tolerates the inverter-address cache not yet existing — a pre-#189 persisted
+        capability may still point at 0x31, which detect() doesn't populate (it reads
+        identity at 0x11), so this would otherwise KeyError between detect() and the
+        first poll. Returns an empty-cache model in that window, matching the
+        .ems / .gateway accessors. (#119, #189)
         """
         if self.capabilities:
             cache = self.register_caches.get(self.capabilities.inverter_address, RegisterCache())
@@ -845,10 +852,11 @@ class Plant(GivEnergyBaseModel):
 
         Resolves the earliest-available inverter identity by trying, in order:
 
-        1. HR(13-17) in the capability-selected inverter cache (``inverter_address`` — 0x31 for
-           AC/HYBRID_GEN1, else 0x11);
+        1. HR(13-17) in the capability-selected inverter cache (``inverter_address`` — 0x11
+           since #189; 0x31 only via a pre-#189 persisted capability);
         2. HR(13-17) in the 0x11 cache — ``detect()``'s ``HR(0,60)`` identity read lands here for
-           every model, so this covers the detect→first-refresh window before 0x31 is populated;
+           every model, so this covers the detect→first-refresh window when a stale capability
+           still points at 0x31;
         3. the ``inverter_serial_number`` envelope field — populated at ``detect()`` and the only
            home on a persisted/bare plant carrying no register caches.
 
@@ -862,8 +870,9 @@ class Plant(GivEnergyBaseModel):
         field can be deprecated.
         """
         addresses = [0x11]
-        # Prefer the device's own register home (0x31 for AC/HYBRID_GEN1); 0x32 is the battery
-        # pack and never a valid inverter address, so a stale pre-#119 0x32 capability is ignored.
+        # Prefer the capability-selected register home (0x11 since #189, or a persisted 0x31);
+        # 0x32 is the battery pack and never a valid inverter address, so a stale pre-#119
+        # 0x32 capability is ignored.
         if self.capabilities is not None and self.capabilities.inverter_address in (0x11, 0x31):
             addresses.insert(0, self.capabilities.inverter_address)
         for addr in dict.fromkeys(addresses):  # de-dup, preserve order

--- a/tests/client/test_detect.py
+++ b/tests/client/test_detect.py
@@ -223,8 +223,8 @@ def test_plant_capabilities_derives_inverter_address_from_model():
     assert PlantCapabilities(device_type=Model.HYBRID).inverter_address == 0x11
     assert PlantCapabilities(device_type=Model.EMS).inverter_address == 0x11
     assert PlantCapabilities(device_type=Model.ALL_IN_ONE).inverter_address == 0x11
-    assert PlantCapabilities(device_type=Model.AC).inverter_address == 0x31
-    assert PlantCapabilities(device_type=Model.HYBRID_GEN1).inverter_address == 0x31
+    assert PlantCapabilities(device_type=Model.AC).inverter_address == 0x11
+    assert PlantCapabilities(device_type=Model.HYBRID_GEN1).inverter_address == 0x11
 
 
 def test_plant_capabilities_explicit_address_overrides_derivation():

--- a/tests/client/test_load_refresh.py
+++ b/tests/client/test_load_refresh.py
@@ -52,29 +52,29 @@ async def test_load_config_single_phase():
 
 
 async def test_load_config_ac_polls_hr300():
-    """AC-coupled model polls HR(300-359) at 0x31 (export priority, EPS, AC charge/discharge limits)."""
+    """AC-coupled model polls HR(300-359) at 0x11 (export priority, EPS, AC charge/discharge limits; #189)."""
     client = _client_with_caps(Model.AC)
     with patch.object(client, "_execute_reads", new_callable=AsyncMock) as mock_exec:
         await client.load_config()
     assert _reqs(mock_exec) == [
-        _hr(0, 60, device=0x31),
-        _hr(60, 60, device=0x31),
-        _hr(120, 60, device=0x31),
-        _ir(120, 60, device=0x31),
-        _hr(300, 60, device=0x31),
+        _hr(0, 60),
+        _hr(60, 60),
+        _hr(120, 60),
+        _ir(120, 60),
+        _hr(300, 60),
     ]
 
 
-async def test_load_config_hybrid_gen1_uses_0x31_no_hr300():
-    """HYBRID_GEN1 exposes registers at 0x31 but is DC-coupled — no HR(300-359) (#162)."""
+async def test_load_config_hybrid_gen1_at_0x11_no_hr300():
+    """HYBRID_GEN1 reads at the unified 0x11 address (#189) and is DC-coupled — no HR(300-359) (#162)."""
     client = _client_with_caps(Model.HYBRID_GEN1)
     with patch.object(client, "_execute_reads", new_callable=AsyncMock) as mock_exec:
         await client.load_config()
     assert _reqs(mock_exec) == [
-        _hr(0, 60, device=0x31),
-        _hr(60, 60, device=0x31),
-        _hr(120, 60, device=0x31),
-        _ir(120, 60, device=0x31),
+        _hr(0, 60),
+        _hr(60, 60),
+        _hr(120, 60),
+        _ir(120, 60),
     ]
 
 
@@ -88,7 +88,7 @@ async def test_load_config_hybrid_gen1_does_not_poll_smart_load():
     client = _client_with_caps(Model.HYBRID_GEN1)
     with patch.object(client, "_execute_reads", new_callable=AsyncMock) as mock_exec:
         await client.load_config()
-    assert _hr(540, 60, device=0x31) not in _reqs(mock_exec)
+    assert _hr(540, 60) not in _reqs(mock_exec)
 
 
 async def test_load_config_three_phase():

--- a/tests/client/test_mock_plant_integration.py
+++ b/tests/client/test_mock_plant_integration.py
@@ -73,11 +73,17 @@ async def test_detect_ems():
 
 @pytest.mark.timeout(30)
 async def test_detect_and_refresh_hybrid_gen1():
-    """HYBRID_GEN1: detect → Model.HYBRID_GEN1 @ 0x31 (not the 0x11 default); refresh completes."""
-    async for client in _client_for("hybrid_2_bat_a/hybrid_gen1_arm449_givbat82_givbat95gen3_60min.log"):
+    """HYBRID_GEN1: detect → Model.HYBRID_GEN1 @ 0x11 (unified addressing, #189); refresh completes.
+
+    Backed by the 0x11-polled capture — recorded by this library's own poll loop, so the
+    mock serves full banks at 0x11 exactly as the live unit did. The older passive dongle
+    capture only carries identity at 0x11 (the dongle polled the 0x31 facade) and can no
+    longer satisfy a 0x11-addressed refresh.
+    """
+    async for client in _client_for("hybrid_2_bat_a/hybrid_gen1_arm449_0x11_poll_10min.log"):
         caps = await client.detect(**_DETECT)
         assert caps.device_type is Model.HYBRID_GEN1
-        assert caps.inverter_address == 0x31
+        assert caps.inverter_address == 0x11
         plant = await client.refresh(timeout=1.0, retries=0)
         assert plant.capabilities.device_type is Model.HYBRID_GEN1
 

--- a/tests/model/test_addressing_from_captures.py
+++ b/tests/model/test_addressing_from_captures.py
@@ -3,11 +3,14 @@
 Rather than synthetic register primes, these feed the committed captures in
 ``tests/fixtures/captures/`` through the framer into a bare ``Plant`` and assert
 the address each topology actually serves its inverter banks at — the concrete
-``0x11`` / ``0x31`` / ``0x32`` evidence the addressing redesign turns on:
+``0x11`` / ``0x31`` / ``0x32`` evidence the addressing redesign turned on:
 
 - **AIO** answers at ``0x11`` and exposes nothing at ``0x32`` (root cause of #105).
-- **HYBRID_GEN1** answers identity-only at ``0x11`` and serves full banks at
-  ``0x31`` — which is why GEN1/AC map to ``0x31`` rather than the ``0x11`` default.
+- **HYBRID_GEN1** (passive dongle capture, pre-#189): the dongle polled identity at
+  ``0x11`` and the full banks at the ``0x31`` facade. Historical wire evidence —
+  since #189 the library polls everything at ``0x11`` (live-validated; see the
+  ``0x11``-polled fixture and its golden-master coverage), and ``0x31`` remains a
+  hardware facade other consumers may still poll.
 - **EMS** serves its IR(2040) rollup at ``0x11``.
 """
 
@@ -72,9 +75,11 @@ async def test_aio_answers_at_0x11_and_nothing_at_0x32():
 
 @pytest.mark.timeout(15)
 async def test_hybrid_gen1_full_banks_at_0x31_identity_only_at_0x11():
-    """HYBRID_GEN1 serves full banks at 0x31, identity-only at 0x11.
+    """The passive HYBRID_GEN1 capture has full banks at 0x31, identity-only at 0x11.
 
-    So it must map to 0x31, not the 0x11 default (#119).
+    A record of what the *dongle* polled pre-#189 (it used the 0x31 facade), pinned
+    so replay never folds addresses (#119). Not the current polling map — since #189
+    the library reads everything at 0x11, proven live by the 0x11-polled fixture.
     """
     plant = await _replay("hybrid_2_bat_a/hybrid_gen1_arm449_givbat82_givbat95gen3_60min.log")
 

--- a/tests/model/test_fixture_golden_master.py
+++ b/tests/model/test_fixture_golden_master.py
@@ -118,28 +118,66 @@ async def test_aio_classifies_as_hv_all_in_one():
 
 
 @pytest.mark.timeout(20)
-async def test_hybrid_gen1_classifies_at_0x31():
-    """HYBRID_GEN1: 0x2001/fw449 → Model.HYBRID_GEN1 @ 0x31 (not the 0x11 default), LV batteries 0x32+."""
+async def test_hybrid_gen1_passive_capture_classifies_at_0x11_banks_stay_at_0x31():
+    """HYBRID_GEN1 passive dongle capture: 0x2001/fw449 → Model.HYBRID_GEN1 @ 0x11 (#189).
+
+    This capture predates the 0x31 retirement: the dongle polled the operational banks
+    at the 0x31 facade, so they live there in the replayed caches — and must STAY there
+    (no folding to the classification address; that's the anti-fold property #127
+    guards). The 0x11-polled sibling fixture below covers the current polling shape.
+    """
     plant = await _replay("hybrid_2_bat_a/hybrid_gen1_arm449_givbat82_givbat95gen3_60min.log")
     caps = _classify(plant)
 
     assert caps.device_type is Model.HYBRID_GEN1
-    assert caps.inverter_address == 0x31
+    assert caps.inverter_address == 0x11
     assert not caps.is_hv
     assert not caps.is_ems
 
-    # Operational banks at 0x31; identity-only at 0x11. LV battery packs at 0x32/0x33.
+    # Operational banks where the dongle polled them (0x31); identity-only at 0x11 in
+    # this capture. LV battery packs at 0x32/0x33.
     assert HR(60) in plant.register_caches[0x31]
     assert HR(60) not in plant.register_caches[0x11]
     assert 0x32 in plant.register_caches
     assert 0x33 in plant.register_caches
 
 
+@pytest.mark.timeout(20)
+async def test_hybrid_gen1_0x11_poll_capture_serves_full_banks_at_0x11():
+    """HYBRID_GEN1 polled by this library at 0x11 (#189): full banks land at 0x11.
+
+    Recorded with the library's own detect → load_config → refresh loop addressing the
+    inverter at 0x11 — the live-hardware proof that 0x11 is a full facade, not
+    identity-only. Passive HA traffic on the same bus still polls 0x31, which must
+    remain separately cached (anti-fold), and the LV packs answer at 0x32/0x33.
+    """
+    plant = await _replay("hybrid_2_bat_a/hybrid_gen1_arm449_0x11_poll_10min.log")
+    caps = _classify(plant)
+
+    assert caps.device_type is Model.HYBRID_GEN1
+    assert caps.inverter_address == 0x11
+    assert not caps.is_hv
+    assert not caps.is_ems
+
+    # Full config banks at 0x11 — what the old "identity-only" claim said couldn't happen.
+    assert HR(60) in plant.register_caches[0x11]
+    assert HR(120) in plant.register_caches[0x11]
+    # Passive 0x31 traffic from another consumer stays at its wire address (anti-fold).
+    assert HR(60) in plant.register_caches[0x31]
+    # LV battery packs.
+    assert 0x32 in plant.register_caches
+    assert 0x33 in plant.register_caches
+
+
 def test_inverter_address_matches_classification_for_all_fixtures():
-    """Belt-and-braces: the model→address map agrees with each fixture's classification."""
+    """Belt-and-braces: the model→address map agrees with where the library polls.
+
+    Unified on 0x11 for every model since #189 — the passive hybrid capture's 0x31
+    banks above are a record of pre-#189 dongle behaviour, not of the polling map.
+    """
     assert inverter_address_for(Model.EMS) == 0x11
     assert inverter_address_for(Model.ALL_IN_ONE) == 0x11
-    assert inverter_address_for(Model.HYBRID_GEN1) == 0x31
+    assert inverter_address_for(Model.HYBRID_GEN1) == 0x11
 
 
 @pytest.mark.parametrize(

--- a/tests/model/test_inverter.py
+++ b/tests/model/test_inverter.py
@@ -1015,10 +1015,10 @@ def test_resolve_model(raw_dtc, arm_fw, expected):
 @pytest.mark.parametrize(
     "model,expected",
     [
-        # 0x31 only for AC and HYBRID_GEN1 (GivTCP's map; issue #119)
-        (Model.AC, 0x31),
-        (Model.HYBRID_GEN1, 0x31),
-        # everything else at the 0x11 default
+        # 0x11 for every model since the 0x31 read-alias retirement (#189);
+        # AC and HYBRID_GEN1 hardware still answers at the 0x31 facade too
+        (Model.AC, 0x11),
+        (Model.HYBRID_GEN1, 0x11),
         (Model.HYBRID, 0x11),
         (Model.HYBRID_GEN2, 0x11),
         (Model.HYBRID_GEN3, 0x11),

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -1460,19 +1460,29 @@ def _make_write_pdu(register: int, value: int, device_address: int = 0x11) -> Wr
 
 
 @pytest.mark.parametrize(
-    ("model", "read_addr"),
-    [(Model.HYBRID_GEN1, 0x31), (Model.HYBRID, 0x11)],
+    ("model", "explicit_addr", "read_addr"),
+    [
+        # pre-#189 persisted capability still pointing at the 0x31 facade
+        (Model.HYBRID_GEN1, 0x31, 0x31),
+        # current derivation: every model reads at 0x11 (#189)
+        (Model.HYBRID_GEN1, None, 0x11),
+        (Model.HYBRID, None, 0x11),
+    ],
 )
-def test_write_echo_routed_to_inverter_address(model: Model, read_addr: int):
+def test_write_echo_routed_to_inverter_address(model: Model, explicit_addr: int | None, read_addr: int):
     """A write echo lands in the cache the model reads (caps.inverter_address).
 
-    Writes go out to 0x11 and the response echoes 0x11, but for AC/HYBRID_GEN1 the model
-    reads caps.inverter_address = 0x31. The echo must be routed there so plant.inverter
-    reflects the write immediately — without a load_config(), and even though refresh() is
-    IR-only. For 0x11 models this is a no-op (echo and reads already share a cache).
+    Writes go out to 0x11 and the response echoes 0x11. Since #189 the model also reads
+    at 0x11, making the routing a no-op — but a pre-#189 persisted capability may still
+    say 0x31 (the AC/HYBRID_GEN1 facade), and the echo must follow it there so
+    plant.inverter reflects the write immediately — without a load_config(), and even
+    though refresh() is IR-only.
     """
     plant = Plant()
-    plant.capabilities = PlantCapabilities(device_type=model)
+    if explicit_addr is not None:
+        plant.capabilities = PlantCapabilities(device_type=model, inverter_address=explicit_addr)
+    else:
+        plant.capabilities = PlantCapabilities(device_type=model)
     assert plant.capabilities.inverter_address == read_addr  # guard the premise
 
     # CHARGE_TARGET_SOC = HR(116); the response echoes the 0x11 write address.
@@ -1483,14 +1493,16 @@ def test_write_echo_routed_to_inverter_address(model: Model, read_addr: int):
     assert plant.inverter.model_dump()["charge_target_soc"] == 85
 
 
-def test_write_echo_not_left_at_wire_address_for_0x31_models():
-    """Regression: for HYBRID_GEN1 the echo must NOT remain at the 0x11 wire address.
+def test_write_echo_not_left_at_wire_address_for_persisted_0x31_caps():
+    """Regression: with a capability still reading at 0x31, the echo must NOT stay at 0x11.
 
-    Pre-fix the value landed in register_caches[0x11], which plant.inverter (reading 0x31)
-    never sees — the reported bug where a write only showed up after load_config().
+    Pre-#187 the value landed in register_caches[0x11], which plant.inverter (reading 0x31)
+    never saw — the reported bug where a write only showed up after load_config(). Since
+    #189 a 0x31 read address only arises from a pre-#189 persisted capability, simulated
+    here with an explicit inverter_address.
     """
     plant = Plant()
-    plant.capabilities = PlantCapabilities(device_type=Model.HYBRID_GEN1)
+    plant.capabilities = PlantCapabilities(device_type=Model.HYBRID_GEN1, inverter_address=0x31)
 
     plant.update(_make_write_pdu(116, 85))
 
@@ -1533,7 +1545,7 @@ def test_derive_inverter_address_fills_only_when_unpinned_and_coercible():
     """_derive_inverter_address sets the model-derived address, never overrides an explicit one."""
     derived = {"device_type": Model.AC}
     _derive_inverter_address(derived)
-    assert derived["inverter_address"] == 0x31
+    assert derived["inverter_address"] == 0x11
 
     explicit = {"device_type": Model.EMS, "inverter_address": 0x99}
     _derive_inverter_address(explicit)

--- a/tests/model/test_plant_accessors.py
+++ b/tests/model/test_plant_accessors.py
@@ -42,13 +42,13 @@ def test_inverter_returns_threephase_for_threephase_model():
 def test_inverter_tolerates_unpopulated_inverter_address_cache():
     """.inverter must not KeyError when its address cache isn't populated yet.
 
-    AC/HYBRID_GEN1 resolve to inverter_address 0x31, which detect() doesn't populate
-    (it only reads identity at 0x11), so .inverter would otherwise KeyError between
-    detect() and the first poll (#119).
+    A pre-#189 persisted capability may still point at the 0x31 facade, which detect()
+    doesn't populate (it reads identity at 0x11), so .inverter would otherwise KeyError
+    between detect() and the first poll (#119, #189).
     """
     from givenergy_modbus.model.inverter import SinglePhaseInverter
 
-    plant = _plant_with_caps(device_type=Model.HYBRID_GEN1)  # derives inverter_address=0x31
+    plant = _plant_with_caps(device_type=Model.HYBRID_GEN1, inverter_address=0x31)  # pre-#189 persisted state
     assert plant.capabilities.inverter_address == 0x31
     assert 0x31 not in plant.register_caches  # nothing cached there yet
     assert isinstance(plant.inverter, SinglePhaseInverter)  # no KeyError


### PR DESCRIPTION
## What

`inverter_address_for()` now returns `0x11` for every model, retiring the `0x31` special-case for AC and HYBRID_GEN1. Closes #189.

## Why

The `0x31` mapping was inherited from GivTCP and justified by a claim ("identity-only at 0x11") that turned out to be false — it was inferred from passive dongle captures that simply never asked `0x11` for more. The evidence is now in on all fronts:

- **HYBRID_GEN1 (live)**: `0x11` serves full HR banks; value-equality with `0x31` across all 114 shared HR registers; writes mutate hardware at both addresses. The official app reads and writes at `0x11`, firmware-invariant across ARM 449/451.
- **AC (live)**: both of @njhcarroll's AC units returned byte-identical HR(60–119) tables at `0x11` and `0x31` (the validation #189 was gated on, via givenergy-hass#52).
- **Fixture**: `hybrid_gen1_arm449_0x11_poll_10min.log` — recorded by this library's own poll loop addressing `0x11` — landed with #187.

With reads and writes sharing one address, the #187 write-echo routing becomes a no-op for freshly detected plants.

## Back-compat

- Capabilities persisted with an explicit `inverter_address: 0x31` keep working — the hardware facade still answers there, the write-echo routing still covers it — and self-heal to `0x11` on the next `detect()`. No migration needed.
- Passive `0x31` traffic from other bus consumers (GivTCP, the cloud) is still ingested and serial-adopted; bare-plant replay still treats `0x11`/`0x31` as inverter addresses (anti-fold preserved).

## Tests

- ~17 assertion updates across 8 files; the persisted-0x31 path keeps dedicated coverage (write-echo routing, unpopulated-cache tolerance) via explicit-address capabilities.
- New golden-master case for the 0x11-polled fixture (full banks at `0x11`, passive `0x31` traffic separately cached, LV packs at `0x32`/`0x33`).
- MockPlant integration test repointed at the 0x11-polled capture — the passive capture can't satisfy a `0x11`-addressed refresh (identity-only there, by construction).
- The passive-capture addressing tests are reframed as historical wire evidence and keep passing unchanged.

`tox` fully green (py311–py314, format, lint, build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)