### PR TITLE
feat(battery): map LV BCU block at 0x31 IR(60-63) (#241)

### DIFF
--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -22,6 +22,7 @@ from givenergy_modbus.model.aio_battery import AioBatteryModule
 from givenergy_modbus.model.battery import Battery
 from givenergy_modbus.model.ems import EmsRegisterGetter
 from givenergy_modbus.model.inverter import Model, resolve_model
+from givenergy_modbus.model.lv_bcu import LV_BCU_ADDRESS, LvBcu
 from givenergy_modbus.model.meter import Meter
 from givenergy_modbus.model.plant import Plant, PlantCapabilities
 from givenergy_modbus.model.register import HR, IR
@@ -532,6 +533,40 @@ class Client:
                 continue
             caps.aio_battery_module_addresses.append(addr)
 
+    async def _detect_lv_bcu(
+        self,
+        caps: PlantCapabilities,
+        prior: PlantCapabilities | None,
+        probe_timeout: float,
+        probe_retries: int,
+    ) -> None:
+        """Probe the LV BCU page and set caps.lv_bcu_address when present (#241).
+
+        The stack-level BMS block (doc §4.4.1.1) answers at 0x31 IR(60-63) on LV
+        systems, firmware-gated: absent units still respond, just with an all-zero
+        block, so is_valid() (any-word-non-zero) is the presence test and the probe
+        costs nothing on healthy systems. Hinted mode follows the meter convention:
+        only re-check an address the prior captured — prior None-ness is trusted, so
+        a firmware upgrade that adds the block needs a cold detect to notice.
+        """
+        bcu_addr = prior.lv_bcu_address if prior is not None else LV_BCU_ADDRESS
+        if bcu_addr is None:
+            return
+        if not await self._probe(
+            ReadInputRegistersRequest(base_register=60, register_count=60, device_address=bcu_addr),
+            timeout=probe_timeout,
+            retries=probe_retries,
+        ):
+            return
+        bcu_cache = self.plant.register_caches.get(bcu_addr)
+        if not bcu_cache:
+            return
+        try:
+            if LvBcu.from_register_cache(bcu_cache).is_valid():
+                caps.lv_bcu_address = bcu_addr
+        except (KeyError, ValueError):
+            _logger.debug("detect: LV BCU probe at 0x%02x failed to decode — skipping", bcu_addr, exc_info=True)
+
     async def _ems_rollup_cross_check(self, timeout: float, retries: int) -> None:
         """Read IR(2040,55) at detect time and sanity-check the per-managed-inverter rollup.
 
@@ -642,12 +677,13 @@ class Client:
         if prior is not None:
             _logger.info(
                 "detect: hinted mode — assuming device_type=Model.%s, inverter=0x%02x, "
-                "meters=[%s], lv_batteries=[%s], bcus=[%s]",
+                "meters=[%s], lv_batteries=[%s], bcus=[%s], lv_bcu=%s",
                 prior.device_type.name,
                 prior.inverter_address,
                 ", ".join(f"0x{a:02x}" for a in prior.meter_addresses),
                 ", ".join(f"0x{a:02x}" for a in prior.lv_battery_addresses),
                 ", ".join(f"0x{0x70 + offset:02x} (x{n})" for offset, n in prior.bcu_stacks),
+                f"0x{prior.lv_bcu_address:02x}" if prior.lv_bcu_address is not None else "None",
             )
 
         # Step 1 — read the inverter's configuration block to get DTC and ARM firmware.
@@ -761,6 +797,13 @@ class Client:
             _logger.info(
                 "detect: lv_battery_addresses=[%s]",
                 ", ".join(f"0x{a:02x}" for a in caps.lv_battery_addresses),
+            )
+
+            # Step 4b — LV BCU page probe (#241).
+            await self._detect_lv_bcu(caps, prior, probe_timeout, probe_retries)
+            _logger.info(
+                "detect: lv_bcu_address=%s",
+                f"0x{caps.lv_bcu_address:02x}" if caps.lv_bcu_address is not None else "None",
             )
 
         # Step 5 — EMS rollup cross-check. See `_ems_rollup_cross_check()` for the contract.
@@ -965,6 +1008,11 @@ class Client:
                 )
         for addr in caps.lv_battery_addresses:
             reqs.append(ReadInputRegistersRequest(base_register=60, register_count=60, device_address=addr))
+        if caps.lv_bcu_address is not None:
+            # LV BCU stack-level page (#241) — count 60 matches the field-validated probe shape.
+            reqs.append(
+                ReadInputRegistersRequest(base_register=60, register_count=60, device_address=caps.lv_bcu_address)
+            )
         for addr in caps.meter_addresses:
             reqs.append(ReadInputRegistersRequest(base_register=60, register_count=30, device_address=addr))
         for offset, _ in caps.bcu_stacks:

--- a/givenergy_modbus/model/battery.py
+++ b/givenergy_modbus/model/battery.py
@@ -77,7 +77,9 @@ class BatteryRegisterGetter(RegisterGetter):
         # mirrored into each pack, so don't sum across packs. Single uint16, so they
         # wrap at 6553.5 kWh. Direction assignment follows the doc (and matches the
         # long-shipped GivTCP fork mapping); one observed plant had lifetime
-        # discharge > charge, which remains unexplained.
+        # discharge > charge, which remains unexplained. Firmware-gated (#241): packs
+        # on BMS fw 3007/3009 read 0 here where fw 3022 populates both — a zero is
+        # "not supported", not a true lifetime figure.
         "e_battery_discharge_total": Def(DT.deci, None, IR(105)),
         "e_battery_charge_total": Def(DT.deci, None, IR(106)),
         # IR(107) "Force_DisChg_Flag" (v4.1.6 doc): no unit or range documented; only 0

--- a/givenergy_modbus/model/lv_bcu.py
+++ b/givenergy_modbus/model/lv_bcu.py
@@ -1,0 +1,73 @@
+"""GivEnergy LV battery BCU (stack-level BMS) data model.
+
+The v4.1.6 doc's §4.4.1.1 "Low Voltage BCU" block gives four input registers but no
+device address. Field probing (#238, #241) located it: the block answers at device
+0x31, registers IR(60-63), confirmed identical on two independent LV hybrid plants.
+0x31 also mirrors the inverter's live IR(0-59) below the block (as does 0x30), so the
+BCU is a register *page* on an inverter-adjacent address rather than a fully separate
+device.
+
+The block is firmware-gated: populated (request currents 167/167) on packs running BMS
+firmware 3022, all-zero on a unit with packs at 3007/3009. The gate could equally sit
+in inverter ARM or dongle firmware — the planes weren't separable across the sampled
+plants — so an all-zero block decodes as "absent/not supported", never an error.
+Absent units still answer reads at 0x31 (with zeros).
+"""
+
+from typing import ClassVar
+
+from pydantic import ConfigDict, create_model
+
+from givenergy_modbus.model.register import IR, RegisterGetter, RegisterMetadataMixin
+from givenergy_modbus.model.register import Converter as C
+from givenergy_modbus.model.register import RegisterDefinition as Def
+
+# The only address the BCU page has been observed at (#241). Capabilities store the
+# address rather than assuming it, in case other models window it elsewhere.
+LV_BCU_ADDRESS = 0x31
+
+
+class LvBcuRegisterGetter(RegisterGetter):
+    """Structured format for the LV BCU stack-level block (FC 0x04, device address 0x31)."""
+
+    REGISTER_LUT = {
+        # Input Registers IR(60)-IR(63), doc §4.4.1.1. The doc names the status pair
+        # `udwBmsStatus1/2` — the `udw` prefix implies uint32 but each is listed as a
+        # single register; kept as raw uint16 words until non-zero values are observed.
+        "bms_status_1": Def(C.uint16, None, IR(60)),
+        "bms_status_2": Def(C.uint16, None, IR(61)),
+        # The charge/discharge current envelope the BMS requests from the inverter,
+        # 1 A units. Only ever observed static (167/167 across two plants); whether it
+        # derates live with SOC/temperature is unconfirmed — see #241.
+        "request_charge_current": Def(C.uint16, None, IR(62)),
+        "request_discharge_current": Def(C.uint16, None, IR(63)),
+    }
+
+
+_LvBcuBase = create_model(  # type: ignore[call-overload]
+    "LvBcu",
+    __config__=ConfigDict(frozen=True, use_enum_values=True),
+    **LvBcuRegisterGetter.to_fields(),
+)
+
+
+class LvBcu(_LvBcuBase, RegisterMetadataMixin):  # type: ignore[misc,valid-type]
+    """GivEnergy LV battery BCU stack-level data (FC 0x04, device address 0x31)."""
+
+    REGISTER_GETTER: ClassVar[type[RegisterGetter]] = LvBcuRegisterGetter
+
+    @classmethod
+    def from_register_cache(cls, register_cache) -> "LvBcu":
+        """Construct an LvBcu from a RegisterCache."""
+        return cls.model_validate(LvBcuRegisterGetter(register_cache).build())
+
+    def is_valid(self) -> bool:
+        """Try to detect if the LV BCU block is present based on its attributes.
+
+        All-zero means absent/not supported (firmware-gated — see module docstring),
+        so presence requires at least one non-zero word.
+        """
+        return any(
+            getattr(self, f) not in (None, 0)
+            for f in ("bms_status_1", "bms_status_2", "request_charge_current", "request_discharge_current")
+        )

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -22,6 +22,7 @@ from givenergy_modbus.model.inverter import (
     resolve_model,
 )
 from givenergy_modbus.model.inverter_threephase import ThreePhaseInverter, select_inverter
+from givenergy_modbus.model.lv_bcu import LvBcu, LvBcuRegisterGetter
 from givenergy_modbus.model.meter import Meter, MeterRegisterGetter
 from givenergy_modbus.model.register import HR, IR, Converter, Register, RegisterGetter, is_valid_serial
 from givenergy_modbus.model.register_cache import RegisterCache
@@ -196,6 +197,9 @@ class PlantCapabilities(BaseModel):
     # AIO (All-in-One) per-module battery device addresses (0x50-0x53). Separate-address
     # layout, distinct from the bcu_stacks stride model — see model/aio_battery.py (#192).
     aio_battery_module_addresses: list[int] = Field(default_factory=list)
+    # LV BCU page address (observed only at 0x31 — see model/lv_bcu.py). None when the
+    # block read all-zero at detect time (firmware-gated, #241).
+    lv_bcu_address: int | None = None
 
     def __init__(
         self,
@@ -205,6 +209,7 @@ class PlantCapabilities(BaseModel):
         lv_battery_addresses: list[int] | None = None,
         bcu_stacks: list[tuple[int, int]] | None = None,
         aio_battery_module_addresses: list[int] | None = None,
+        lv_bcu_address: int | None = None,
         **kwargs: Any,
     ) -> None:
         # Custom __init__ for two reasons:
@@ -227,6 +232,8 @@ class PlantCapabilities(BaseModel):
             kwargs["bcu_stacks"] = bcu_stacks
         if aio_battery_module_addresses is not None:
             kwargs["aio_battery_module_addresses"] = aio_battery_module_addresses
+        if lv_bcu_address is not None:
+            kwargs["lv_bcu_address"] = lv_bcu_address
         _map_legacy_aliases(kwargs, stacklevel=3)
         super().__init__(**kwargs)
 
@@ -346,6 +353,7 @@ class PlantCapabilities(BaseModel):
             "lv_battery_addresses": [f"0x{a:02x}" for a in self.lv_battery_addresses],
             "bcu_stacks": [[offset, modules] for offset, modules in self.bcu_stacks],
             "aio_battery_module_addresses": [f"0x{a:02x}" for a in self.aio_battery_module_addresses],
+            "lv_bcu_address": f"0x{self.lv_bcu_address:02x}" if self.lv_bcu_address is not None else None,
         }
 
     @classmethod
@@ -406,6 +414,9 @@ class PlantCapabilities(BaseModel):
             # (`0x70 + offset` in detect()). Fail loud at parse time instead.
             bcu_stacks=[(int(offset), int(modules)) for offset, modules in (normalised.get("bcu_stacks") or [])],
             aio_battery_module_addresses=[_addr(a) for a in (normalised.get("aio_battery_module_addresses") or [])],
+            lv_bcu_address=(
+                _addr(normalised["lv_bcu_address"]) if normalised.get("lv_bcu_address") is not None else None
+            ),
         )
 
     def __repr__(self) -> str:
@@ -413,6 +424,7 @@ class PlantCapabilities(BaseModel):
         batts = ", ".join(f"0x{a:02x}" for a in self.lv_battery_addresses)
         bcus = ", ".join(f"({o}, {n})" for o, n in self.bcu_stacks)
         aio_mods = ", ".join(f"0x{a:02x}" for a in self.aio_battery_module_addresses)
+        lv_bcu = f"0x{self.lv_bcu_address:02x}" if self.lv_bcu_address is not None else "None"
         return (
             f"PlantCapabilities("
             f"device_type=Model.{self.device_type.name}, "
@@ -420,7 +432,8 @@ class PlantCapabilities(BaseModel):
             f"meter_addresses=[{meters}], "
             f"lv_battery_addresses=[{batts}], "
             f"bcu_stacks=[{bcus}], "
-            f"aio_battery_module_addresses=[{aio_mods}])"
+            f"aio_battery_module_addresses=[{aio_mods}], "
+            f"lv_bcu_address={lv_bcu})"
         )
 
     @property
@@ -542,6 +555,10 @@ class Plant(GivEnergyBaseModel):
         if self.capabilities is not None:
             if device_address == self.capabilities.inverter_address:
                 return SinglePhaseInverterRegisterGetter
+            # After the inverter check so a (theoretical) pre-#189 persisted
+            # inverter_address=0x31 still routes to the inverter getter.
+            if device_address == self.capabilities.lv_bcu_address:
+                return LvBcuRegisterGetter
             if 0x32 <= device_address <= 0x37:
                 return BatteryRegisterGetter
         else:
@@ -981,6 +998,24 @@ class Plant(GivEnergyBaseModel):
                 except Exception:
                     _logger.error("Failed to decode AIO battery module at 0x%02x", addr, exc_info=True)
         return modules
+
+    @property
+    def lv_bcu(self) -> LvBcu | None:
+        """Return the LV BCU stack-level block, or None when absent.
+
+        None when capabilities are unset, the block wasn't detected (firmware-gated —
+        see model/lv_bcu.py), or its cache hasn't been populated yet.
+        """
+        if not self.capabilities or self.capabilities.lv_bcu_address is None:
+            return None
+        cache = self.register_caches.get(self.capabilities.lv_bcu_address)
+        if not cache:
+            return None
+        try:
+            return LvBcu.from_register_cache(cache)
+        except Exception:
+            _logger.error("Failed to decode LV BCU at 0x%02x", self.capabilities.lv_bcu_address, exc_info=True)
+            return None
 
     @property
     def meters(self) -> dict[int, Meter]:

--- a/tests/client/test_detect.py
+++ b/tests/client/test_detect.py
@@ -75,6 +75,31 @@ def test_plant_capabilities_round_trip_with_aio_modules():
     assert restored.aio_battery_module_addresses == [0x50, 0x51, 0x52, 0x53]
 
 
+def test_plant_capabilities_round_trip_with_lv_bcu():
+    caps = PlantCapabilities(
+        device_type=Model.HYBRID,
+        inverter_address=0x11,
+        lv_battery_addresses=[0x32, 0x33],
+        lv_bcu_address=0x31,
+    )
+    assert caps.to_dict()["lv_bcu_address"] == "0x31"
+    restored = PlantCapabilities.from_dict(caps.to_dict())
+    assert restored == caps
+    assert restored.lv_bcu_address == 0x31
+
+
+def test_plant_capabilities_lv_bcu_defaults_none_and_survives_round_trip():
+    """Payloads persisted before the field existed must load with lv_bcu_address=None."""
+    caps = PlantCapabilities(device_type=Model.HYBRID)
+    assert caps.lv_bcu_address is None
+    payload = caps.to_dict()
+    assert payload["lv_bcu_address"] is None
+    assert PlantCapabilities.from_dict(payload).lv_bcu_address is None
+    # Pre-field payload shape (no key at all):
+    del payload["lv_bcu_address"]
+    assert PlantCapabilities.from_dict(payload).lv_bcu_address is None
+
+
 def test_plant_capabilities_from_dict_accepts_v2_0_0_legacy_shape():
     """Regression: a v2.0.0-shaped payload must still parse after the v2.0.1 schema change.
 
@@ -353,6 +378,89 @@ async def test_detect_finds_lv_batteries():
             caps = await client.detect()
 
     assert caps.lv_battery_addresses == [0x32, 0x33]
+
+
+async def test_detect_finds_lv_bcu():
+    """A populated BCU block at 0x31 sets lv_bcu_address (#241)."""
+    client = _make_client()
+    _prime_cache(client, 0x11, {HR(0): 0x2001, HR(21): 0})
+    _prime_battery_serial(client, 0x32)
+    # The field-observed BCU shape: status words zero, request currents 167/167.
+    _prime_cache(client, 0x31, {IR(60): 0, IR(61): 0, IR(62): 167, IR(63): 167})
+
+    async def _probe_side_effect(request, *, timeout, retries):
+        return request.device_address == 0x31
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
+        with patch.object(client, "_probe", side_effect=_probe_side_effect):
+            caps = await client.detect()
+
+    assert caps.lv_bcu_address == 0x31
+
+
+async def test_detect_all_zero_lv_bcu_block_means_absent():
+    """An all-zero block at 0x31 leaves lv_bcu_address=None (firmware-gated, #241).
+
+    Units without the block still answer the probe — with zeros — so the probe
+    succeeding is necessary but not sufficient.
+    """
+    client = _make_client()
+    _prime_cache(client, 0x11, {HR(0): 0x2001, HR(21): 0})
+    _prime_battery_serial(client, 0x32)
+    _prime_cache(client, 0x31, {IR(60): 0, IR(61): 0, IR(62): 0, IR(63): 0})
+
+    async def _probe_side_effect(request, *, timeout, retries):
+        return request.device_address == 0x31
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
+        with patch.object(client, "_probe", side_effect=_probe_side_effect):
+            caps = await client.detect()
+
+    assert caps.lv_bcu_address is None
+
+
+async def test_detect_hinted_reconfirms_lv_bcu():
+    """Hinted mode re-probes a prior lv_bcu_address and keeps it when still valid."""
+    client = _make_client()
+    _prime_cache(client, 0x11, {HR(0): 0x2001, HR(21): 0})
+    _prime_battery_serial(client, 0x32)
+    _prime_cache(client, 0x31, {IR(60): 0, IR(61): 0, IR(62): 167, IR(63): 167})
+    prior = PlantCapabilities(device_type=Model.HYBRID_GEN1, lv_battery_addresses=[0x32], lv_bcu_address=0x31)
+
+    async def _probe_side_effect(request, *, timeout, retries):
+        return request.device_address == 0x31
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
+        with patch.object(client, "_probe", side_effect=_probe_side_effect):
+            caps = await client.detect(prior=prior)
+
+    assert caps.lv_bcu_address == 0x31
+
+
+async def test_detect_hinted_absent_lv_bcu_skips_probe():
+    """Hinted mode trusts a prior None — no 0x31 probe is dispatched.
+
+    Follows the meter convention: hinted detect only re-checks addresses the
+    prior captured, so a firmware upgrade that adds the block needs a cold
+    detect to notice.
+    """
+    client = _make_client()
+    _prime_cache(client, 0x11, {HR(0): 0x2001, HR(21): 0})
+    _prime_battery_serial(client, 0x32)
+    prior = PlantCapabilities(device_type=Model.HYBRID_GEN1, lv_battery_addresses=[0x32])
+
+    probed_addresses = []
+
+    async def _probe_side_effect(request, *, timeout, retries):
+        probed_addresses.append(request.device_address)
+        return False
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
+        with patch.object(client, "_probe", side_effect=_probe_side_effect):
+            caps = await client.detect(prior=prior)
+
+    assert caps.lv_bcu_address is None
+    assert 0x31 not in probed_addresses
 
 
 def _prime_aio_module_serial(client: Client, device_address: int, serial: str = "HX2414G832") -> None:

--- a/tests/client/test_detect.py
+++ b/tests/client/test_detect.py
@@ -463,6 +463,45 @@ async def test_detect_hinted_absent_lv_bcu_skips_probe():
     assert 0x31 not in probed_addresses
 
 
+@pytest.mark.asyncio
+async def test_detect_lv_bcu_probe_succeeds_but_cache_absent():
+    """Probe returns True but no data landed in the cache — gracefully leaves lv_bcu_address=None."""
+    client = _make_client()
+    _prime_cache(client, 0x11, {HR(0): 0x2001, HR(21): 0})
+    _prime_battery_serial(client, 0x32)
+    # No cache at 0x31 — probe "succeeds" but no registers were stored.
+
+    async def _probe_succeed_at_0x31(request, *, timeout, retries):
+        return request.device_address == 0x31
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
+        with patch.object(client, "_probe", side_effect=_probe_succeed_at_0x31):
+            caps = await client.detect()
+
+    assert caps.lv_bcu_address is None
+
+
+@pytest.mark.asyncio
+async def test_detect_lv_bcu_decode_error_is_swallowed():
+    """A decoding error in the BCU probe is logged and leaves lv_bcu_address=None."""
+    from unittest.mock import patch as _patch
+
+    client = _make_client()
+    _prime_cache(client, 0x11, {HR(0): 0x2001, HR(21): 0})
+    _prime_battery_serial(client, 0x32)
+    _prime_cache(client, 0x31, {IR(60): 1, IR(61): 0, IR(62): 0, IR(63): 0})
+
+    async def _probe_succeed_at_0x31(request, *, timeout, retries):
+        return request.device_address == 0x31
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
+        with patch.object(client, "_probe", side_effect=_probe_succeed_at_0x31):
+            with _patch("givenergy_modbus.client.client.LvBcu.from_register_cache", side_effect=ValueError("corrupt")):
+                caps = await client.detect()
+
+    assert caps.lv_bcu_address is None
+
+
 def _prime_aio_module_serial(client: Client, device_address: int, serial: str = "HX2414G832") -> None:
     """Prime an AIO module cache with a valid module serial (IR 114-118)."""
     regs = {IR(114 + i): int.from_bytes(serial[i * 2 : i * 2 + 2].encode("latin1"), "big") for i in range(5)}

--- a/tests/client/test_load_refresh.py
+++ b/tests/client/test_load_refresh.py
@@ -248,6 +248,23 @@ async def test_refresh_lv_batteries():
     assert _ir(60, 60, device=0x34) in reqs
 
 
+async def test_refresh_lv_bcu():
+    """A detected LV BCU adds an IR 60+60 read at its page address (#241)."""
+    client = _client_with_caps(Model.HYBRID, lv_battery_addresses=[0x32], lv_bcu_address=0x31)
+    with patch.object(client, "_execute_reads", new_callable=AsyncMock) as mock_exec:
+        await client.refresh()
+    reqs = _reqs(mock_exec)
+    assert _ir(60, 60, device=0x31) in reqs
+
+
+async def test_refresh_no_lv_bcu_read_when_absent():
+    """No 0x31 read when the BCU block wasn't detected."""
+    client = _client_with_caps(Model.HYBRID, lv_battery_addresses=[0x32])
+    with patch.object(client, "_execute_reads", new_callable=AsyncMock) as mock_exec:
+        await client.refresh()
+    assert _ir(60, 60, device=0x31) not in _reqs(mock_exec)
+
+
 async def test_refresh_meter_addresses():
     """Meter devices each add an IR 60+30 read."""
     client = _client_with_caps(Model.HYBRID, meter_addresses=[0x01, 0x02])

--- a/tests/model/test_lv_bcu.py
+++ b/tests/model/test_lv_bcu.py
@@ -1,0 +1,48 @@
+"""Tests for the LV BCU stack-level block model (#241)."""
+
+from givenergy_modbus.model.lv_bcu import LV_BCU_ADDRESS, LvBcu
+from givenergy_modbus.model.register import IR
+from givenergy_modbus.model.register_cache import RegisterCache
+
+
+def test_address_constant():
+    assert LV_BCU_ADDRESS == 0x31
+
+
+def test_from_registers_field_values():
+    """Decode the block as observed in the field (#238: two LV plants, BMS fw 3022).
+
+    Status words zero, request currents 167 A in both directions — the only
+    populated shape seen on real hardware so far.
+    """
+    bcu = LvBcu.from_register_cache(RegisterCache({IR(60): 0, IR(61): 0, IR(62): 167, IR(63): 167}))
+    assert bcu.bms_status_1 == 0
+    assert bcu.bms_status_2 == 0
+    assert bcu.request_charge_current == 167
+    assert bcu.request_discharge_current == 167
+    assert bcu.is_valid()
+
+
+def test_all_zero_block_is_absent():
+    """All-zero decodes as absent, not error (firmware-gated, #241).
+
+    Units without the block still answer reads at 0x31 — with zeros — so
+    presence requires at least one non-zero word.
+    """
+    bcu = LvBcu.from_register_cache(RegisterCache({IR(60): 0, IR(61): 0, IR(62): 0, IR(63): 0}))
+    assert not bcu.is_valid()
+
+
+def test_any_nonzero_word_is_present():
+    """A non-zero status word alone marks the block present, even with zero currents."""
+    bcu = LvBcu.from_register_cache(RegisterCache({IR(60): 1, IR(61): 0, IR(62): 0, IR(63): 0}))
+    assert bcu.is_valid()
+
+
+def test_empty_cache():
+    bcu = LvBcu.from_register_cache(RegisterCache())
+    assert bcu.bms_status_1 is None
+    assert bcu.bms_status_2 is None
+    assert bcu.request_charge_current is None
+    assert bcu.request_discharge_current is None
+    assert not bcu.is_valid()

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -1570,6 +1570,14 @@ def test_getter_for_device_address_with_capabilities():
     assert plant._getter_for_device_address(0x99) is None
 
 
+def test_getter_for_device_address_lv_bcu():
+    """When capabilities carry lv_bcu_address, that address routes to LvBcuRegisterGetter (#241)."""
+    from givenergy_modbus.model.lv_bcu import LvBcuRegisterGetter
+
+    plant = Plant(capabilities=PlantCapabilities(device_type=Model.HYBRID, lv_bcu_address=0x31))
+    assert plant._getter_for_device_address(0x31) is LvBcuRegisterGetter
+
+
 def test_commit_bank_incoherent_serial_discards_bank(plant: Plant, caplog):
     """A battery bank whose serial number registers decode to garbage must be discarded.
 

--- a/tests/model/test_plant_accessors.py
+++ b/tests/model/test_plant_accessors.py
@@ -193,3 +193,35 @@ def test_gateway_returned_for_gateway_device():
     plant = _plant_with_caps(device_type=Model.GATEWAY)
     gw = plant.gateway
     assert isinstance(gw, (GatewayV1, GatewayV2))
+
+
+# ---------------------------------------------------------------------------
+# plant.lv_bcu — present only when capabilities carry lv_bcu_address (#241)
+# ---------------------------------------------------------------------------
+
+
+def test_lv_bcu_none_without_capabilities():
+    assert Plant().lv_bcu is None
+
+
+def test_lv_bcu_none_when_not_detected():
+    plant = _plant_with_caps(device_type=Model.HYBRID, lv_battery_addresses=[0x32])
+    assert plant.lv_bcu is None
+
+
+def test_lv_bcu_none_when_cache_unpopulated():
+    """No KeyError between detect() and the first poll of the BCU page."""
+    plant = _plant_with_caps(device_type=Model.HYBRID, lv_bcu_address=0x31)
+    assert 0x31 not in plant.register_caches
+    assert plant.lv_bcu is None
+
+
+def test_lv_bcu_decodes_from_cache():
+    from givenergy_modbus.model.lv_bcu import LvBcu
+
+    plant = _plant_with_caps(device_type=Model.HYBRID, lv_bcu_address=0x31)
+    _prime(plant, 0x31, {IR(60): 0, IR(61): 0, IR(62): 167, IR(63): 167})
+    bcu = plant.lv_bcu
+    assert isinstance(bcu, LvBcu)
+    assert bcu.request_charge_current == 167
+    assert bcu.request_discharge_current == 167

--- a/tests/model/test_plant_accessors.py
+++ b/tests/model/test_plant_accessors.py
@@ -225,3 +225,17 @@ def test_lv_bcu_decodes_from_cache():
     assert isinstance(bcu, LvBcu)
     assert bcu.request_charge_current == 167
     assert bcu.request_discharge_current == 167
+
+
+def test_lv_bcu_decode_error_returns_none(caplog):
+    """A malformed cache raises during decode — must return None, not propagate (#241)."""
+    import logging
+    from unittest.mock import patch
+
+    plant = _plant_with_caps(device_type=Model.HYBRID, lv_bcu_address=0x31)
+    _prime(plant, 0x31, {IR(60): 1})
+    with patch("givenergy_modbus.model.plant.LvBcu.from_register_cache", side_effect=RuntimeError("oops")):
+        with caplog.at_level(logging.ERROR):
+            result = plant.lv_bcu
+    assert result is None
+    assert "Failed to decode LV BCU" in caplog.text

--- a/tests/test_deprecation_aliases.py
+++ b/tests/test_deprecation_aliases.py
@@ -179,6 +179,7 @@ def test_capabilities_to_dict_format():
         "lv_battery_addresses": ["0x33"],
         "bcu_stacks": [[0, 2]],
         "aio_battery_module_addresses": [],
+        "lv_bcu_address": None,
     }
 
 


### PR DESCRIPTION
## Summary

- Introduces `LvBcu` model for the §4.4.1.1 stack-level BMS block on LV battery plants (device `0x31`, IR 60–63)
- `bms_status_1`/`bms_status_2` (IR 60/61, raw uint16) and `request_charge_current`/`request_discharge_current` (IR 62/63, 1 A resolution)
- `is_valid()` treats an all-zero block as absent/firmware-gated rather than an error — field evidence: populated on BMS fw 3022, all-zero on fw 3007/3009
- `detect()` probes `0x31` on LV plants and sets `PlantCapabilities.lv_bcu_address`; hinted mode trusts a prior `None` to skip the probe
- `refresh()` solicits IR(60-119)@`0x31` when the capability is set

## Deferred

IR 62/63 semantics (live telemetry vs configured constant) and `bms_status_1/2` decoding deferred pending Adrian's under-load captures (#241).

## Test plan

- [x] `uv run pytest --cov` — 987 passed, 0 failures
- [x] `uv run tox -q` — py311/py312/py313/py314 + format/lint/build all green
- [x] Live smoke test against `192.168.46.50` (fw 3007/3009): `lv_bcu_address=None` — correct negative-control
- [x] Positive path covered by unit tests built on Adrian's field captures (fw 3022: IR 62/63 = 167 A)

Closes #241

🤖 Generated with [Claude Code](https://claude.com/claude-code)