### PR TITLE
feat(commands): add set_charge_target_soc + clarify set_charge_target naming (#243)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ async def main():
     plant = client.plant
 
     # Write configuration to the device
-    await client.one_shot_command(commands.set_charge_target(80))
+    await client.one_shot_command(commands.set_charge_target_enabled(80))
     # set a charging slot from 00:30 to 04:30; slot_map selects correct registers for this model
     await client.one_shot_command(
         commands.set_charge_slot(1, TimeSlot.from_components(0, 30, 4, 30), plant.inverter.slot_map)

--- a/docs/migrating-from-the-async-fork.md
+++ b/docs/migrating-from-the-async-fork.md
@@ -107,7 +107,7 @@ The fork threads an `inv_type: str` parameter through many `set_*` helpers
 and branches on substrings like `"3ph"`. Here the model-specific behaviour
 is explicit instead:
 
-- 3-phase variants are separate helpers: `set_charge_target_3ph()`,
+- 3-phase variants are separate helpers: `set_charge_target_enabled_3ph()`,
   `set_battery_soc_reserve_3ph()`, `disable_charge_target_3ph()`, …
 - Slot commands take a `SlotMap` (`SINGLE_PHASE_SLOTS`, `EXTENDED_SLOTS`,
   `THREE_PHASE_SLOTS`) instead of an `inv_type` string — pass
@@ -129,8 +129,8 @@ await client.execute(reqs, timeout=2.0, retries=3)
 | `set_battery_discharge_limit_ac(v, inv_type)` | `set_battery_discharge_limit_ac(v)` |
 | `set_battery_soc_reserve(v, inv_type)` | `set_battery_soc_reserve(v)` / `set_battery_soc_reserve_3ph(v)` |
 | `_set_charge_slot(discharge, idx, slot, inv_type)` | `set_charge_slot(idx, slot, slot_map)` / `set_discharge_slot(idx, slot, slot_map)` |
-| `set_charge_target(v, inv_type)` | `set_charge_target(v)` / `set_charge_target_3ph(v)` |
-| `set_charge_target_only(v, inv_type)` | no equivalent yet — [#243](https://github.com/dewet22/givenergy-modbus/issues/243) |
+| `set_charge_target(v, inv_type)` | `set_charge_target_enabled(v)` / `set_charge_target_enabled_3ph(v)` (old `set_charge_target(v)` retained as a deprecated alias) |
+| `set_charge_target_only(v, inv_type)` | `set_charge_target_soc(v)` / `set_charge_target_soc_3ph(v)` |
 | `set_soc_target(discharge, idx, v, inv_type)` | EMS models: `set_ems_charge_target_soc(idx, v)` etc.; non-EMS per-slot targets: [#243](https://github.com/dewet22/givenergy-modbus/issues/243) |
 
 EMS, export and smart-load slots all have first-class helpers

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -25,7 +25,7 @@ async def main():
     plant = client.plant
 
     # Write configuration to the device
-    await client.one_shot_command(commands.set_charge_target(80))
+    await client.one_shot_command(commands.set_charge_target_enabled(80))
     await client.one_shot_command(
         commands.set_charge_slot(1, TimeSlot.from_components(0, 30, 4, 30), plant.inverter.slot_map)
     )
@@ -185,7 +185,7 @@ The recommended entry point is the inverter instance itself:
 ```python
 inverter = plant.inverter
 
-await client.one_shot_command(inverter.set_charge_target(80))
+await client.one_shot_command(inverter.set_charge_target_enabled(80))
 await client.one_shot_command(inverter.set_enable_discharge(True))
 await client.one_shot_command(inverter.set_charge_slot(1, my_timeslot))
 ```
@@ -242,13 +242,14 @@ case-by-case.
 | `_EmsCommands` | `Ems` only | ▣ ems |
 | `commands.*` only | _(not exposed as mixin method)_ | ⛔ commands-only |
 
-An unmarked row means the method is available on both inverter types. On `ThreePhaseInverter`, `_ThreePhaseCommands` overrides `set_enable_charge`, `set_battery_soc_reserve`, `set_mode_dynamic`, `set_charge_target`, `disable_charge_target`, and the slot setters to use the correct three-phase registers (HR 1112, 1109, 1111, 1113–1121).
+An unmarked row means the method is available on both inverter types. On `ThreePhaseInverter`, `_ThreePhaseCommands` overrides `set_enable_charge`, `set_battery_soc_reserve`, `set_mode_dynamic`, `set_charge_target_enabled`, `disable_charge_target`, and the slot setters to use the correct three-phase registers (HR 1112, 1109, 1111, 1113–1121).
 
 ### Charging
 
 | Function | Description | Surface |
 |---|---|---|
-| `set_charge_target(soc)` | Stop charging when SOC reaches `soc`% (4–100) | |
+| `set_charge_target_enabled(soc)` | Enable charging and stop when SOC reaches `soc`% (4–100). (`set_charge_target` is a deprecated alias) | |
+| `set_charge_target_soc(soc)` | Set just the charge-target SOC (4–100), leaving the enable bits untouched | |
 | `disable_charge_target()` | Remove SOC limit, target 100% | |
 | `set_enable_charge(enabled)` | Enable or disable charging | |
 | `set_battery_charge_limit(val)` | Charge power limit (0–50%) | |

--- a/givenergy_modbus/client/commands.py
+++ b/givenergy_modbus/client/commands.py
@@ -160,6 +160,7 @@ def disable_charge_target() -> list[TransparentRequest]:
 
 def set_charge_target_enabled(target_soc: int) -> list[TransparentRequest]:
     """Enable charging and stop once SOC reaches target_soc. Also referred to as "winter mode"."""
+    target_soc = _as_int(target_soc, "target_soc")
     if not 4 <= target_soc <= 100:
         raise ValueError(f"Charge Target SOC ({target_soc}) must be in [4-100]%")
     ret = set_enable_charge(True)
@@ -179,6 +180,7 @@ def set_charge_target(target_soc: int) -> list[TransparentRequest]:
 
 def set_charge_target_soc(target_soc: int) -> list[TransparentRequest]:
     """Set only the charge target SOC (HR 116), leaving the charge / charge-target enable bits untouched."""
+    target_soc = _as_int(target_soc, "target_soc")
     if not 4 <= target_soc <= 100:
         raise ValueError(f"Charge Target SOC ({target_soc}) must be in [4-100]%")
     return [WriteHoldingRegisterRequest(RegisterMap.CHARGE_TARGET_SOC, target_soc)]
@@ -293,6 +295,7 @@ def set_battery_soc_reserve_3ph(val: int) -> list[TransparentRequest]:
 
 def set_charge_target_enabled_3ph(target_soc: int) -> list[TransparentRequest]:
     """Enable AC charging and set the charge target on three-phase inverters (HR 1111, shadows single-phase HR 116)."""
+    target_soc = _as_int(target_soc, "target_soc")
     if not 4 <= target_soc <= 100:
         raise ValueError(f"Charge Target SOC ({target_soc}) must be in [4-100]%")
     ret = set_ac_charge(True)
@@ -317,6 +320,7 @@ def set_charge_target_3ph(target_soc: int) -> list[TransparentRequest]:
 
 def set_charge_target_soc_3ph(target_soc: int) -> list[TransparentRequest]:
     """Set only the charge target SOC on three-phase inverters (HR 1111), leaving enable bits untouched."""
+    target_soc = _as_int(target_soc, "target_soc")
     if not 4 <= target_soc <= 100:
         raise ValueError(f"Charge Target SOC ({target_soc}) must be in [4-100]%")
     return [WriteHoldingRegisterRequest(RegisterMap.CHARGE_TARGET_SOC_3PH, target_soc)]

--- a/givenergy_modbus/client/commands.py
+++ b/givenergy_modbus/client/commands.py
@@ -158,8 +158,8 @@ def disable_charge_target() -> list[TransparentRequest]:
     ]
 
 
-def set_charge_target(target_soc: int) -> list[TransparentRequest]:
-    """Sets inverter to stop charging when SOC reaches the desired level. Also referred to as "winter mode"."""
+def set_charge_target_enabled(target_soc: int) -> list[TransparentRequest]:
+    """Enable charging and stop once SOC reaches target_soc. Also referred to as "winter mode"."""
     if not 4 <= target_soc <= 100:
         raise ValueError(f"Charge Target SOC ({target_soc}) must be in [4-100]%")
     ret = set_enable_charge(True)
@@ -169,6 +169,19 @@ def set_charge_target(target_soc: int) -> list[TransparentRequest]:
         ret.append(WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE_TARGET, 1))
         ret.append(WriteHoldingRegisterRequest(RegisterMap.CHARGE_TARGET_SOC, target_soc))
     return ret
+
+
+@deprecated("use set_charge_target_enabled(target_soc) instead")
+def set_charge_target(target_soc: int) -> list[TransparentRequest]:
+    """Deprecated: use set_charge_target_enabled(target_soc)."""
+    return set_charge_target_enabled(target_soc)
+
+
+def set_charge_target_soc(target_soc: int) -> list[TransparentRequest]:
+    """Set only the charge target SOC (HR 116), leaving the charge / charge-target enable bits untouched."""
+    if not 4 <= target_soc <= 100:
+        raise ValueError(f"Charge Target SOC ({target_soc}) must be in [4-100]%")
+    return [WriteHoldingRegisterRequest(RegisterMap.CHARGE_TARGET_SOC, target_soc)]
 
 
 def set_enable_charge(enabled: bool) -> list[TransparentRequest]:
@@ -278,8 +291,8 @@ def set_battery_soc_reserve_3ph(val: int) -> list[TransparentRequest]:
     return [WriteHoldingRegisterRequest(RegisterMap.BATTERY_SOC_RESERVE_3PH, val)]
 
 
-def set_charge_target_3ph(target_soc: int) -> list[TransparentRequest]:
-    """Set charge target SOC on three-phase inverters (HR 1111, shadows single-phase HR 116)."""
+def set_charge_target_enabled_3ph(target_soc: int) -> list[TransparentRequest]:
+    """Enable AC charging and set the charge target on three-phase inverters (HR 1111, shadows single-phase HR 116)."""
     if not 4 <= target_soc <= 100:
         raise ValueError(f"Charge Target SOC ({target_soc}) must be in [4-100]%")
     ret = set_ac_charge(True)
@@ -294,6 +307,19 @@ def set_charge_target_3ph(target_soc: int) -> list[TransparentRequest]:
         ret.append(WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE_TARGET, 1))
         ret.append(WriteHoldingRegisterRequest(RegisterMap.CHARGE_TARGET_SOC_3PH, target_soc))
     return ret
+
+
+@deprecated("use set_charge_target_enabled_3ph(target_soc) instead")
+def set_charge_target_3ph(target_soc: int) -> list[TransparentRequest]:
+    """Deprecated: use set_charge_target_enabled_3ph(target_soc)."""
+    return set_charge_target_enabled_3ph(target_soc)
+
+
+def set_charge_target_soc_3ph(target_soc: int) -> list[TransparentRequest]:
+    """Set only the charge target SOC on three-phase inverters (HR 1111), leaving enable bits untouched."""
+    if not 4 <= target_soc <= 100:
+        raise ValueError(f"Charge Target SOC ({target_soc}) must be in [4-100]%")
+    return [WriteHoldingRegisterRequest(RegisterMap.CHARGE_TARGET_SOC_3PH, target_soc)]
 
 
 def set_battery_charge_limit(val: int) -> list[TransparentRequest]:
@@ -863,9 +889,18 @@ class _InverterCommands:
         """Disable use of a charge target so the battery charges to 100%."""
         return disable_charge_target()
 
+    def set_charge_target_enabled(self, target_soc: int) -> list[TransparentRequest]:
+        """Enable charging and stop once SOC reaches target_soc (4-100)."""
+        return set_charge_target_enabled(target_soc)
+
+    @deprecated("use set_charge_target_enabled(target_soc) instead")
     def set_charge_target(self, target_soc: int) -> list[TransparentRequest]:
-        """Sets inverter to stop charging when SOC reaches the desired level (4-100)."""
-        return set_charge_target(target_soc)
+        """Deprecated: use set_charge_target_enabled(target_soc)."""
+        return set_charge_target_enabled(target_soc)
+
+    def set_charge_target_soc(self, target_soc: int) -> list[TransparentRequest]:
+        """Adjust the charge target SOC (4-100) without touching the charge / charge-target enable bits."""
+        return set_charge_target_soc(target_soc)
 
     # --- charge/discharge enable --------------------------------------------
 
@@ -992,7 +1027,7 @@ class _ThreePhaseCommands:
     - `set_enable_charge()` → AC_CHARGE_ENABLE HR(1112) instead of HR(96)
     - `set_battery_soc_reserve()` → HR(1109) instead of HR(110)
     - `set_mode_dynamic()` → HR(1109) for the SOC reserve step instead of HR(110)
-    - `set_charge_target()` → HR(1112)+HR(1111) instead of HR(96)+HR(116)
+    - `set_charge_target_enabled()` → HR(1112)+HR(1111) instead of HR(96)+HR(116)
     - `set_battery_reserve_soc()` relocated here (three-phase only, HR 1078)
 
     MRO puts `_ThreePhaseCommands` before `_InverterCommands` on `ThreePhaseInverter`,
@@ -1070,9 +1105,18 @@ class _ThreePhaseCommands:
         """Remove SOC limit and target 100% charging (three-phase: HR 1111, shadows single-phase HR 116)."""
         return disable_charge_target_3ph()
 
+    def set_charge_target_enabled(self, target_soc: int) -> list[TransparentRequest]:
+        """Enable AC charging and set the charge target (three-phase HR 1111/1112, shadows single-phase HR 116)."""
+        return set_charge_target_enabled_3ph(target_soc)
+
+    @deprecated("use set_charge_target_enabled(target_soc) instead")
     def set_charge_target(self, target_soc: int) -> list[TransparentRequest]:
-        """Set charge target SOC (three-phase: HR 1111 + AC_CHARGE_ENABLE, shadows single-phase HR 116)."""
-        return set_charge_target_3ph(target_soc)
+        """Deprecated: use set_charge_target_enabled(target_soc)."""
+        return set_charge_target_enabled_3ph(target_soc)
+
+    def set_charge_target_soc(self, target_soc: int) -> list[TransparentRequest]:
+        """Adjust the charge target SOC, no enable side effects (three-phase HR 1111, shadows single-phase HR 116)."""
+        return set_charge_target_soc_3ph(target_soc)
 
 
 class _EmsCommands:

--- a/tests/client/test_commands.py
+++ b/tests/client/test_commands.py
@@ -54,6 +54,9 @@ async def test_set_charge_target_soc_writes_only_the_target_register():
     assert commands.set_charge_target_soc_3ph(45) == [
         WriteHoldingRegisterRequest(RegisterMap.CHARGE_TARGET_SOC_3PH, 45),
     ]
+    # Encode round-trip confirms both target registers are on the PDU write allowlist.
+    commands.set_charge_target_soc(45)[0].encode()
+    commands.set_charge_target_soc_3ph(45)[0].encode()
 
     # The whole point: no enable side effects (unlike set_charge_target_enabled).
     for reqs in (commands.set_charge_target_soc(45), commands.set_charge_target_soc_3ph(45)):
@@ -73,6 +76,20 @@ async def test_set_charge_target_soc_writes_only_the_target_register():
             fn(0)
         with pytest.raises(ValueError, match=r"Charge Target SOC \(101\) must be in \[4-100\]\%"):
             fn(101)
+
+
+async def test_charge_target_setters_reject_non_integral():
+    """All charge-target setters route target_soc through _as_int (reject bool / non-integral float)."""
+    for fn in (
+        commands.set_charge_target_enabled,
+        commands.set_charge_target_soc,
+        commands.set_charge_target_enabled_3ph,
+        commands.set_charge_target_soc_3ph,
+    ):
+        with pytest.raises(ValueError, match="bool"):
+            fn(True)
+        with pytest.raises(ValueError, match="integral"):
+            fn(50.5)
 
 
 async def test_set_charge():

--- a/tests/client/test_commands.py
+++ b/tests/client/test_commands.py
@@ -14,28 +14,65 @@ from givenergy_modbus.pdu import WriteHoldingRegisterRequest
 
 async def test_configure_charge_target():
     """Ensure we can set and disable a charge target."""
-    assert commands.set_charge_target(45) == [
+    assert commands.set_charge_target_enabled(45) == [
         WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE, 1),
         WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE_TARGET, 1),
         WriteHoldingRegisterRequest(RegisterMap.CHARGE_TARGET_SOC, 45),
     ]
