### PR TITLE
fix(meter): pf_* decode as signed int16 ×1e-4; p_apparent_* deci-scaled

### DIFF
--- a/givenergy_modbus/model/meter.py
+++ b/givenergy_modbus/model/meter.py
@@ -43,14 +43,21 @@ class MeterRegisterGetter(RegisterGetter):
         "p_reactive_phase_2": Def(C.int16, None, IR(73)),
         "p_reactive_phase_3": Def(C.int16, None, IR(74)),
         "p_reactive_total": Def(C.int16, None, IR(75)),
-        "p_apparent_phase_1": Def(C.int16, None, IR(76)),
-        "p_apparent_phase_2": Def(C.int16, None, IR(77)),
-        "p_apparent_phase_3": Def(C.int16, None, IR(78)),
-        "p_apparent_total": Def(C.int16, None, IR(79)),
-        "pf_phase_1": Def(C.milli, None, IR(80)),
-        "pf_phase_2": Def(C.milli, None, IR(81)),
-        "pf_phase_3": Def(C.milli, None, IR(82)),
-        "pf_total": Def(C.milli, None, IR(83)),
+        # Apparent power is deci-scaled (0.1 VA), unlike active/reactive at 1 W/var —
+        # capture-proven via the displacement-PF cross-check: S >= sqrt(P²+Q²) only
+        # holds at x0.1, and the same identity lands the reactive registers exactly
+        # at 1 var, contradicting the doc's 0.1 var suggestion. Unsigned: apparent
+        # power is a magnitude (the capture shows it positive during export while
+        # p_active goes negative), and a signed decode would overflow above 3.27 kVA.
+        # See #246.
+        "p_apparent_phase_1": Def(C.deci, None, IR(76)),
+        "p_apparent_phase_2": Def(C.deci, None, IR(77)),
+        "p_apparent_phase_3": Def(C.deci, None, IR(78)),
+        "p_apparent_total": Def(C.deci, None, IR(79)),
+        "pf_phase_1": Def(C.pf_signed, None, IR(80), min=-1.0, max=1.0),
+        "pf_phase_2": Def(C.pf_signed, None, IR(81), min=-1.0, max=1.0),
+        "pf_phase_3": Def(C.pf_signed, None, IR(82), min=-1.0, max=1.0),
+        "pf_total": Def(C.pf_signed, None, IR(83), min=-1.0, max=1.0),
         "frequency": Def(C.centi, None, IR(84), min=40.0, max=70.0),
         "e_import_active": Def(C.deci, None, IR(85)),
         "e_import_reactive": Def(C.deci, None, IR(86)),

--- a/givenergy_modbus/model/register.py
+++ b/givenergy_modbus/model/register.py
@@ -172,6 +172,18 @@ class Converter:
             return val / 10
 
     @staticmethod
+    def pf_signed(val: int) -> float:
+        """Decode a power factor as a signed 16-bit int in 1/10,000 units (EE [-1, +1]).
+
+        The meter PF registers IR(80-83) use this plain signed encoding — distinct
+        from the inverter's HR(52), which is offset-unsigned (raw/10,000 - 1). The
+        sign carries flow direction; capture-proven against displacement-PF
+        cross-checks on real meters (#246).
+        """
+        if val is not None:
+            return Converter.int16(val) / 10_000
+
+    @staticmethod
     def datetime(year, month, day, hour, min, sec) -> "datetime | None":
         """Compose a datetime from 6 registers."""
         if None not in [year, month, day, hour, min, sec]:
