### PR TITLE
fix(battery): guard LV battery banks against sub-bus splice corruption (#256)

### DIFF
--- a/givenergy_modbus/model/battery_splice.py
+++ b/givenergy_modbus/model/battery_splice.py
@@ -1,0 +1,113 @@
+"""Physics-delta classifier for LV battery banks — the substrate of the #256 splice guard.
+
+BMS sub-bus corruption is re-framed by the dongle with a *valid CRC* (#147), so it passes
+the #255 CRC guard and commits valid-looking garbage over good cache. Every spliced value
+sits inside its per-register bounds, the bank isn't all-zero (so Pattern B / #206 doesn't
+fire) and the serial can stay valid (so ``is_coherent`` passes) — nothing catches it.
+
+What *does* separate corruption from real data is physics: classifying the 1,103
+consecutive-frame transitions in the capture corpus by physically-impossible per-register
+movement gives perfect separation (1,086 clean / 17 corrupt / zero false trips). Every
+corruption event trips >=2 physically-independent registers or changes a normally-constant
+one; the only physics-singleton in the corpus (a MOSFET temperature stepping 6.3 degC in
+one poll) is genuine.
+
+This module is the single source of truth for those thresholds. ``Plant._commit_bank``
+imports it to guard live commits; ``tests/debug/physics_delta_classify.py`` imports it to
+re-validate the corpus separation against the very same constants.
+
+Thresholds are in raw register units and set at roughly 10x what the quantity can really do
+in a ~30 s poll interval — cell voltages barely move (electrochemical inertia), cell-mass
+temperatures drift, the junction-adjacent MOSFET sensor steps (hence its much wider
+threshold), capacities move with charge current (~0.5 Ah/poll at LV power). Status/bitfield
+words carry no physics and are exempt (IR(91) legitimately toggles 0x0E10 <-> 0x0610 every
+few minutes). ``num_cells``, ``bms_firmware_version`` and the serial block are constant —
+ANY transient change is corruption on its own.
+
+Indices throughout are **bank-relative** (``i`` == register ``IR(60 + i)``); the trips
+returned carry the **absolute** IR number for logging.
+"""
+
+from __future__ import annotations
+
+#: Battery banks span IR(60..119); index ``i`` here is register ``IR(BANK_BASE + i)``.
+BANK_BASE = 60
+
+# (class name, bank-relative indices, threshold on |delta| in raw units).
+SCALAR_RULES: list[tuple[str, list[int], int]] = [
+    ("cell_mV", list(range(0, 16)), 100),  # IR(60-75) cells: ~10 mV/poll real max
+    ("cell_temp_deci", [16, 17, 18, 19, 43, 44], 50),  # IR(76-79,103,104): thermal mass
+    ("mosfet_temp_deci", [21], 200),  # IR(81): junction-adjacent, steps with load
+    ("v_cells_sum_mV", [20], 1600),  # IR(80)
+    ("soc_pct", [40], 10),  # IR(100)
+    ("e_total_deci", [45, 46], 50),  # IR(105/106) lifetime energy
+]
+# uint32 pairs: (class name, (high index, low index), threshold on the assembled pair value).
+PAIR_RULES: list[tuple[str, tuple[int, int], int]] = [
+    ("v_out_mV", (22, 23), 2000),  # IR(82-83)
+    ("cap_centiAh", (24, 25), 1000),  # IR(84-85) cap_calibrated
+    ("cap_centiAh", (26, 27), 1000),  # IR(86-87) cap_design
+    ("cap_centiAh", (28, 29), 1000),  # IR(88-89) cap_remaining
+    ("cap_centiAh", (41, 42), 1000),  # IR(101-102) cap_design2
+]
+# num_cells IR(97), bms_firmware_version IR(98), serial block IR(110-114) — ANY change is
+# corruption on its own. IR(115) is deliberately NOT here: the corpus treated it as a
+# constant canary, but battery.py documents it as a mutable ``usb_device_inserted`` field
+# (observed values 0/8/11), so a normal USB insert/remove would false-trip. The temp-zero
+# corruption cohort it was meant to catch already trips the >=2-physics rule on the
+# temperatures themselves (#256 discussion).
+IMMUTABLE: list[int] = [37, 38, *range(50, 55)]
+# Exempt (no physics): status/warning words IR(90-94), i_battery IR(95), num_cycles IR(96),
+# usb_device_inserted IR(115), unknown/reserved IR(99,107-109,116-119).
+
+#: class name -> threshold, for the escrow guard's value-consistency check on a held trip.
+#: Every ``cap_centiAh`` pair shares the same threshold, so the flattening is unambiguous.
+THRESHOLD_BY_CLASS: dict[str, int] = {name: thr for name, _, thr in SCALAR_RULES} | {
+    name: thr for name, _, thr in PAIR_RULES
+}
+
+#: A single trip: (absolute IR number, class name, old comparable value, new comparable value).
+#: For pair rules the comparable values are the assembled uint32s, not the high word alone.
+Trip = tuple[int, str, int, int]
+
+
+def classify_transition(
+    prev: list[int],
+    new: list[int],
+    present: set[int] | None = None,
+) -> tuple[list[Trip], list[Trip]]:
+    """Classify one IR(60,60) battery-bank transition into (physics trips, immutable violations).
+
+    ``prev`` / ``new`` are length-60 lists of **raw** register values, bank-relative
+    (``prev[i]`` is the previous raw value of ``IR(BANK_BASE + i)``).
+
+    ``present`` is the set of bank-relative indices whose value is genuinely available in
+    *both* banks; a rule is skipped unless all of its registers are present. Pass ``None``
+    to evaluate every rule (the offline corpus tool's behaviour, where both frames are
+    always full reads). The live guard passes the intersection so a partial bank or a
+    never-seen register can't manufacture a spurious delta.
+
+    Each returned trip is ``(absolute_IR_number, class_name, old_comparable, new_comparable)``;
+    for pair rules the comparable values are the assembled uint32s.
+    """
+    phys: list[Trip] = []
+    immut: list[Trip] = []
+    for name, idxs, thr in SCALAR_RULES:
+        for i in idxs:
+            if present is not None and i not in present:
+                continue
+            if abs(new[i] - prev[i]) > thr:
+                phys.append((i + BANK_BASE, name, prev[i], new[i]))
+    for name, (hi, lo), thr in PAIR_RULES:
+        if present is not None and (hi not in present or lo not in present):
+            continue
+        new_val = (new[hi] << 16) | new[lo]
+        old_val = (prev[hi] << 16) | prev[lo]
+        if abs(new_val - old_val) > thr:
+            phys.append((hi + BANK_BASE, name, old_val, new_val))
+    for i in IMMUTABLE:
+        if present is not None and i not in present:
+            continue
+        if new[i] != prev[i]:
+            immut.append((i + BANK_BASE, "IMMUTABLE", prev[i], new[i]))
+    return phys, immut

--- a/givenergy_modbus/model/battery_splice.py
+++ b/givenergy_modbus/model/battery_splice.py
@@ -66,13 +66,18 @@ THRESHOLD_BY_CLASS: dict[str, int] = {name: thr for name, _, thr in SCALAR_RULES
     name: thr for name, _, thr in PAIR_RULES
 }
 
-#: If the prior IR(60,60) commit is older than this many seconds, the per-poll physics thresholds
-#: no longer apply — a legitimate multi-field change after a network outage or prolonged refresh
-#: failure would exceed them, and rejected banks do not advance the cache timestamp, so the guard
-#: would pin the cache to a stale baseline forever. At this age the guard resets to cold-start
-#: semantics: adopt unconditionally and rebuild the baseline.
-#: Value: 10× the nominal ~30 s poll interval — large enough to survive transient hiccups but
-#: short enough that a genuine outage triggers a clean recovery on the first post-reconnect poll.
+#: Maximum plausible gap (seconds) between consecutive *observed* battery banks. If the guard
+#: sees no full bank for a device for longer than this, the next one arrives after a genuine
+#: polling outage (network drop / prolonged refresh failure): the cached baseline is too stale
+#: for the per-poll physics thresholds — legitimate SOC/temp/cap drift would exceed them — so the
+#: guard resets to cold-start semantics and adopts it.
+#: Critically this is measured against the last *observed* bank, NOT the last accepted commit. A
+#: sustained corruption run (e.g. a multi-poll temp-zero stream, an observed #256 shape) keeps
+#: arriving each poll and is rejected each poll; its last *good commit* ages past this bound, but
+#: the observation clock stays ~one poll old, so the bypass never fires and corruption stays
+#: rejected for as long as it lasts.
+#: Value: 10× the nominal ~30 s poll interval — survives transient hiccups, recovers a real outage
+#: on the first post-reconnect poll.
 STALE_BYPASS_SECONDS: int = 300
 
 #: A single trip: (absolute IR number, class name, old comparable value, new comparable value).

--- a/givenergy_modbus/model/battery_splice.py
+++ b/givenergy_modbus/model/battery_splice.py
@@ -66,6 +66,15 @@ THRESHOLD_BY_CLASS: dict[str, int] = {name: thr for name, _, thr in SCALAR_RULES
     name: thr for name, _, thr in PAIR_RULES
 }
 
+#: If the prior IR(60,60) commit is older than this many seconds, the per-poll physics thresholds
+#: no longer apply — a legitimate multi-field change after a network outage or prolonged refresh
+#: failure would exceed them, and rejected banks do not advance the cache timestamp, so the guard
+#: would pin the cache to a stale baseline forever. At this age the guard resets to cold-start
+#: semantics: adopt unconditionally and rebuild the baseline.
+#: Value: 10× the nominal ~30 s poll interval — large enough to survive transient hiccups but
+#: short enough that a genuine outage triggers a clean recovery on the first post-reconnect poll.
+STALE_BYPASS_SECONDS: int = 300
+
 #: A single trip: (absolute IR number, class name, old comparable value, new comparable value).
 #: For pair rules the comparable values are the assembled uint32s, not the high word alone.
 Trip = tuple[int, str, int, int]

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -543,6 +543,15 @@ class Plant(GivEnergyBaseModel):
     # Ephemeral runtime state, rebuilt with a fresh Plant on reconnect; not serialised.
     _splice_escrow: dict[int, tuple[int, int]] = PrivateAttr(default_factory=dict)
 
+    # Splice-guard observation clock (#256): per battery device address, the ingestion time of the
+    # last full IR(60,60) bank the guard examined — accepted OR rejected. The stale-baseline bypass
+    # keys off this, NOT the last accepted commit: a sustained corruption run (every poll rejected)
+    # leaves the last-good commit ageing past the bypass window, but keeps arriving each poll, so
+    # this clock stays ~one poll old and the bypass never fires. Only a genuine polling gap (real
+    # outage, no banks at all) makes it stale and resets to cold-start adoption. Ephemeral; resets
+    # with a fresh Plant on reconnect; not serialised.
+    _splice_last_seen: dict[int, datetime] = PrivateAttr(default_factory=dict)
+
     # Direct-inverter register caches injected by add_direct_source() for multi-Client
     # reconciliation (#106 Phase 3). Stored separately from register_caches to avoid the
     # Modbus address collision (both EMS controller and direct inverter live at 0x11).
@@ -794,26 +803,22 @@ class Plant(GivEnergyBaseModel):
 
         Only full battery banks are guarded: a short read can't be physics-classified, a
         device with no prior committed bank (cold start) has nothing to compare against, and
-        a baseline older than ``STALE_BYPASS_SECONDS`` is too stale for per-poll thresholds
-        to apply (legitimate multi-field drift after a reconnect gap would trip them) — all
-        three fall through as a no-op commit so the cache self-heals without manual recovery.
+        a gap of more than ``STALE_BYPASS_SECONDS`` since the last *observed* full bank — a
+        genuine polling outage, not a rejection streak — is too stale for per-poll thresholds
+        to apply (legitimate multi-field drift over the gap would trip them) — all three fall
+        through as a no-op commit so the cache self-heals without manual recovery.
         """
         if register_count < 60:
             return True
-        # Stale-baseline bypass: after a long gap the per-poll thresholds don't hold (legitimate
-        # SOC/temp/cap drift would exceed them), and rejected banks never advance the timestamp,
-        # so without this the guard would pin the cache to the stale baseline indefinitely after
-        # a network outage or prolonged refresh failure. Adopt unconditionally and rebuild.
-        last_age = self.block_age(device_address, "IR", BANK_BASE, 60, now=now)
-        if last_age is not None and last_age > STALE_BYPASS_SECONDS:
-            self._splice_escrow.pop(device_address, None)
-            _logger.info(
-                "Battery bank for device 0x%02x: prior commit %.0f s old — splice guard bypassed "
-                "(stale baseline); adopting as new baseline.",
-                device_address,
-                last_age,
-            )
-            return True
+        now_ts = now if now is not None else datetime.now(UTC)
+        if now_ts.tzinfo is None:
+            now_ts = now_ts.replace(tzinfo=UTC)
+        # Record this observation up front — a rejected bank is still an observation, so the gap
+        # computed below measures time since we last *saw* a full bank, not since we last accepted
+        # one. This is what separates a real outage from a sustained corruption run (see below).
+        prev_seen = self._splice_last_seen.get(device_address)
+        self._splice_last_seen[device_address] = now_ts
+
         cache = self.register_caches[device_address]
         prev = [0] * 60
         new = [0] * 60
@@ -828,6 +833,23 @@ class Plant(GivEnergyBaseModel):
                 present.add(i)
         if not present:
             return True  # cold start: no last-good to compare against
+
+        # Stale-observation bypass: after a genuine polling gap the per-poll thresholds don't hold
+        # (legitimate SOC/temp/cap drift over the gap would exceed them), and rejected banks never
+        # advance the cache, so without recovery the guard would pin the cache to the stale baseline
+        # forever after a network outage. Crucially this keys off the last *observation*, not the
+        # last accepted commit: a sustained corruption run (e.g. a multi-poll temp-zero stream)
+        # keeps arriving and being rejected each poll, ageing the last *commit* past the window —
+        # but prev_seen stays ~one poll old, so this does NOT fire and the corruption stays rejected.
+        if prev_seen is not None and (now_ts - prev_seen).total_seconds() > STALE_BYPASS_SECONDS:
+            self._splice_escrow.pop(device_address, None)
+            _logger.info(
+                "Battery bank for device 0x%02x: %.0f s since the last observed bank — splice guard "
+                "bypassed (stale baseline); adopting as new baseline.",
+                device_address,
+                (now_ts - prev_seen).total_seconds(),
+            )
+            return True
 
         phys, immut = classify_transition(prev, new, present)
 

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -8,7 +8,12 @@ from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, model_validator
 from givenergy_modbus.model import GivEnergyBaseModel
 from givenergy_modbus.model.aio_battery import AioBatteryModule
 from givenergy_modbus.model.battery import Battery, BatteryRegisterGetter
-from givenergy_modbus.model.battery_splice import BANK_BASE, THRESHOLD_BY_CLASS, classify_transition
+from givenergy_modbus.model.battery_splice import (
+    BANK_BASE,
+    STALE_BYPASS_SECONDS,
+    THRESHOLD_BY_CLASS,
+    classify_transition,
+)
 from givenergy_modbus.model.devices import DeviceType, PlantDevice
 from givenergy_modbus.model.devices import Inverter as UnifiedInverter
 from givenergy_modbus.model.ems import Ems
@@ -665,7 +670,7 @@ class Plant(GivEnergyBaseModel):
 
         if isinstance(pdu, ReadHoldingRegistersResponse):
             incoming = {HR(k): v for k, v in pdu.to_dict().items()}
-            if self._commit_bank(device_address, incoming, pdu.register_count):
+            if self._commit_bank(device_address, incoming, pdu.register_count, received_at=received_at):
                 self._stamp_block(device_address, "HR", pdu.base_register, pdu.register_count, received_at)
                 self._track_content_change(
                     device_address, "HR", pdu.base_register, pdu.register_count, incoming, received_at
@@ -676,7 +681,7 @@ class Plant(GivEnergyBaseModel):
                 # constants. is_suspicious() logs at debug when it fires.
                 return
             incoming = {IR(k): v for k, v in pdu.to_dict().items()}  # type: ignore[misc]
-            if self._commit_bank(device_address, incoming, pdu.register_count):
+            if self._commit_bank(device_address, incoming, pdu.register_count, received_at=received_at):
                 self._stamp_block(device_address, "IR", pdu.base_register, pdu.register_count, received_at)
                 self._track_content_change(
                     device_address, "IR", pdu.base_register, pdu.register_count, incoming, received_at
@@ -695,7 +700,14 @@ class Plant(GivEnergyBaseModel):
                 target = self.capabilities.inverter_address if self.capabilities is not None else device_address
                 self.register_caches.setdefault(target, RegisterCache()).update({HR(pdu.register): pdu.value})
 
-    def _commit_bank(self, device_address: int, incoming: dict, register_count: int = 60) -> bool:
+    def _commit_bank(
+        self,
+        device_address: int,
+        incoming: dict,
+        register_count: int = 60,
+        *,
+        received_at: datetime | None = None,
+    ) -> bool:
         """Validate incoming register bank against bounds and commit if clean.
 
         Returns True if the bank was committed to the cache, False if it was discarded —
@@ -707,6 +719,9 @@ class Plant(GivEnergyBaseModel):
         to full blocks (>= 60 registers), where a simultaneous all-zero read is genuinely
         suspicious. A short read (e.g. a single power register legitimately settling to
         zero) must not be blocked.
+
+        ``received_at`` is the PDU ingestion timestamp, threaded to the splice guard so it
+        can measure baseline staleness consistently with the rest of the stamping logic.
         """
         cache = self.register_caches[device_address]
         # Pattern B (#78/#147/#199, tracked in #206): a bank that previously held non-zero data and
@@ -758,12 +773,16 @@ class Plant(GivEnergyBaseModel):
         # all the checks above wave through. Runs last so the existing serial gate owns serial
         # corruption (quietly) and the bounds pass runs first; it must see last-good, so it sits
         # before the update below. Gated to battery banks via the getter identity.
-        if getter_cls is BatteryRegisterGetter and not self._splice_guard(device_address, incoming, register_count):
+        if getter_cls is BatteryRegisterGetter and not self._splice_guard(
+            device_address, incoming, register_count, now=received_at
+        ):
             return False
         self.register_caches[device_address].update(incoming)
         return True
 
-    def _splice_guard(self, device_address: int, incoming: dict, register_count: int) -> bool:
+    def _splice_guard(
+        self, device_address: int, incoming: dict, register_count: int, now: datetime | None = None
+    ) -> bool:
         """Reject (or escrow) a battery bank corrupted by a valid-CRC BMS sub-bus splice (#256).
 
         Returns True to allow the commit, False to hold last-good. Compares the incoming bank
@@ -773,11 +792,27 @@ class Plant(GivEnergyBaseModel):
         lone impossible delta is escrowed — held one poll and committed only if the next poll
         reads the same value again (a genuine step persists; every observed splice reverts).
 
-        Only full battery banks are guarded: a short read can't be physics-classified, and a
-        device with no prior committed bank (cold start) has nothing to compare against — both
-        fall through as a no-op commit.
+        Only full battery banks are guarded: a short read can't be physics-classified, a
+        device with no prior committed bank (cold start) has nothing to compare against, and
+        a baseline older than ``STALE_BYPASS_SECONDS`` is too stale for per-poll thresholds
+        to apply (legitimate multi-field drift after a reconnect gap would trip them) — all
+        three fall through as a no-op commit so the cache self-heals without manual recovery.
         """
         if register_count < 60:
+            return True
+        # Stale-baseline bypass: after a long gap the per-poll thresholds don't hold (legitimate
+        # SOC/temp/cap drift would exceed them), and rejected banks never advance the timestamp,
+        # so without this the guard would pin the cache to the stale baseline indefinitely after
+        # a network outage or prolonged refresh failure. Adopt unconditionally and rebuild.
+        last_age = self.block_age(device_address, "IR", BANK_BASE, 60, now=now)
+        if last_age is not None and last_age > STALE_BYPASS_SECONDS:
+            self._splice_escrow.pop(device_address, None)
+            _logger.info(
+                "Battery bank for device 0x%02x: prior commit %.0f s old — splice guard bypassed "
+                "(stale baseline); adopting as new baseline.",
+                device_address,
+                last_age,
+            )
             return True
         cache = self.register_caches[device_address]
         prev = [0] * 60

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, model_validator
 from givenergy_modbus.model import GivEnergyBaseModel
 from givenergy_modbus.model.aio_battery import AioBatteryModule
 from givenergy_modbus.model.battery import Battery, BatteryRegisterGetter
+from givenergy_modbus.model.battery_splice import BANK_BASE, THRESHOLD_BY_CLASS, classify_transition
 from givenergy_modbus.model.devices import DeviceType, PlantDevice
 from givenergy_modbus.model.devices import Inverter as UnifiedInverter
 from givenergy_modbus.model.ems import Ems
@@ -529,6 +530,14 @@ class Plant(GivEnergyBaseModel):
     # exposed — see that method for why a threshold isn't yet derivable.
     _block_unchanged_since: dict = PrivateAttr(default_factory=dict)
 
+    # Splice-guard escrow (#256): per battery device address, the single physics-singleton
+    # transition currently held back pending confirmation — (tripping IR number, comparable
+    # value held). A held bank never updates the cache, so the next poll re-compares against
+    # the same last-good; the held value commits only if the device reads it again within
+    # threshold (genuine step persists) rather than snapping back (transient splice reverts).
+    # Ephemeral runtime state, rebuilt with a fresh Plant on reconnect; not serialised.
+    _splice_escrow: dict[int, tuple[int, int]] = PrivateAttr(default_factory=dict)
+
     # Direct-inverter register caches injected by add_direct_source() for multi-Client
     # reconciliation (#106 Phase 3). Stored separately from register_caches to avoid the
     # Modbus address collision (both EMS controller and direct inverter live at 0x11).
@@ -745,8 +754,91 @@ class Plant(GivEnergyBaseModel):
                 # TODO(enforcement): add `return False` here to discard the entire bank on any
                 # violation. When that happens, also raise this back to WARNING — at that point
                 # it has user-visible consequences (a poll cycle's data is dropped).
+        # Battery sub-bus splice guard (#256): valid-CRC, in-bounds, valid-serial garbage that
+        # all the checks above wave through. Runs last so the existing serial gate owns serial
+        # corruption (quietly) and the bounds pass runs first; it must see last-good, so it sits
+        # before the update below. Gated to battery banks via the getter identity.
+        if getter_cls is BatteryRegisterGetter and not self._splice_guard(device_address, incoming, register_count):
+            return False
         self.register_caches[device_address].update(incoming)
         return True
+
+    def _splice_guard(self, device_address: int, incoming: dict, register_count: int) -> bool:
+        """Reject (or escrow) a battery bank corrupted by a valid-CRC BMS sub-bus splice (#256).
+
+        Returns True to allow the commit, False to hold last-good. Compares the incoming bank
+        against the cached last-good using per-register-class physics thresholds
+        (:mod:`givenergy_modbus.model.battery_splice`): a change to a constant register or
+        >=2 physically-impossible per-poll deltas is corruption and is rejected outright; a
+        lone impossible delta is escrowed — held one poll and committed only if the next poll
+        reads the same value again (a genuine step persists; every observed splice reverts).
+
+        Only full battery banks are guarded: a short read can't be physics-classified, and a
+        device with no prior committed bank (cold start) has nothing to compare against — both
+        fall through as a no-op commit.
+        """
+        if register_count < 60:
+            return True
+        cache = self.register_caches[device_address]
+        prev = [0] * 60
+        new = [0] * 60
+        present: set[int] = set()
+        for i in range(60):
+            reg = IR(BANK_BASE + i)
+            cached = cache.get(reg)
+            incoming_val = incoming.get(reg)
+            prev[i] = cached if cached is not None else 0
+            new[i] = incoming_val if incoming_val is not None else prev[i]
+            if incoming_val is not None and cached is not None:
+                present.add(i)
+        if not present:
+            return True  # cold start: no last-good to compare against
+
+        phys, immut = classify_transition(prev, new, present)
+
+        if immut or len(phys) >= 2:
+            self._splice_escrow.pop(device_address, None)
+            reason = "constant-register change" if immut else ">=2 physics-impossible deltas"
+            _logger.warning(
+                "Rejected battery bank for device 0x%02x — sub-bus splice (%s); keeping last-good. "
+                "Trips: %s. Please report if seen.",
+                device_address,
+                reason,
+                self._format_splice_trips(immut + phys),
+            )
+            return False
+
+        if len(phys) == 1:
+            ir_no, name, _old, new_val = phys[0]
+            held = self._splice_escrow.get(device_address)
+            if held is not None and held[0] == ir_no and abs(new_val - held[1]) <= THRESHOLD_BY_CLASS[name]:
+                # The held value read the same again this poll — a genuine step that persists,
+                # not a transient splice (which reverts) — so commit the now-confirmed bank.
+                self._splice_escrow.pop(device_address, None)
+                _logger.info(
+                    "Battery bank for device 0x%02x: escrowed step at IR(%d) confirmed on re-read; committing.",
+                    device_address,
+                    ir_no,
+                )
+                return True
+            self._splice_escrow[device_address] = (ir_no, new_val)
+            _logger.warning(
+                "Held battery bank for device 0x%02x — single physics-impossible delta (%s) held pending "
+                "confirmation next poll; keeping last-good. Please report if seen.",
+                device_address,
+                self._format_splice_trips(phys),
+            )
+            return False
+
+        # Clean transition (no trips): a previously-held step that snapped back lands here, so
+        # drop any escrow and commit.
+        self._splice_escrow.pop(device_address, None)
+        return True
+
+    @staticmethod
+    def _format_splice_trips(trips: list[tuple[int, str, int, int]]) -> str:
+        """Render splice-guard trips compactly for the WARNING log (raw register units)."""
+        return ", ".join(f"IR({ir}) {name} {old}->{new}" for ir, name, old, new in trips)
 
     def _stamp_block(
         self,

--- a/tests/debug/physics_delta_classify.py
+++ b/tests/debug/physics_delta_classify.py
@@ -44,34 +44,15 @@ from collections import Counter
 from pathlib import Path
 
 from givenergy_modbus.framer import ClientFramer
+
+# The thresholds and the transition classifier are the production constants from the #256
+# splice guard — imported here so this corpus tool re-validates separation against the very
+# same rules the live guard enforces (no drift). See that module for the threshold rationale.
+from givenergy_modbus.model.battery_splice import BANK_BASE, classify_transition
 from givenergy_modbus.pdu import ReadInputRegistersResponse
 
 CAPTURE_LINE = re.compile(r"^(\S+) (rx|tx) ([0-9a-f]+)")
 BATTERY_DEVICES = range(0x32, 0x38)
-BANK_BASE = 60
-
-# (class name, indices within the bank, threshold on |delta| in raw units).
-# Indices are register - 60. Thresholds ~10x the real per-poll maximum.
-SCALAR_RULES = [
-    ("cell_mV", list(range(0, 16)), 100),  # cells: ~10 mV/poll real max
-    ("cell_temp_deci", [16, 17, 18, 19, 43, 44], 50),  # IR(76-79,103,104): thermal mass
-    ("mosfet_temp_deci", [21], 200),  # IR(81): junction-adjacent, steps with load
-    ("v_cells_sum_mV", [20], 1600),
-    ("soc_pct", [40], 10),
-    ("e_total_deci", [45, 46], 50),  # IR(105/106) lifetime energy
-]
-# uint32 pairs: (class name, (high index, low index), threshold on pair value).
-PAIR_RULES = [
-    ("v_out_mV", (22, 23), 2000),
-    ("cap_centiAh", (24, 25), 1000),  # cap_calibrated
-    ("cap_centiAh", (26, 27), 1000),  # cap_design
-    ("cap_centiAh", (28, 29), 1000),  # cap_remaining
-    ("cap_centiAh", (41, 42), 1000),  # cap_design2
-]
-# num_cells, bms_firmware_version, serial block + trailing constant IR(115).
-IMMUTABLE = [37, 38, *range(50, 56)]
-# Exempt (no physics): status/warning words IR(90-94), i_battery IR(95),
-# num_cycles IR(96), unknown/reserved IR(99,107-109,116-119).
 
 
 def load_rx_frames(paths: list[Path]) -> list[tuple[str, str, bytes]]:
@@ -100,21 +81,12 @@ def bonkers(
 ) -> tuple[list[tuple[int, str, int, int]], list[tuple[int, str, int, int]]]:
     """Return (physics trips, immutable violations) for one transition.
 
-    Each entry is (register number, class name, previous raw, new raw).
+    Thin compatibility alias over ``battery_splice.classify_transition`` — note the arg
+    order flips (``regs`` is the *current* frame, ``prev`` the previous), so the underlying
+    call is ``classify_transition(prev, regs)``. Each entry is
+    (register number, class name, previous raw, new raw).
     """
-    phys, immut = [], []
-    for name, idxs, thr in SCALAR_RULES:
-        for i in idxs:
-            if abs(regs[i] - prev[i]) > thr:
-                phys.append((i + BANK_BASE, name, prev[i], regs[i]))
-    for name, (h, lo), thr in PAIR_RULES:
-        a, b = (regs[h] << 16) | regs[lo], (prev[h] << 16) | prev[lo]
-        if abs(a - b) > thr:
-            phys.append((h + BANK_BASE, name, b, a))
-    for i in IMMUTABLE:
-        if regs[i] != prev[i]:
-            immut.append((i + BANK_BASE, "IMMUTABLE", prev[i], regs[i]))
-    return phys, immut
+    return classify_transition(prev, regs)
 
 
 async def classify(paths: list[Path]) -> int:

--- a/tests/model/test_battery_splice.py
+++ b/tests/model/test_battery_splice.py
@@ -108,6 +108,24 @@ def test_present_gating_skips_rules_with_absent_registers():
     assert classify_transition(base, new, present=present) == ([], [])
 
 
+def test_present_gating_skips_pair_rule_with_absent_register():
+    """A PAIR rule is skipped when either of its two words is absent from `present`."""
+    base = _baseline()
+    new = list(base)
+    new[29] = 36000  # would trip the cap_remaining (28, 29) pair...
+    present = set(range(60)) - {29}  # ...but its low word is absent, so skip
+    assert classify_transition(base, new, present=present) == ([], [])
+
+
+def test_present_gating_skips_immutable_with_absent_register():
+    """An IMMUTABLE check is skipped when its register is absent from `present`."""
+    base = _baseline()
+    new = list(base)
+    new[38] = 3006  # would be a bms_firmware_version immutable violation...
+    present = set(range(60)) - {38}  # ...but it's absent, so skip
+    assert classify_transition(base, new, present=present) == ([], [])
+
+
 def test_threshold_table_covers_every_rule_class():
     """Every class name used by a rule must resolve in THRESHOLD_BY_CLASS (escrow lookup)."""
     from givenergy_modbus.model.battery_splice import PAIR_RULES, SCALAR_RULES

--- a/tests/model/test_battery_splice.py
+++ b/tests/model/test_battery_splice.py
@@ -1,0 +1,118 @@
+"""Unit tests for the #256 physics-delta classifier (battery_splice.classify_transition).
+
+These pin the threshold tables and the trip logic independent of Plant, so CI re-confirms
+the corpus separation rules directly. The Plant-level integration (reject / escrow / commit)
+is exercised in test_plant.py.
+"""
+
+from givenergy_modbus.model.battery_splice import (
+    BANK_BASE,
+    IMMUTABLE,
+    THRESHOLD_BY_CLASS,
+    classify_transition,
+)
+
+
+def _baseline() -> list[int]:
+    """A physically-plausible length-60 raw bank (bank-relative; index i == IR(60+i))."""
+    bank = [0] * 60
+    for i in range(0, 16):  # cells 3.300 V
+        bank[i] = 3300
+    for i in range(16, 20):  # cell-mass temps 25.0 °C
+        bank[i] = 250
+    bank[20] = 52800  # v_cells_sum mV
+    bank[21] = 260  # t_bms_mosfet deci
+    bank[23] = 52800  # v_out low word
+    bank[25] = bank[27] = bank[29] = bank[42] = 16000  # cap pairs low words (centiAh)
+    bank[37] = 16  # num_cells
+    bank[38] = 3005  # bms_firmware_version
+    bank[40] = 55  # soc %
+    bank[43], bank[44] = 250, 240  # t_max, t_min
+    bank[45], bank[46] = 1000, 1200  # lifetime energy
+    bank[50], bank[51], bank[52], bank[53], bank[54] = 0x4247, 0x3132, 0x3334, 0x3536, 0x3738
+    bank[55] = 8  # usb_device_inserted (mutable, exempt)
+    return bank
+
+
+def test_identical_banks_have_no_trips():
+    base = _baseline()
+    assert classify_transition(base, list(base)) == ([], [])
+
+
+def test_ir115_is_dropped_from_immutable():
+    """IR(115) (bank index 55) must not be immutable — it's a mutable usb_device_inserted field."""
+    assert 55 not in IMMUTABLE
+    assert IMMUTABLE == [37, 38, 50, 51, 52, 53, 54]
+
+
+def test_single_cell_voltage_step_is_one_physics_trip():
+    base = _baseline()
+    new = list(base)
+    new[5] = 3600  # +300 mV > 100 mV threshold
+    phys, immut = classify_transition(base, new)
+    assert immut == []
+    assert phys == [(BANK_BASE + 5, "cell_mV", 3300, 3600)]
+
+
+def test_within_threshold_jitter_does_not_trip():
+    base = _baseline()
+    new = list(base)
+    new[5] = 3399  # +99 mV, within the 100 mV threshold
+    new[16] = 299  # +49 deci, within the 50 threshold
+    assert classify_transition(base, new) == ([], [])
+
+
+def test_constant_register_change_is_immutable_violation():
+    base = _baseline()
+    new = list(base)
+    new[38] = 3006  # bms_firmware_version changed by one
+    phys, immut = classify_transition(base, new)
+    assert phys == []
+    assert immut == [(98, "IMMUTABLE", 3005, 3006)]
+
+
+def test_serial_change_is_immutable_violation():
+    base = _baseline()
+    new = list(base)
+    new[50] = 0x4248  # first serial word changed
+    _phys, immut = classify_transition(base, new)
+    assert immut == [(110, "IMMUTABLE", 0x4247, 0x4248)]
+
+
+def test_pair_rule_uses_assembled_uint32_value():
+    """cap_remaining is the IR(88)/IR(89) pair; the trip must report the assembled uint32s."""
+    base = _baseline()
+    new = list(base)
+    new[29] = 36000  # cap_remaining low word: 160 Ah -> 360 Ah
+    phys, immut = classify_transition(base, new)
+    assert immut == []
+    assert phys == [(88, "cap_centiAh", 16000, 36000)]  # high index, assembled values
+
+
+def test_two_independent_physics_deltas_both_reported():
+    base = _baseline()
+    new = list(base)
+    new[14] = 3600  # a cell
+    new[43] = 0  # t_max to zero
+    phys, immut = classify_transition(base, new)
+    assert immut == []
+    assert {p[0] for p in phys} == {BANK_BASE + 14, 103}
+
+
+def test_present_gating_skips_rules_with_absent_registers():
+    base = _baseline()
+    new = list(base)
+    new[5] = 3600  # would trip cell_mV...
+    # ...but exclude index 5 from `present`, so the rule is skipped.
+    present = set(range(60)) - {5}
+    assert classify_transition(base, new, present=present) == ([], [])
+
+
+def test_threshold_table_covers_every_rule_class():
+    """Every class name used by a rule must resolve in THRESHOLD_BY_CLASS (escrow lookup)."""
+    from givenergy_modbus.model.battery_splice import PAIR_RULES, SCALAR_RULES
+
+    for name, _idxs, thr in SCALAR_RULES:
+        assert THRESHOLD_BY_CLASS[name] == thr
+    for name, _pair, thr in PAIR_RULES:
+        assert THRESHOLD_BY_CLASS[name] == thr

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -2694,3 +2694,31 @@ def test_splice_rejected_bank_preserves_staleness(plant: Plant):
     _feed_bank(plant, corrupted, device_address=_BATT, received_at=_T0 + timedelta(seconds=30))
     # Age at t0 + 45 s must reflect the last *committed* bank at t0, not the rejected one.
     assert plant.block_age(_BATT, "IR", 60, 60, now=_T0 + timedelta(seconds=45)) == 45.0
+
+
+def test_splice_stale_baseline_bypass(plant: Plant, caplog):
+    """After a long gap the guard bypasses physics checks and adopts the incoming bank.
+
+    Per-poll thresholds are calibrated for ~30 s intervals. After a network outage or
+    prolonged refresh failure, a legitimate multi-field change (SOC/temp/cap drift) would
+    exceed them. Without this bypass, the guard would reject the first post-reconnect bank
+    and then pin the cache forever — rejected banks never advance the timestamp so every
+    subsequent poll also compares against the same stale baseline.
+    """
+    import logging
+
+    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)
+    # Simulate a 400 s gap (> STALE_BYPASS_SECONDS=300): values that would be >=2 physics
+    # trips on a fresh baseline must commit unconditionally after a stale one.
+    t_reconnect = _T0 + timedelta(seconds=400)
+    post_outage = _coherent_battery_bank({60: 3700, 76: 0})  # 2 battery-physics trips
+    with caplog.at_level(logging.INFO, logger="givenergy_modbus.model.plant"):
+        _feed_bank(plant, post_outage, device_address=_BATT, received_at=t_reconnect)
+    # Values committed (guard bypassed).
+    assert plant.register_caches[_BATT][IR(60)] == 3700
+    assert plant.register_caches[_BATT][IR(76)] == 0
+    # Bypass emits an INFO log; no splice rejection WARNING.
+    infos = [r for r in caplog.records if "stale baseline" in r.message and "0x33" in r.message]
+    assert len(infos) == 1 and infos[0].levelno == logging.INFO
+    warns = [r for r in caplog.records if "Rejected battery bank" in r.message]
+    assert not warns

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -2427,3 +2427,270 @@ def test_register_age_keeps_freshest_when_older_window_seen_later(plant: Plant):
     plant.update(_make_ir_pdu({5: 2367}, base_register=0), received_at=t_old)  # IR(0,60), older
     now = datetime(2026, 6, 11, 12, 0, 30, tzinfo=UTC)
     assert plant.register_age(0x32, IR(5), now=now) == 10.0
+
+
+# ---------------------------------------------------------------------------
+# Battery sub-bus splice guard (#256) — Plant-level integration tests
+#
+# Tests that the splice guard correctly rejects or escrows LV battery banks
+# carrying physics-impossible register deltas, even when CRC, bounds, and
+# serial-coherence checks pass. All tests target device 0x33: on a bare
+# Plant, 0x32 → SinglePhaseInverterRegisterGetter and 0x33–0x37 →
+# BatteryRegisterGetter, so only 0x33+ is guarded.
+# ---------------------------------------------------------------------------
+
+
+def _coherent_battery_bank(overrides: dict[int, int] | None = None) -> dict[int, int]:
+    """A valid, coherent LV battery bank keyed by absolute IR number (60..119)."""
+    bank: dict[int, int] = {
+        # 16 cells at 3.300 V (bank-relative 0–15 → IR60–75)
+        **{60 + i: 3300 for i in range(16)},
+        # cell-mass temps at 25.0 °C (bank-relative 16–19 → IR76–79)
+        **{76 + i: 250 for i in range(4)},
+        80: 52800,  # v_cells_sum IR80
+        81: 260,  # mosfet_temp IR81
+        82: 0,
+        83: 52800,  # v_out pair IR82–83
+        84: 0,
+        85: 16000,  # cap_calibrated IR84–85
+        86: 0,
+        87: 16000,  # cap_design IR86–87
+        88: 0,
+        89: 16000,  # cap_remaining IR88–89
+        97: 16,  # num_cells IR97 (IMMUTABLE)
+        98: 3005,  # bms_fw IR98 (IMMUTABLE)
+        100: 55,  # soc IR100
+        101: 0,
+        102: 16000,  # cap_design2 IR101–102
+        103: 250,  # t_max IR103
+        104: 240,  # t_min IR104
+        105: 1000,  # e_total hi IR105
+        106: 1200,  # e_total lo IR106
+        # serial IR110–114 (IMMUTABLE) — "BG12345678", same as the Pattern-B battery test (L1797)
+        110: 0x4247,
+        111: 0x3132,
+        112: 0x3334,
+        113: 0x3536,
+        114: 0x3738,
+        115: 8,  # usb_device_inserted IR115 (mutable, exempt from IMMUTABLE)
+    }
+    if overrides:
+        bank.update(overrides)
+    return bank
+
+
+_BATT = 0x33  # battery pack #1 on bare Plant; 0x32 → inverter getter on bare Plant
+
+
+def test_splice_capacity_cohort_rejected(plant: Plant, caplog):
+    """A cap-pair physics step + immutable mutation is rejected outright (constant-register change)."""
+    import logging
+
+    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)
+    corrupted = _coherent_battery_bank(
+        {
+            89: 36000,  # IR89: cap_remaining low word 16000 → 36000, pair delta 20000 > 1000 threshold
+            98: 3006,  # IR98: bms_fw IMMUTABLE violation
+        }
+    )
+    with caplog.at_level(logging.WARNING, logger="givenergy_modbus.model.plant"):
+        _feed_bank(plant, corrupted, device_address=_BATT, received_at=_T0 + timedelta(seconds=30))
+    assert plant.register_caches[_BATT][IR(89)] == 16000  # last-good retained
+    assert plant.register_caches[_BATT][IR(98)] == 3005
+    warns = [r for r in caplog.records if "Rejected battery bank" in r.message and "0x33" in r.message]
+    assert len(warns) == 1
+    assert "constant-register change" in warns[0].message
+
+
+def test_splice_cell_and_temp_cohort_rejected(plant: Plant, caplog):
+    """Two independent physics trips (a cell + a temperature) are rejected outright (≥2-physics rule)."""
+    import logging
+
+    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)
+    corrupted = _coherent_battery_bank(
+        {
+            74: 3700,  # IR74: cell delta 400 mV > 100 threshold
+            103: 0,  # IR103: t_max delta 250 > 50 threshold
+        }
+    )
+    with caplog.at_level(logging.WARNING, logger="givenergy_modbus.model.plant"):
+        _feed_bank(plant, corrupted, device_address=_BATT, received_at=_T0 + timedelta(seconds=30))
+    assert plant.register_caches[_BATT][IR(74)] == 3300
+    assert plant.register_caches[_BATT][IR(103)] == 250
+    warns = [r for r in caplog.records if "Rejected battery bank" in r.message and "0x33" in r.message]
+    assert len(warns) == 1
+    assert "physics-impossible" in warns[0].message
+
+
+def test_splice_temp_cohort_zeros_rejected(plant: Plant, caplog):
+    """All four cell-mass temps dropping to zero (4 physics trips) is rejected outright."""
+    import logging
+
+    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)
+    corrupted = _coherent_battery_bank({76 + i: 0 for i in range(4)})  # IR76–79: 250 → 0
+    with caplog.at_level(logging.WARNING, logger="givenergy_modbus.model.plant"):
+        _feed_bank(plant, corrupted, device_address=_BATT, received_at=_T0 + timedelta(seconds=30))
+    assert plant.register_caches[_BATT][IR(76)] == 250  # last-good retained
+    warns = [r for r in caplog.records if "Rejected battery bank" in r.message and "0x33" in r.message]
+    assert len(warns) == 1
+
+
+def test_splice_clean_bank_commits_no_false_trip(plant: Plant, caplog):
+    """In-threshold jitter on a clean bank commits normally and emits no splice WARNING."""
+    import logging
+
+    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)
+    # +99 mV cell (≤ 100 threshold), +49 deci temp (≤ 50 threshold) — both within limits.
+    jitter = _coherent_battery_bank({60: 3399, 76: 299})
+    with caplog.at_level(logging.WARNING, logger="givenergy_modbus.model.plant"):
+        _feed_bank(plant, jitter, device_address=_BATT, received_at=_T0 + timedelta(seconds=30))
+    warns = [r for r in caplog.records if "splice" in r.message.lower() or "Held battery bank" in r.message]
+    assert not warns
+    assert plant.register_caches[_BATT][IR(60)] == 3399
+    assert plant.register_caches[_BATT][IR(76)] == 299
+
+
+def test_splice_single_step_escrow_then_confirm(plant: Plant, caplog):
+    """A lone impossible delta is escrowed; re-reading the same value confirms and commits."""
+    import logging
+
+    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)
+    t1 = _T0 + timedelta(seconds=30)
+    t2 = _T0 + timedelta(seconds=60)
+    wild = _coherent_battery_bank({60: 3500})  # IR60: +200 mV > 100 threshold — one trip
+
+    with caplog.at_level(logging.WARNING, logger="givenergy_modbus.model.plant"):
+        _feed_bank(plant, wild, device_address=_BATT, received_at=t1)
+    holds = [r for r in caplog.records if "Held battery bank" in r.message and "0x33" in r.message]
+    assert len(holds) == 1, "single impossible delta must emit one 'held' WARNING"
+    assert plant.register_caches[_BATT][IR(60)] == 3300, "escrowed bank must not commit"
+
+    caplog.clear()
+    # Re-read the same value: |3500 − 3500| = 0 ≤ 100 → value-consistent → confirm.
+    with caplog.at_level(logging.INFO, logger="givenergy_modbus.model.plant"):
+        _feed_bank(plant, wild, device_address=_BATT, received_at=t2)
+    confirms = [r for r in caplog.records if "confirmed" in r.message and "0x33" in r.message]
+    assert len(confirms) == 1, "confirmed step must emit one INFO log"
+    assert plant.register_caches[_BATT][IR(60)] == 3500, "confirmed step must commit"
+
+
+def test_splice_single_step_escrow_then_snapback(plant: Plant, caplog):
+    """A transient splice that snaps back clears the escrow and commits the clean bank."""
+    import logging
+
+    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)
+    t1 = _T0 + timedelta(seconds=30)
+    t2 = _T0 + timedelta(seconds=60)
+    wild = _coherent_battery_bank({60: 3500})
+    with caplog.at_level(logging.WARNING, logger="givenergy_modbus.model.plant"):
+        _feed_bank(plant, wild, device_address=_BATT, received_at=t1)
+    assert plant.register_caches[_BATT][IR(60)] == 3300
+
+    caplog.clear()
+    clean = _coherent_battery_bank()  # IR60 back to seed value
+    with caplog.at_level(logging.WARNING, logger="givenergy_modbus.model.plant"):
+        _feed_bank(plant, clean, device_address=_BATT, received_at=t2)
+    warns = [r for r in caplog.records if "splice" in r.message.lower() or "Held battery bank" in r.message]
+    assert not warns, "snapback to seed must commit cleanly with no WARNING"
+    assert plant.register_caches[_BATT][IR(60)] == 3300
+
+
+def test_splice_two_wild_values_in_a_row_held(plant: Plant, caplog):
+    """Two consecutive wild values for the same register are both held (value-consistency guard)."""
+    import logging
+
+    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)
+    t1 = _T0 + timedelta(seconds=30)
+    t2 = _T0 + timedelta(seconds=60)
+    # v1: IR60 → 3500 (|3500 − 3300| = 200 > 100) → escrow (IR60, 3500).
+    # v2: IR60 → 3700 (|3700 − 3500| = 200 > 100) → does NOT confirm → re-escrow (IR60, 3700).
+    v1 = _coherent_battery_bank({60: 3500})
+    v2 = _coherent_battery_bank({60: 3700})
+    with caplog.at_level(logging.WARNING, logger="givenergy_modbus.model.plant"):
+        _feed_bank(plant, v1, device_address=_BATT, received_at=t1)
+        _feed_bank(plant, v2, device_address=_BATT, received_at=t2)
+    holds = [r for r in caplog.records if "Held battery bank" in r.message and "0x33" in r.message]
+    assert len(holds) == 2, "each wild read must emit its own 'held' WARNING"
+    assert plant.register_caches[_BATT][IR(60)] == 3300, "neither wild value must have committed"
+
+
+def test_splice_cold_start_no_op_commit(plant: Plant, caplog):
+    """The first bank to a fresh device address has no last-good and commits as a no-op."""
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="givenergy_modbus.model.plant"):
+        _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)
+    warns = [r for r in caplog.records if "splice" in r.message.lower() or "Held battery bank" in r.message]
+    assert not warns
+    assert plant.register_caches[_BATT][IR(60)] == 3300
+
+
+def test_splice_ir115_usb_change_alone_commits(plant: Plant, caplog):
+    """IR(115) usb_device_inserted is mutable (exempt from IMMUTABLE); a change alone must commit."""
+    import logging
+
+    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)
+    with caplog.at_level(logging.WARNING, logger="givenergy_modbus.model.plant"):
+        _feed_bank(
+            plant,
+            _coherent_battery_bank({115: 11}),  # 8 → 11, no other changes
+            device_address=_BATT,
+            received_at=_T0 + timedelta(seconds=30),
+        )
+    warns = [r for r in caplog.records if "splice" in r.message.lower() or "Held battery bank" in r.message]
+    assert not warns
+    assert plant.register_caches[_BATT][IR(115)] == 11
+
+
+def test_splice_short_read_skips_guard(plant: Plant, caplog):
+    """A register_count < 60 frame bypasses the splice guard even if values would trip battery physics."""
+    import logging
+
+    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)
+    # IR76 dropping to 0 would be a temp-zero physics trip on a full 60-register bank.
+    # With count=1 the guard gates off and the value commits normally.
+    with caplog.at_level(logging.WARNING, logger="givenergy_modbus.model.plant"):
+        _feed_bank(plant, {76: 0}, device_address=_BATT, count=1, received_at=_T0 + timedelta(seconds=30))
+    warns = [r for r in caplog.records if "splice" in r.message.lower() or "Held battery bank" in r.message]
+    assert not warns
+    assert plant.register_caches[_BATT][IR(76)] == 0  # committed
+
+
+def test_splice_non_battery_device_skips_guard(plant: Plant, caplog):
+    """On a bare Plant, 0x32 → inverter getter; the splice guard is not applied there."""
+    import logging
+
+    # Seed 0x32 with a battery-shaped bank (committed under the inverter getter).
+    _feed_bank(plant, _coherent_battery_bank(), device_address=0x32, received_at=_T0)
+    # Two battery-physics trips — would be rejected on 0x33, but 0x32 is not BatteryRegisterGetter.
+    wild = _coherent_battery_bank({60: 3700, 76: 0})
+    with caplog.at_level(logging.WARNING, logger="givenergy_modbus.model.plant"):
+        _feed_bank(plant, wild, device_address=0x32, received_at=_T0 + timedelta(seconds=30))
+    warns = [r for r in caplog.records if "splice" in r.message.lower() or "Held battery bank" in r.message]
+    assert not warns
+    assert plant.register_caches[0x32][IR(60)] == 3700  # committed
+
+
+def test_splice_escrow_isolated_per_device(plant: Plant):
+    """The splice escrow is keyed per device; confirming 0x33 must not affect 0x34's held state."""
+    _feed_bank(plant, _coherent_battery_bank(), device_address=0x33, received_at=_T0)
+    _feed_bank(plant, _coherent_battery_bank(), device_address=0x34, received_at=_T0)
+    t1 = _T0 + timedelta(seconds=30)
+    t2 = _T0 + timedelta(seconds=60)
+    # Hold 0x33 on IR60; hold 0x34 on IR61.
+    _feed_bank(plant, _coherent_battery_bank({60: 3500}), device_address=0x33, received_at=t1)
+    _feed_bank(plant, _coherent_battery_bank({61: 3500}), device_address=0x34, received_at=t1)
+    # Confirm 0x33 by re-reading IR60=3500.
+    _feed_bank(plant, _coherent_battery_bank({60: 3500}), device_address=0x33, received_at=t2)
+    assert plant.register_caches[0x33][IR(60)] == 3500, "0x33 confirmed and committed"
+    assert plant.register_caches[0x34][IR(61)] == 3300, "0x34 still held; 0x33 confirm must not clear it"
+
+
+def test_splice_rejected_bank_preserves_staleness(plant: Plant):
+    """A splice-rejected bank records no ingestion timestamp; block_age keeps growing (#65/#256)."""
+    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)
+    # ≥2 physics trips → rejected → _stamp_block never called.
+    corrupted = _coherent_battery_bank({60: 3700, 76: 0})
+    _feed_bank(plant, corrupted, device_address=_BATT, received_at=_T0 + timedelta(seconds=30))
+    # Age at t0 + 45 s must reflect the last *committed* bank at t0, not the rejected one.
+    assert plant.block_age(_BATT, "IR", 60, 60, now=_T0 + timedelta(seconds=45)) == 45.0

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -2722,3 +2722,59 @@ def test_splice_stale_baseline_bypass(plant: Plant, caplog):
     assert len(infos) == 1 and infos[0].levelno == logging.INFO
     warns = [r for r in caplog.records if "Rejected battery bank" in r.message]
     assert not warns