-    assert commands.set_charge_target(100) == [
+    assert commands.set_charge_target_enabled(100) == [
         WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE, 1),
         WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE_TARGET, 0),
         WriteHoldingRegisterRequest(RegisterMap.CHARGE_TARGET_SOC, 100),
     ]
 
     with pytest.raises(ValueError, match=r"Charge Target SOC \(0\) must be in \[4-100\]\%"):
-        commands.set_charge_target(0)
+        commands.set_charge_target_enabled(0)
     with pytest.raises(ValueError, match=r"Charge Target SOC \(1\) must be in \[4-100\]\%"):
-        commands.set_charge_target(1)
+        commands.set_charge_target_enabled(1)
     with pytest.raises(ValueError, match=r"Charge Target SOC \(101\) must be in \[4-100\]\%"):
-        commands.set_charge_target(101)
+        commands.set_charge_target_enabled(101)
 
     assert commands.disable_charge_target() == [
         WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE_TARGET, 0),
         WriteHoldingRegisterRequest(RegisterMap.CHARGE_TARGET_SOC, 100),
     ]
+
+
+async def test_set_charge_target_is_deprecated_alias():
+    """set_charge_target is retained as a deprecated alias for set_charge_target_enabled (1ph + 3ph)."""
+    with pytest.warns(DeprecationWarning):
+        assert commands.set_charge_target(45) == commands.set_charge_target_enabled(45)
+    with pytest.warns(DeprecationWarning):
+        assert commands.set_charge_target_3ph(45) == commands.set_charge_target_enabled_3ph(45)
+
+
+async def test_set_charge_target_soc_writes_only_the_target_register():
+    """set_charge_target_soc adjusts the target SOC without touching any enable bit."""
+    assert commands.set_charge_target_soc(45) == [
+        WriteHoldingRegisterRequest(RegisterMap.CHARGE_TARGET_SOC, 45),
+    ]
+    assert commands.set_charge_target_soc_3ph(45) == [
+        WriteHoldingRegisterRequest(RegisterMap.CHARGE_TARGET_SOC_3PH, 45),
+    ]
+
+    # The whole point: no enable side effects (unlike set_charge_target_enabled).
+    for reqs in (commands.set_charge_target_soc(45), commands.set_charge_target_soc_3ph(45)):
+        written = {r.register for r in reqs}
+        assert RegisterMap.ENABLE_CHARGE not in written
+        assert RegisterMap.ENABLE_CHARGE_TARGET not in written
+        assert RegisterMap.AC_CHARGE_ENABLE not in written
+
+    # 100 writes the register as-is — no special "disable" folding.
+    assert commands.set_charge_target_soc(100) == [
+        WriteHoldingRegisterRequest(RegisterMap.CHARGE_TARGET_SOC, 100),
+    ]
+
+    # Same [4-100] bound as set_charge_target_enabled.
+    for fn in (commands.set_charge_target_soc, commands.set_charge_target_soc_3ph):
+        with pytest.raises(ValueError, match=r"Charge Target SOC \(0\) must be in \[4-100\]\%"):
+            fn(0)
+        with pytest.raises(ValueError, match=r"Charge Target SOC \(101\) must be in \[4-100\]\%"):
+            fn(101)
 
 
 async def test_set_charge():

