### PR TITLE
feat(inverter): derive three-phase p_battery and e_battery_throughput

### DIFF
--- a/givenergy_modbus/model/inverter_threephase.py
+++ b/givenergy_modbus/model/inverter_threephase.py
@@ -447,9 +447,20 @@ class ThreePhaseInverterRegisterGetter(RegisterGetter):
     Merges the single-phase SinglePhaseInverterRegisterGetter LUT with three-phase-specific
     registers. Three-phase entries win for any key that appears in both (e.g.
     battery_soc moves from IR(59) to IR(1132)).
+
+    p_battery and e_battery_throughput are dropped from the merged LUT: on three-phase
+    they are DERIVED @computed_field properties on ThreePhaseInverter (from the native
+    p_battery_charge/discharge and the charge/discharge energy totals). Left register-backed
+    they would inherit single-phase IR(52) / IR(6,7), which three-phase firmware does not
+    populate (they read frozen) — and a generated pydantic field cannot be shadowed by a
+    same-named computed_field.
     """
 
-    REGISTER_LUT = dict(SinglePhaseInverterRegisterGetter.REGISTER_LUT, **_THREE_PHASE_LUT)
+    REGISTER_LUT = {
+        k: v
+        for k, v in dict(SinglePhaseInverterRegisterGetter.REGISTER_LUT, **_THREE_PHASE_LUT).items()
+        if k not in ("p_battery", "e_battery_throughput")
+    }
 
 
 _ThreePhaseInverterBase = create_model(  # type: ignore[call-overload]
@@ -548,6 +559,33 @@ class ThreePhaseInverter(  # type: ignore[valid-type,misc]
     def battery_discharge_power(self) -> float | None:
         """Non-negative battery discharge power (W); aliases p_battery_discharge (#205)."""
         return self.p_battery_discharge  # type: ignore[attr-defined]
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def p_battery(self) -> float | None:
+        """Net battery power (W); +ve = discharging, −ve = charging (#262).
+
+        Derived from the native p_battery_discharge − p_battery_charge registers; the
+        inherited single-phase IR(52) reads frozen on three-phase firmware. Sign matches
+        single-phase, where battery_discharge_power = max(0, p_battery). Returns None if
+        either input is None.
+        """
+        if self.p_battery_discharge is None or self.p_battery_charge is None:  # type: ignore[attr-defined]
+            return None
+        return self.p_battery_discharge - self.p_battery_charge  # type: ignore[attr-defined]
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def e_battery_throughput(self) -> float | None:
+        """Total battery energy throughput (kWh): charge_total + discharge_total (#262).
+
+        Derived from the native energy totals (IR1394/5 + IR1390/1); the inherited
+        single-phase e_battery_throughput (IR6/7) reads frozen on three-phase firmware.
+        Returns None if either input is None.
+        """
+        if self.e_battery_charge_total is None or self.e_battery_discharge_total is None:  # type: ignore[attr-defined]
+            return None
+        return self.e_battery_charge_total + self.e_battery_discharge_total  # type: ignore[attr-defined]
 
     @property
     def slot_map(self) -> SlotMap:

--- a/tests/model/test_inverter_threephase.py
+++ b/tests/model/test_inverter_threephase.py
@@ -1,7 +1,12 @@
 import pytest
 
 from givenergy_modbus.model.inverter import Model, SinglePhaseInverter, Status
-from givenergy_modbus.model.inverter_threephase import THREE_PHASE_SLOTS, ThreePhaseInverter, select_inverter
+from givenergy_modbus.model.inverter_threephase import (
+    THREE_PHASE_SLOTS,
+    ThreePhaseInverter,
+    ThreePhaseInverterRegisterGetter,
+    select_inverter,
+)
 from givenergy_modbus.model.register import HR, IR
 from givenergy_modbus.model.register_cache import RegisterCache
 
@@ -143,6 +148,54 @@ def test_individual_fields(reg, value, field, expected):
     cache = _cache({reg: value})
     tph = ThreePhaseInverter.from_register_cache(cache)
     assert getattr(tph, field) == expected
+
+
+def test_p_battery_derived_from_charge_discharge():
+    """Three-phase p_battery is derived: discharge − charge (+ve = discharging).
+
+    Sign matches single-phase, where battery_discharge_power = max(0, p_battery).
+    The inherited single-phase IR(52) reads frozen on three-phase firmware, so the
+    register-backed field is dropped in favour of this computed one.
+    """
+    # discharge 0, charge 200.0 → -200.0 (charging)
+    charging = ThreePhaseInverter.from_register_cache(_cache({IR(1136): 0, IR(1137): 0, IR(1138): 0, IR(1139): 2000}))
+    assert charging.p_battery == pytest.approx(-200.0)  # type: ignore[attr-defined]
+    assert charging.battery_charge_power == pytest.approx(200.0)  # type: ignore[attr-defined]
+    assert charging.battery_discharge_power == pytest.approx(0.0)  # type: ignore[attr-defined]
+
+    # discharge 350.0, charge 0 → +350.0 (discharging)
+    discharging = ThreePhaseInverter.from_register_cache(
+        _cache({IR(1136): 0, IR(1137): 3500, IR(1138): 0, IR(1139): 0})
+    )
+    assert discharging.p_battery == pytest.approx(350.0)  # type: ignore[attr-defined]
+
+    # Either input missing → None (matches single-phase computed-field posture)
+    assert ThreePhaseInverter.from_register_cache(_cache({IR(1136): 0, IR(1137): 100})).p_battery is None  # type: ignore[attr-defined]
+    assert ThreePhaseInverter.from_register_cache(RegisterCache()).p_battery is None  # type: ignore[attr-defined]
+
+    assert "p_battery" in discharging.model_dump()
+
+
+def test_e_battery_throughput_derived_from_totals():
+    """Three-phase e_battery_throughput = charge_total + discharge_total (kWh)."""
+    inv = ThreePhaseInverter.from_register_cache(_cache({IR(1390): 0, IR(1391): 100, IR(1394): 0, IR(1395): 50}))
+    # discharge_total 10.0 + charge_total 5.0 = 15.0
+    assert inv.e_battery_throughput == pytest.approx(15.0)  # type: ignore[attr-defined]
+
+    # Either input missing → None
+    missing = ThreePhaseInverter.from_register_cache(_cache({IR(1394): 0, IR(1395): 50}))
+    assert missing.e_battery_throughput is None  # type: ignore[attr-defined]
+    assert ThreePhaseInverter.from_register_cache(RegisterCache()).e_battery_throughput is None  # type: ignore[attr-defined]
+
+    assert "e_battery_throughput" in inv.model_dump()
+
+
+def test_derived_battery_fields_are_not_register_backed():
+    """p_battery / e_battery_throughput are computed fields, not LUT entries."""
+    assert ThreePhaseInverter.precision_of("p_battery") is None
+    assert ThreePhaseInverter.precision_of("e_battery_throughput") is None
+    assert ThreePhaseInverterRegisterGetter.registers_of("p_battery") == ()
+    assert ThreePhaseInverterRegisterGetter.registers_of("e_battery_throughput") == ()
 
 
 def test_three_phase_inverter_slot_map():


### PR DESCRIPTION
## What

On three-phase, `p_battery` and `e_battery_throughput` were *inherited* from the single-phase LUT (via the `dict(SP_LUT, **_THREE_PHASE_LUT)` merge), so they pointed at single-phase registers (`IR52`, `IR6/7`) that three-phase firmware never populates — they read **frozen**. This replaces them with derived `@computed_field` properties from the native three-phase registers:

- `p_battery` = `p_battery_discharge − p_battery_charge` (+ve = discharging, −ve = charging — matching the single-phase sign convention where `battery_discharge_power = max(0, p_battery)`)
- `e_battery_throughput` = `e_battery_charge_total + e_battery_discharge_total`

## Why

This was the frozen-battery-fields symptom from [givenergy-hass#174](https://github.com/dewet22/givenergy-hass/issues/174). hass already resolves these consumer-side; this is the upstream facade so any consumer keying off `p_battery` (cli, others) gets correct values on three-phase without per-model branching. The premise was validated against the GIV-3HY-11 capture: `p_battery_charge`/`p_battery_discharge` decode correctly and the sign is unambiguous.

## Implementation note

Both keys are dropped from the merged `REGISTER_LUT` before the computed properties are defined — pydantic v2 will not let a `@computed_field` shadow a generated model field. `build()`/`to_fields()`/`precision_of()`/`registers_of()` simply stop emitting them (confirmed: `precision_of` → None, `registers_of` → ()), and the metadata path already tolerates non-LUT computed fields (the existing `battery_charge_power` precedent). Return type is `float | None` (inputs are deci floats), None-propagating like the single-phase computed fields.

## Out of scope

The inherited single-phase `t_battery` (IR56) is likewise frozen on three-phase but has no inverter-level three-phase source register, so it can't be derived the same way — left as a separate open question.

Full suite green (1033 passed).

Closes #262