@@ -219,6 +231,7 @@ class Converter:
 # Converters absent from this map (enums, bools, strings, timeslots, datetimes,
 # and any bespoke converter) are treated as non-numeric — precision None.
 _PRECISION_BY_CONVERTER: dict[Any, int] = {
+    Converter.pf_signed: 4,
     Converter.milli: 3,
     Converter.centi: 2,
     Converter.deci: 1,

--- a/tests/model/test_fixture_golden_master.py
+++ b/tests/model/test_fixture_golden_master.py
@@ -98,6 +98,32 @@ async def test_ems_plant_classifies_and_decodes_topology():
 
 
 @pytest.mark.timeout(20)
+async def test_ems_meter_pf_and_apparent_power_decode():
+    """Meter pf_*/p_apparent_* decode pinned to real capture values (#246).
+
+    The displacement-PF identity cosφ = P/√(P² + Q²) settles all three scales on
+    this capture: PF is signed int16 ×1e-4 (meter 0x03: raw 9998 → +0.9998 with
+    Q=11 var giving cosφ = 0.9998 exactly; meter 0x01: raw 64670 → −0.0866),
+    apparent power is deci-scaled (S = 575.2 VA ≥ √(P²+Q²) = 567.1; at 1 VA the
+    cross-check collapses), and reactive stays at 1 var (at 0.1 var the identity
+    breaks on both meters).
+    """
+    plant = await _replay("ems_2_inv_3_bat_a/ems_arm1036_30min.log")
+    caps = _classify(plant)
+    caps.meter_addresses = [0x01, 0x03]
+
+    m1, m3 = plant.meters[0x01], plant.meters[0x03]
+    assert m3.pf_total == 0.9998
+    assert m3.p_active_total == 567
+    assert m3.p_apparent_total == 575.2
+    assert m3.p_reactive_total == 11
+    assert m1.pf_total == -0.0866
+    assert m1.p_active_total == -47
+    assert m1.p_apparent_total == 713.2
+    assert m1.p_reactive_total == -564
+
+
+@pytest.mark.timeout(20)
 async def test_aio_classifies_as_hv_all_in_one():
     """All-in-One: 0x8001/fw612 → Model.ALL_IN_ONE @ 0x11, HV BCU stack separately addressed."""
     plant = await _replay("aio_a/aio_arm612_5min.log")

--- a/tests/model/test_meter.py
+++ b/tests/model/test_meter.py
@@ -43,14 +43,14 @@ def test_meter_from_synthetic_registers():
             73: 100,
             74: 100,
             75: 300,  # p_reactive_total
-            76: 2302,  # p_apparent_phase_1
-            77: 2202,
-            78: 2402,
-            79: 6906,  # p_apparent_total
-            80: 999,  # pf_phase_1 = 0.999  (milli)
-            81: 998,
-            82: 997,
-            83: 998,  # pf_total
+            76: 23020,  # p_apparent_phase_1 = 2302.0 VA  (deci)
+            77: 22020,
+            78: 24020,
+            79: 30900,  # p_apparent_total = 3090.0 VA
+            80: 9990,  # pf_phase_1 = 0.999  (signed 1/10000)
+            81: 9980,
+            82: 9970,
+            83: 9980,  # pf_total
             84: 5000,  # frequency = 50.00 Hz  (centi)
             85: 12345,  # e_import_active = 1234.5 kWh  (deci)
             86: 100,
@@ -67,6 +67,7 @@ def test_meter_from_synthetic_registers():
     assert m.i_phase_2 == 9.5  # type: ignore[attr-defined]
     assert m.i_total == 30.0  # type: ignore[attr-defined]
     assert m.p_active_total == 6900  # type: ignore[attr-defined]
+    assert m.p_apparent_total == 3090.0  # type: ignore[attr-defined]
     assert m.pf_total == 0.998  # type: ignore[attr-defined]
     assert m.frequency == 50.0  # type: ignore[attr-defined]
     assert m.e_import_active == 1234.5  # type: ignore[attr-defined]
@@ -78,6 +79,37 @@ def test_meter_negative_power():
     cache = _meter_cache({60: 2300, 71: 65536 - 1000})  # -1000 W export
     m = Meter.from_register_cache(cache)
     assert m.p_active_total == -1000  # type: ignore[attr-defined]
+
+
+def test_meter_pf_signed_decode():
+    """pf_* decode as signed int16 x 1e-4 (EE [-1, +1]) — not unsigned milli (#246).
+
+    Raw values pinned from the committed EMS capture: meter 0x03 read 9998
+    (near-unity import) and meter 0x01 read 64670 (-866 as int16; small export).
+    The old C.milli decode produced the impossible 9.998 / 64.67.
+    """
+    m = Meter.from_register_cache(_meter_cache({60: 2300, 80: 9998, 83: 64670}))
+    assert m.pf_phase_1 == 0.9998  # type: ignore[attr-defined]
+    assert m.pf_total == -0.0866  # type: ignore[attr-defined]
+
+
+def test_meter_apparent_power_unsigned_above_int16_range():
+    """p_apparent_* is an unsigned magnitude — loads above 3.27 kVA must not go negative.
+
+    The capture shows apparent power staying positive during export (p_active < 0),
+    so the register is unsigned; a signed decode would overflow for any load above
+    32767 raw (3276.7 VA) — e.g. an EV charger or kettle (#246).
+    """
+    m = Meter.from_register_cache(_meter_cache({60: 2300, 79: 40000}))
+    assert m.p_apparent_total == 4000.0  # type: ignore[attr-defined]
+
+
+def test_meter_pf_precision():
+    """precision_of reports 4 decimal places for the pf_signed-converted fields."""
+    from givenergy_modbus.model.meter import MeterRegisterGetter
+
+    assert MeterRegisterGetter.precision_of("pf_total") == 4
+    assert MeterRegisterGetter.precision_of("p_apparent_total") == 1
 
 
 def test_meter_is_valid_zero_voltage():

--- a/tests/model/test_register.py
+++ b/tests/model/test_register.py
@@ -94,6 +94,16 @@ def test_register():
         json.dumps({HR(0): 1234, HR(1): 17185, HR(2): 43981, IR(0): 2}, cls=RegisterEncoder)
 
 
+def test_converter_pf_signed():
+    """Signed int16 x 1e-4 power-factor decode (EE [-1, +1]) — see #246."""
+    assert Converter.pf_signed(9998) == 0.9998  # near-unity import (capture, meter 0x03)
+    assert Converter.pf_signed(64670) == -0.0866  # small export (capture, meter 0x01)
+    assert Converter.pf_signed(0) == 0.0
+    assert Converter.pf_signed(10_000) == 1.0
+    assert Converter.pf_signed(0x10000 - 10_000) == -1.0
+    assert Converter.pf_signed(None) is None
+
+
 def test_converter_timeslot_sentinel():
     from givenergy_modbus.model import TimeSlot
 


### PR DESCRIPTION
## What

Fixes the meter power-factor decode (#246): `pf_phase_1..3`/`pf_total` (IR 80–83) move from unsigned `C.milli` to a new `C.pf_signed` converter — signed int16 ×1e-4, the EE [−1, +1] convention — with `min=-1.0, max=1.0` bounds. `p_apparent_*` (IR 76–79) gain deci-scaling (0.1 VA). `p_reactive_*` is deliberately unchanged. Closes #246.

## Evidence

All three scales are settled by the displacement-PF identity cosφ = P/√(P² + Q²) against the committed EMS capture (`ems_arm1036_30min.log`):

| | meter 0x03 (importing) | meter 0x01 (exporting) |
|---|---|---|
| PF raw → decoded | 9998 → **+0.9998** | 64670 → **−0.0866** |
| identity (Q at 1 var) | cosφ = 0.9998 — exact | cosφ ≈ 0.083 — matches |
| old `C.milli` decode | 9.998 (impossible) | 64.67 (impossible) |

- **Apparent at ×0.1**: S = 575.2 VA ≥ √(P²+Q²) = 567.1 (margin reads as distortion power). At 1 VA the cross-check collapses (567/5752 ≈ 0.099 vs 0.9998).
- **Reactive stays at 1 var**: at the doc-suggested ×0.1, the identity gives 0.999998 ≠ 0.9998 (0x03) and 0.64 ≠ 0.0866 (0x01). The doc's 0.1 var column is wrong here.
- The inverter's HR(52) `power_factor` (offset-unsigned, raw/10,000 − 1) is a different wire encoding and is untouched — #209 tracks that side, including whether the 3ph IR(1068) PF is this signed family at ×1e-3.

## Tests

- Converter unit tests (capture values, ±1 saturation, None passthrough).
- Synthetic meter decode updated to the new scales.
- New golden-master test replaying the EMS capture and pinning all eight values (PF/active/apparent/reactive on both meters) — the full coherence triangle, so a future scale regression on any of the three families trips it.

`tox` fully green (py311–py314, format, lint, build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected decoding of apparent power readings to display with proper decimal precision (0.1 VA scaling).
  * Fixed power factor value interpretation to correctly handle signed measurements and enforce valid bounds (−1.0 to +1.0).

* **Tests**
  * Enhanced test coverage for power factor and apparent power meter decoding with real-world capture data validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->