--- a/tests/client/test_inverter_commands.py
+++ b/tests/client/test_inverter_commands.py
@@ -80,11 +80,33 @@ def test_mixin_classvar_does_not_leak_into_model_dump():
 
 def test_inverter_set_charge_target_emits_correct_writes():
     inv = _single_phase()
-    assert inv.set_charge_target(80) == [
+    assert inv.set_charge_target_enabled(80) == [
         WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE, 1),
         WriteHoldingRegisterRequest(RegisterMap.ENABLE_CHARGE_TARGET, 1),
         WriteHoldingRegisterRequest(RegisterMap.CHARGE_TARGET_SOC, 80),
     ]
+
+
+def test_inverter_set_charge_target_is_deprecated_alias():
+    """The mixin set_charge_target is a deprecated alias for set_charge_target_enabled (1ph + 3ph)."""
+    with pytest.warns(DeprecationWarning):
+        assert _single_phase().set_charge_target(80) == _single_phase().set_charge_target_enabled(80)
+    with pytest.warns(DeprecationWarning):
+        assert _three_phase().set_charge_target(80) == _three_phase().set_charge_target_enabled(80)
+
+
+def test_inverter_set_charge_target_soc_writes_only_hr116():
+    """Single-phase set_charge_target_soc writes only HR(116) — no enable bits."""
+    requests = _single_phase().set_charge_target_soc(55)
+    assert requests == [WriteHoldingRegisterRequest(RegisterMap.CHARGE_TARGET_SOC, 55)]
+    requests[0].encode()  # encode round-trip confirms allowlist membership
+
+
+def test_three_phase_set_charge_target_soc_writes_only_hr1111():
+    """Three-phase set_charge_target_soc writes only HR(1111) — no enable bits, no single-phase HR(116)."""
+    requests = _three_phase().set_charge_target_soc(55)
+    assert requests == [WriteHoldingRegisterRequest(RegisterMap.CHARGE_TARGET_SOC_3PH, 55)]
+    requests[0].encode()
 
 
 def test_inverter_set_enable_charge_emits_single_write():