+
+
+def test_splice_sustained_corruption_never_bypassed(plant: Plant, caplog):
+    """A sustained corruption run stays rejected indefinitely — never adopted via the stale bypass.
+
+    The bypass keys off the last *observed* bank, not the last accepted commit. A continuous
+    temp-zero stream (an observed #256 corruption shape) keeps arriving each poll and is rejected
+    each poll: the last good commit ages past STALE_BYPASS_SECONDS, but the observation clock stays
+    one poll old, so the bypass never fires. Regression for the re-review P1: keying off commit age
+    alone would adopt the still-corrupt bank after 5 minutes.
+    """
+    import logging
+
+    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)
+    corrupt = _coherent_battery_bank({76 + i: 0 for i in range(4)})  # 4 temp-zero physics trips
+    with caplog.at_level(logging.INFO, logger="givenergy_modbus.model.plant"):
+        # 20 consecutive polls × 30 s = 600 s, well past the 300 s bypass window.
+        for n in range(1, 21):
+            _feed_bank(plant, corrupt, device_address=_BATT, received_at=_T0 + timedelta(seconds=30 * n))
+    # Last-good temps retained the whole time; the corrupt zeros never committed.
+    assert plant.register_caches[_BATT][IR(76)] == 250
+    # The bypass must never have fired (it would have adopted a corrupt bank).
+    assert not [r for r in caplog.records if "stale baseline" in r.message]
+    # Every corrupt poll was rejected.
+    rejects = [r for r in caplog.records if "Rejected battery bank" in r.message and "0x33" in r.message]
+    assert len(rejects) == 20
+
+
+def test_splice_bypass_only_after_genuine_gap_not_rejection_streak(plant: Plant, caplog):
+    """An intervening (rejected) bank resets the observation clock, so a later gap is measured fresh.
+
+    A corruption bank at t+30 is rejected but still counts as an observation. A genuine bank at
+    t+400 is then only ~370 s after that rejected one (> window → bypass), confirming the clock
+    tracks every observation, not just commits. The complement of the sustained-run test.
+    """
+    import logging
+
+    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)
+    # A rejected corruption bank shortly after seed: advances the observation clock to _T0+30.
+    _feed_bank(
+        plant,
+        _coherent_battery_bank({60: 3700, 76: 0}),
+        device_address=_BATT,
+        received_at=_T0 + timedelta(seconds=30),
+    )
+    assert plant.register_caches[_BATT][IR(76)] == 250  # rejected, last-good kept
+    # Then a real gap to _T0+400: 370 s since the last observation (the rejected bank) → bypass.
+    with caplog.at_level(logging.INFO, logger="givenergy_modbus.model.plant"):
+        _feed_bank(
+            plant,
+            _coherent_battery_bank({60: 3700, 76: 0}),
+            device_address=_BATT,
+            received_at=_T0 + timedelta(seconds=400),
+        )
+    assert plant.register_caches[_BATT][IR(76)] == 0  # adopted via bypass
+    assert [r for r in caplog.records if "stale baseline" in r.message and "0x33" in r.message]

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -2778,3 +2778,41 @@ def test_splice_bypass_only_after_genuine_gap_not_rejection_streak(plant: Plant,
         )
     assert plant.register_caches[_BATT][IR(76)] == 0  # adopted via bypass
     assert [r for r in caplog.records if "stale baseline" in r.message and "0x33" in r.message]
