### PR TITLE
fix(inverter): correct three-phase i_battery scale (deci → centi)

### DIFF
--- a/givenergy_modbus/model/inverter_threephase.py
+++ b/givenergy_modbus/model/inverter_threephase.py
@@ -372,8 +372,9 @@ _THREE_PHASE_LUT = {
     "v_inv_bus": Def(C.deci, None, IR(1135)),
     "p_battery_discharge": Def(C.uint32, C.deci, IR(1136), IR(1137), max=100000),
     "p_battery_charge": Def(C.uint32, C.deci, IR(1138), IR(1139), max=100000),
-    # i_battery shadows single-phase IR(51); same converter, different scale
-    "i_battery": Def(C.int16, C.deci, IR(1140), min=-500.0, max=500.0),
+    # i_battery shadows single-phase IR(51); same converter and scale (centi).
+    # Field-confirmed centi against a GIV-3HY-11 HV capture (V×I vs p_battery_charge).
+    "i_battery": Def(C.int16, C.centi, IR(1140), min=-500.0, max=500.0),
     #
     # Input Registers 1180–1192 — EPS
     #

--- a/givenergy_modbus/model/inverter_threephase.py
+++ b/givenergy_modbus/model/inverter_threephase.py
@@ -374,7 +374,8 @@ _THREE_PHASE_LUT = {
     "p_battery_charge": Def(C.uint32, C.deci, IR(1138), IR(1139), max=100000),
     # i_battery shadows single-phase IR(51); same converter and scale (centi).
     # Field-confirmed centi against a GIV-3HY-11 HV capture (V×I vs p_battery_charge).
-    "i_battery": Def(C.int16, C.centi, IR(1140), min=-500.0, max=500.0),
+    # Bounds match single-phase (±300 A); a centi-scaled int16 caps at ±327.67 anyway.
+    "i_battery": Def(C.int16, C.centi, IR(1140), min=-300.0, max=300.0),
     #
     # Input Registers 1180–1192 — EPS
     #

--- a/givenergy_modbus/model/register.py
+++ b/givenergy_modbus/model/register.py
@@ -552,8 +552,8 @@ class RegisterMetadataMixin:
         """Decimal places for ``name`` per its register scaling (None if non-numeric/unknown).
 
         Precision is model-specific: the same attribute may scale differently
-        across models (e.g. ``i_battery`` is centivolts on single-phase but
-        decivolts on three-phase), so always query the concrete model.
+        across models (e.g. ``p_pv1`` is raw watts on single-phase but a
+        deci-scaled float on three-phase), so always query the concrete model.
         """
         return cls.REGISTER_GETTER.precision_of(name)
 

--- a/tests/model/test_inverter_threephase.py
+++ b/tests/model/test_inverter_threephase.py
@@ -135,7 +135,7 @@ def test_energy_totals():
         (IR(1067), 5000, "f_ac1", 50.0),
         (IR(1068), 65535 - 100 + 1, "power_factor", -100),  # int16 negative
         (IR(1132), 75, "battery_soc", 75),
-        (IR(1140), 65536 - 50, "i_battery", -5.0),  # int16 at deci scale
+        (IR(1140), 65536 - 50, "i_battery", -0.5),  # int16 at centi scale
         (HR(1002), 95, "active_rate", 95),
     ],
 )
@@ -143,6 +143,18 @@ def test_individual_fields(reg, value, field, expected):
     cache = _cache({reg: value})
     tph = ThreePhaseInverter.from_register_cache(cache)
     assert getattr(tph, field) == expected
+
+
+def test_i_battery_centi_scale():
+    """i_battery on three-phase is centi (÷100), matching single-phase IR(51).
+
+    Field-confirmed against a real GIV-3HY-11 HV capture: the V×I identity at the
+    battery terminals only balances against p_battery_charge under the centi scale.
+    """
+    neg = ThreePhaseInverter.from_register_cache(_cache({IR(1140): 65536 - 50}))
+    assert neg.i_battery == pytest.approx(-0.50)
+    pos = ThreePhaseInverter.from_register_cache(_cache({IR(1140): 250}))
+    assert pos.i_battery == pytest.approx(2.50)
 
 
 def test_three_phase_inverter_slot_map():

--- a/tests/model/test_register.py
+++ b/tests/model/test_register.py
@@ -629,14 +629,15 @@ def test_getter_precision_of_known_and_unknown():
 def test_model_precision_of_is_model_specific():
     """The same attribute can scale differently per model — query the concrete model.
 
-    i_battery is centivolts (2 dp) on single-phase but decivolts (1 dp) on
-    three-phase; this is the whole reason precision is exposed per model.
+    p_pv1 is raw watts (uint16, 0 dp) on single-phase (IR18) but a deci-scaled
+    float (1 dp) on three-phase (IR1017/1018); this is the whole reason precision
+    is exposed per model.
     """
     from givenergy_modbus.model.inverter import SinglePhaseInverter
     from givenergy_modbus.model.inverter_threephase import ThreePhaseInverter
 
-    assert SinglePhaseInverter.precision_of("i_battery") == 2
-    assert ThreePhaseInverter.precision_of("i_battery") == 1
+    assert SinglePhaseInverter.precision_of("p_pv1") == 0
+    assert ThreePhaseInverter.precision_of("p_pv1") == 1
     # A computed attribute (not register-backed) falls through to None.
     assert SinglePhaseInverter.precision_of("p_pv") is None
 


### PR DESCRIPTION
## What

`ThreePhaseInverter.i_battery` (IR1140) was defined with the `deci` converter (÷10) but should be `centi` (÷100), matching the single-phase definition (IR51). It was decoding 10× too large (e.g. −1.7 A where the real current was −0.17 A).

## Evidence

This came out of decoding the first real three-phase HV capture (a GIV-3HY-11, via [givenergy-hass#174](https://github.com/dewet22/givenergy-hass/issues/174)). Cross-checking the battery current against the V×I identity at the battery terminals — a direct physical relationship, independent of any system-balance assumptions:

| `v_battery_bms` | raw IR(1140) | as deci | as centi | `p_battery_charge` (validated) |
|---|---|---|---|---|
| 470.3 V | −17 | −1.7 A → −799 W | −0.17 A → **−80 W** | **86.4 W** |
| 470.3 V | −16 | −1.6 A → −752 W | −0.16 A → **−75 W** | **76.1 W** |
| 470.3 V | −13 | −1.3 A → −611 W | −0.13 A → **−61 W** | **62.8 W** |

V×I only balances against the independently-validated `p_battery_charge` under the **centi** scale. The original `deci` was an authoring-time guess (no three-phase hardware was available); this is the first time it met a real ammeter.

## Test changes

- Regression test asserting the centi decode, plus the existing parametrised case updated (−5.0 → −0.5).
- The per-model precision test (and the `precision_of` docstring) used `i_battery` as its example of "scales differently per model" — which no longer holds now both models are centi. Repointed to `p_pv1`, a genuine raw-watts (single-phase) vs deci-float (three-phase) divergence.

Full suite green (1031 passed).

Closes #264

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected battery current measurement scaling and valid operating range for three-phase inverters to ensure accurate readings during operation.

* **Documentation**
  * Enhanced documentation to clarify that measurement precision, scaling and ranges vary across different inverter models.

* **Tests**
  * Updated tests to verify correct battery current measurement scaling and range handling for three-phase inverters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->