@@ -266,7 +288,7 @@ def test_three_phase_set_battery_reserve_soc_available():
 
 def test_three_phase_set_charge_target_uses_correct_registers():
     """set_charge_target on three-phase emits HR(1112) AC_CHARGE_ENABLE + HR(1111) charge target."""
-    requests = _three_phase().set_charge_target(80)
+    requests = _three_phase().set_charge_target_enabled(80)
     regs = {r.register: r.value for r in requests}
     assert RegisterMap.AC_CHARGE_ENABLE in regs, "three-phase must enable AC charge (HR 1112)"
     assert RegisterMap.CHARGE_TARGET_SOC_3PH in regs, "three-phase must write charge target to HR(1111)"
@@ -279,7 +301,7 @@ def test_three_phase_set_charge_target_uses_correct_registers():
 
 def test_single_phase_set_charge_target_unchanged():
     """Regression: single-phase set_charge_target must still use HR(96) and HR(116)."""
-    requests = _single_phase().set_charge_target(80)
+    requests = _single_phase().set_charge_target_enabled(80)
     regs = {r.register: r.value for r in requests}
     assert RegisterMap.ENABLE_CHARGE in regs
     assert RegisterMap.CHARGE_TARGET_SOC in regs
@@ -319,12 +341,12 @@ def test_three_phase_set_battery_soc_reserve_validates():
 def test_three_phase_set_charge_target_validates():
     """Out-of-range charge target must raise ValueError via the 3ph primitive."""
     with pytest.raises(ValueError, match=r"\[4-100\]"):