+
+
+def test_splice_guard_normalises_naive_received_at(plant: Plant, caplog):
+    """A tz-naive received_at is normalised to UTC in the guard, so the gap still computes (#256).
+
+    Mirrors block_age()'s posture: ingestion timestamps may arrive naive. The observation clock
+    must normalise them, or subtracting a naive from an aware datetime would raise.
+    """
+    import logging
+
+    naive_t0 = datetime(2026, 6, 9, 12, 0, 0)  # no tzinfo
+    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=naive_t0)
+    assert plant.register_caches[_BATT][IR(60)] == 3300  # cold-start commit, no crash on naive
+
+    naive_later = datetime(2026, 6, 9, 12, 6, 40)  # +400 s, still naive (> bypass window)
+    with caplog.at_level(logging.INFO, logger="givenergy_modbus.model.plant"):
+        _feed_bank(
+            plant,
+            _coherent_battery_bank({60: 3700, 76: 0}),  # would be >=2 trips on a fresh baseline
+            device_address=_BATT,
+            received_at=naive_later,
+        )
+    # The 400 s gap across two naive timestamps was computed correctly → bypass fired.
+    assert plant.register_caches[_BATT][IR(76)] == 0
+    assert [r for r in caplog.records if "stale baseline" in r.message and "0x33" in r.message]
+
+
+def test_splice_guard_defaults_now_when_received_at_missing(plant: Plant):
+    """With no received_at, the guard stamps the observation with the current time (#256).
+
+    The `now is None` fallback must produce a tz-aware timestamp so consecutive observations
+    still subtract cleanly; a near-instant second poll has a ~0 s gap and commits normally.
+    """
+    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT)  # received_at=None
+    assert plant.register_caches[_BATT][IR(60)] == 3300  # cold-start commit, no crash
+    # Second bank moments later: gap ~0 s (no bypass), single in-threshold change commits.
+    _feed_bank(plant, _coherent_battery_bank({60: 3350}), device_address=_BATT)
+    assert plant.register_caches[_BATT][IR(60)] == 3350