-        _three_phase().set_charge_target(101)
+        _three_phase().set_charge_target_enabled(101)
 
 
 def test_three_phase_set_charge_target_100_disables_charge_target():
     """set_charge_target(100) on three-phase disables ENABLE_CHARGE_TARGET and writes HR(1111)=100."""
-    requests = _three_phase().set_charge_target(100)
+    requests = _three_phase().set_charge_target_enabled(100)
     regs = {r.register: r.value for r in requests}
     assert RegisterMap.ENABLE_CHARGE_TARGET in regs
     assert regs[RegisterMap.ENABLE_CHARGE_TARGET] == 0


### PR DESCRIPTION
First of the two command helpers GivTCP's modbusv2 port needs (#243).

## What & why

GivTCP's `write.py` calls a fork helper `set_charge_target_only` to nudge the charge-target SOC while leaving the enable bits as the user set them. We had no equivalent — `set_charge_target` always force-enables charging (HR96) and the target flag (HR20) as a side effect.

- **New** `set_charge_target_soc(soc)` (plus `set_charge_target_soc_3ph` and the three-phase mixin override) — writes only `CHARGE_TARGET_SOC` (HR116) / `CHARGE_TARGET_SOC_3PH` (HR1111), nothing else. It's the non-EMS sibling of the existing `set_ems_charge_target_soc`.
- **Renamed** the misleadingly-named `set_charge_target` → `set_charge_target_enabled` (and `set_charge_target_3ph` → `set_charge_target_enabled_3ph`), since that helper does far more than its name implied. The old names stay as `@deprecated` aliases, so this is backwards-compatible; they'd come out in 3.0.

Both target registers were already in the write-safety allowlists, so there are no new writable registers here.

## Scope

This is part 1 of #243. The per-slot (non-EMS) target-SOC writes are deferred — they'd add ~20 currently-unverified registers to the write-safety gate, and I'd rather cross-check those addresses against the app's Direct Control list first (#48). So this PR intentionally does not close #243.

## Verification

- Full `tox` matrix (py311–py314 + format + lint + build) green; 1035 tests pass.
- TDD throughout — the new behaviour and the deprecation each had a failing test first.
- A register-safety pass confirmed no new write surface and no behaviour drift in the renamed functions.

Docs (migration guide, usage, README) updated to the new names; the migration guide's `set_charge_target_only` row now points at `set_charge_target_soc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced clearer charge target command helpers: `set_charge_target_enabled()` for enabling/disabling targets and `set_charge_target_soc()` for updating target percentage without changing enable states.
  * Added corresponding three-phase inverter variants.

* **Deprecations**
  * Legacy charge target commands are now deprecated; existing code remains functional but should migrate to new APIs.

* **Documentation**
  * Updated examples and migration guides to reflect the new command names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->