### PR DESCRIPTION
## Summary

BMS sub-bus corruption is re-framed by the dongle with a **valid CRC** (#147), so it passes the #255 CRC guard and commits valid-looking garbage over good cache — Ah spikes, temp dropouts to zero, fake 3.600 V cells — ~30×/day on the reporting install. None of the existing defences catch it: corrupted values are in-bounds, the bank is never all-zero (Pattern B / #206 doesn't fire), and the serial can stay valid (`is_coherent` passes).

- **New module `givenergy_modbus/model/battery_splice.py`** — single source of truth for per-register-class physics thresholds, empirically grounded on the 1,103-transition capture corpus (1,086 clean / 17 corrupt / zero false trips). Lifted from the #257 debug tool so the live guard and the corpus classifier can never drift apart.
- **`Plant._commit_bank` splice guard** — runs last, after serial-coherence and bounds, on full (≥60 register) `BatteryRegisterGetter` banks only:
  - **≥2 physics trips or any IMMUTABLE change** → reject outright, keep last-good
  - **Exactly 1 physics trip** → escrow: hold last-good, commit only if the next poll reads the same value again (genuine steps persist; every observed splice reverts within one poll)
  - **0 trips** → commit normally
- **IR(115) exempt from IMMUTABLE** — `battery.py` documents it as mutable `usb_device_inserted` (observed values 0/8/11); a USB insert/remove would false-trip. The temp-zero corruption cohort it was meant to catch trips ≥2 temperatures on its own.
- **`tests/debug/physics_delta_classify.py` refactored** — now imports thresholds from the production module.

## Test plan

- [x] 10 unit tests in `tests/model/test_battery_splice.py` — pin threshold tables, trip logic, `present` gating, absolute IR numbering, pair-rule uint32 assembly
- [x] 13 integration tests in `tests/model/test_plant.py` — reject-outright (immutable + capacity cohort, cell+temp, temp-zeros), false-positive guard (clean jitter commits), single-trip escrow (confirm, snapback, two-wilds-in-a-row), cold-start, IR(115) exemption, short-read gate, non-battery-device gate, per-device escrow isolation, staleness preservation on reject
- [x] 1023/1023 tests pass; ruff, mypy, bandit clean
- [ ] Corpus re-validation: `uv run python tests/debug/physics_delta_classify.py tests/fixtures/captures/*/*.log` — expect 17 corruption transitions flagged, zero false trips (unchanged vs #257 baseline except any IR(115)-driven immutable lines drop)

## Known trade-offs

- **Genuine `bms_firmware_version` or serial change** (BMS firmware update, battery swap) is rejected until the next reconnect rebuilds the Plant (fresh cache → cold-start adopt). Rare and reconnect-coupled; integrity-preserving. If long-lived-Plant swaps ever bite, the fix is to extend the escrow machinery to immutable trips — noted as a follow-up, not built here.
- **Single-trip latency** — a genuine physics-singleton step (the one in the corpus: MOSFET temp +6.3 °C in one poll) is delayed by one poll while it confirms. Worst case: one stale reading in 30 s.

Closes #256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added battery splice guard to detect and reject physically impossible battery bank transitions, preventing corrupted data from being cached.
  * Implemented escrow logic to hold questionable readings pending confirmation on the next poll before committing to cache.

* **Tests**
  * Comprehensive unit and integration tests for battery transition validation and corruption detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->