### PR TITLE
feat(model): compact probe-dump serialisation (to_compact/parse_compact)

### DIFF
--- a/givenergy_modbus/model/register_cache.py
+++ b/givenergy_modbus/model/register_cache.py
@@ -264,8 +264,10 @@ def _compact_blocks(indices: list[int]) -> list[tuple[int, int]]:
 
     A block never crosses a 60-aligned boundary and never spans a gap, so whole probe
     reads emit as clean ``(60k, 60)`` rows that can't overlap, while sparse/partial data
-    still round-trips exactly (no zero-fill).
+    still round-trips exactly (no zero-fill). Empty input yields no blocks.
     """
+    if not indices:
+        return []
     blocks: list[tuple[int, int]] = []
     base = prev = indices[0]
     for idx in indices[1:]:

--- a/givenergy_modbus/model/register_cache.py
+++ b/givenergy_modbus/model/register_cache.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import logging
+import re
 from collections import defaultdict
 from typing import TYPE_CHECKING
 
@@ -237,3 +238,123 @@ class RegisterCache(defaultdict[Register, int]):
         if start_val is None or end_val is None or start_val == 60 or end_val == 60:
             return None
         return TimeSlot.from_repr(start_val, end_val)
+
+
+# --- Compact probe-dump serialisation -----------------------------------------------------------
+# A human-legible hex dump of register ranges, peer to RegisterCache.json()/from_json() but
+# multi-device. Kept as a text format (vs json) because users paste these redacted dumps into
+# bug reports and can eyeball the plaintext values. Serialisation lives here; file I/O (share-safe
+# writes, size caps, provenance) is the caller's (e.g. givenergy-cli).
+
+_REG_CLS: dict[str, type[Register]] = {"HR": HR, "IR": IR, "MR": MR}
+_COMPACT_STRIDE = 60  # GivEnergy probes read 60-aligned, 60-long blocks; emit on that grid.
+
+# Device-inline row: ``0x<dev>:<BANK>(<base>,<count>) <hex>`` (the canonical format).
+_COMPACT_ROW_RE = re.compile(r"^0x([0-9a-fA-F]+):(HR|IR|MR)\((\d+),(\d+)\)\s+([0-9a-fA-F]*)$")
+# TODO(remove in a near-future version once confident no old-format dumps remain): legacy format
+# put the device in a ``# <BANK> probe @ device 0x<NN> …`` header preceding bare colon rows.
+_COMPACT_LEGACY_HEADER_RE = re.compile(r"^#\s*\w+\s+probe\s+@\s+device\s+0x([0-9a-fA-F]+)")
+_COMPACT_LEGACY_ROW_RE = re.compile(r"^(HR|IR|MR)\((\d+),(\d+)\):\s+([0-9a-fA-F]*)$")
+# A bare-hex line — a continuation of a value reflowed across lines by copy-paste.
+_COMPACT_HEX_RE = re.compile(r"^[0-9a-fA-F]+$")
+
+
+def _compact_blocks(indices: list[int]) -> list[tuple[int, int]]:
+    """Group sorted register indices into (base, count) blocks, split at the 60-stride.
+
+    A block never crosses a 60-aligned boundary and never spans a gap, so whole probe
+    reads emit as clean ``(60k, 60)`` rows that can't overlap, while sparse/partial data
+    still round-trips exactly (no zero-fill).
+    """
+    blocks: list[tuple[int, int]] = []
+    base = prev = indices[0]
+    for idx in indices[1:]:
+        if idx == prev + 1 and idx // _COMPACT_STRIDE == base // _COMPACT_STRIDE:
+            prev = idx
+        else:
+            blocks.append((base, prev - base + 1))
+            base = prev = idx
+    blocks.append((base, prev - base + 1))
+    return blocks
+
+
+def to_compact(caches: "dict[int, RegisterCache]") -> str:
+    """Serialise device register caches to the compact hex probe-dump format.
+
+    Peer to :meth:`RegisterCache.json` — a pure ``str`` projection with no file I/O. Each
+    row is self-describing::
+
+        0x32:HR(0,60) 0000000500ff…
+
+    ``0x<dev>`` is the device address, ``HR``/``IR``/``MR`` the bank, ``(<base>,<count>)`` the
+    range, then ``count × 4`` lowercase hex chars (one 16-bit register per 4). Blocks are split
+    on the 60-register grid GivEnergy probes read on, so whole-block caches round-trip as clean,
+    non-overlapping rows. Rows are emitted in (device, bank, base) order for stable output.
+    Provenance (host:port) is the caller's to add as an ignored ``#`` comment.
+    """
+    lines: list[str] = []
+    for device in sorted(caches):
+        by_bank: dict[str, dict[int, int]] = {}
+        for reg, val in caches[device].items():
+            if isinstance(val, int) and not isinstance(val, bool):
+                by_bank.setdefault(reg.reg_type, {})[reg.index] = val
+        for bank in ("HR", "IR", "MR"):
+            present = by_bank.get(bank)
+            if not present:
+                continue
+            for base, count in _compact_blocks(sorted(present)):
+                hexstr = "".join(f"{present[base + i] & 0xFFFF:04x}" for i in range(count))
+                lines.append(f"0x{device:02x}:{bank}({base},{count}) {hexstr}")
+    return "".join(line + "\n" for line in lines)
+
+
+def parse_compact(text: str) -> "dict[int, RegisterCache]":
+    """Parse a compact probe-dump back into device caches (inverse of :func:`to_compact`).
+
+    Lenient and order-agnostic — the input is human-pasted diagnostic text. Accepts the
+    device-inline grammar emitted by :func:`to_compact` and (transitionally) the legacy
+    header format. Hex reflowed across lines by copy-paste is reassembled; a row that still
+    doesn't reach its declared length is skipped without aborting the rest. ``#`` comments
+    (provenance), ``Probing …`` status, ``..`` timed-out ranges and blank lines are ignored.
+    """
+    caches: dict[int, RegisterCache] = {}
+    legacy_device: int | None = None
+    lines = [line.strip() for line in text.splitlines()]
+    i, n = 0, len(lines)
+    while i < n:
+        line = lines[i]
+        i += 1
+
+        header = _COMPACT_LEGACY_HEADER_RE.match(line)
+        if header:
+            legacy_device = int(header.group(1), 16)
+            continue
+
+        inline = _COMPACT_ROW_RE.match(line)
+        legacy = _COMPACT_LEGACY_ROW_RE.match(line) if not inline else None
+        if inline:
+            device = int(inline.group(1), 16)
+            bank, base, count, hexstr = inline.group(2), int(inline.group(3)), int(inline.group(4)), inline.group(5)
+        elif legacy is not None:
+            if legacy_device is None:
+                _logger.warning("Skipping legacy compact row before any device header: %r", line)
+                continue
+            device = legacy_device
+            bank, base, count, hexstr = legacy.group(1), int(legacy.group(2)), int(legacy.group(3)), legacy.group(4)
+        else:
+            continue  # comment / Probing… / `..` timed-out / blank / stray
+
+        want = count * 4
+        # Reassemble hex reflowed across lines: pull in following bare-hex continuation lines.
+        while len(hexstr) < want and i < n and _COMPACT_HEX_RE.match(lines[i]):
+            hexstr += lines[i]
+            i += 1
+        if len(hexstr) != want:
+            _logger.warning("Skipping compact row with %d hex chars, expected %d: %r", len(hexstr), want, line)
+            continue
+
+        cls = _REG_CLS[bank]
+        cache = caches.setdefault(device, RegisterCache())
+        for j in range(count):
+            cache[cls(base + j)] = int(hexstr[j * 4 : j * 4 + 4], 16)
+    return caches

--- a/tests/model/test_register_cache.py
+++ b/tests/model/test_register_cache.py
@@ -2,7 +2,7 @@ import datetime
 
 from givenergy_modbus.model import TimeSlot
 from givenergy_modbus.model.register import HR, IR, MR
-from givenergy_modbus.model.register_cache import RegisterCache, parse_compact, to_compact
+from givenergy_modbus.model.register_cache import RegisterCache, _compact_blocks, parse_compact, to_compact
 from tests.model.test_register import HOLDING_REGISTERS, INPUT_REGISTERS
 
 
@@ -30,6 +30,11 @@ def test_compact_round_trip():
         0x32: RegisterCache({IR(60 + i): 0xABCD - i for i in range(60)}),
     }
     assert parse_compact(to_compact(caches)) == caches
+
+
+def test_compact_blocks_empty():
+    """The block grouper is a total function: empty indices → no blocks."""
+    assert _compact_blocks([]) == []
 
 
 def test_to_compact_grammar_and_60_aligned_blocking():

--- a/tests/model/test_register_cache.py
+++ b/tests/model/test_register_cache.py
@@ -2,7 +2,7 @@ import datetime
 
 from givenergy_modbus.model import TimeSlot
 from givenergy_modbus.model.register import HR, IR, MR
-from givenergy_modbus.model.register_cache import RegisterCache
+from givenergy_modbus.model.register_cache import RegisterCache, parse_compact, to_compact
 from tests.model.test_register import HOLDING_REGISTERS, INPUT_REGISTERS
 
 
@@ -21,6 +21,70 @@ def test_to_from_json():
 def test_to_from_json_mr():
     """Ensure MR keys round-trip through JSON serialisation."""
     assert RegisterCache.from_json('{"MR(0)": 1, "MR:5": 99}') == {MR(0): 1, MR(5): 99}
+
+
+def test_compact_round_trip():
+    """to_compact → parse_compact reproduces the device caches (multi-device, multi-bank, full blocks)."""
+    caches = {
+        0x31: RegisterCache({**{HR(i): i for i in range(60)}, **{IR(i): i * 2 for i in range(60)}}),
+        0x32: RegisterCache({IR(60 + i): 0xABCD - i for i in range(60)}),
+    }
+    assert parse_compact(to_compact(caches)) == caches
+
+
+def test_to_compact_grammar_and_60_aligned_blocking():
+    """Device-inline rows, 60-aligned non-overlapping blocks, lowercase hex."""
+    caches = {0x31: RegisterCache({HR(i): i for i in range(120)})}
+    out = to_compact(caches)
+    lines = out.splitlines()
+    # HR 0-119 splits at the 60 boundary into two non-overlapping rows, device inline.
+    assert lines[0] == "0x31:HR(0,60) " + "".join(f"{i:04x}" for i in range(60))
+    assert lines[1] == "0x31:HR(60,60) " + "".join(f"{i:04x}" for i in range(60, 120))
+    assert not any("probe @ device" in line for line in lines)  # no header
+
+
+def test_parse_compact_inline_sample():
+    """Parse the device-inline format."""
+    dump = "0x31:HR(0,3) 000000050234\n"
+    assert parse_compact(dump) == {0x31: RegisterCache({HR(0): 0, HR(1): 5, HR(2): 0x0234})}
+
+
+def test_parse_compact_legacy_header_fallback():
+    """Legacy header format (device in a comment, colon rows) still parses, incl. host:port tail."""
+    dump = "# HR probe @ device 0x31 on 192.168.1.5:8899\nHR(0,3): 000000050234\n"
+    assert parse_compact(dump) == {0x31: RegisterCache({HR(0): 0, HR(1): 5, HR(2): 0x0234})}
+
+
+def test_parse_compact_ignores_diagnostics_and_provenance():
+    """Timed-out `..` ranges, `Probing …` status lines, blank lines, and `#` provenance are ignored."""
+    dump = "Probing IR(0,60)…\n# probe of 192.168.1.5:8899\n0x11:IR(0,2) 00010002\nIR(180..239): timed out\n\n"
+    assert parse_compact(dump) == {0x11: RegisterCache({IR(0): 1, IR(1): 2})}
+
+
+def test_parse_compact_order_agnostic():
+    """Rows supplied out of order still produce the right caches."""
+    dump = "0x32:IR(5,1) 0009\n0x31:HR(0,1) 0007\n"
+    assert parse_compact(dump) == {0x31: RegisterCache({HR(0): 7}), 0x32: RegisterCache({IR(5): 9})}
+
+
+def test_parse_compact_tolerates_wrapped_hex():
+    """A reflowed (line-wrapped) hex value reassembles; a garbled row drops without aborting the rest."""
+    # IR(0,3) wants 12 hex chars, reflowed across two lines → reassembles.
+    wrapped = "0x11:IR(0,3) 00010002\n0003\n0x11:IR(10,1) 002a\n"
+    assert parse_compact(wrapped) == {0x11: RegisterCache({IR(0): 1, IR(1): 2, IR(2): 3, IR(10): 0x2A})}
+
+    # Overshooting continuation → only that row drops; the well-formed row still parses.
+    garbled = "0x11:HR(0,2) 0005\nzzzznotsensehex\n0x11:HR(10,1) 002a\n"
+    assert parse_compact(garbled) == {0x11: RegisterCache({HR(10): 0x2A})}
+
+
+def test_parse_compact_merges_concatenated_sections():
+    """Concatenated dumps across devices/banks merge into one cache map."""
+    dump = "0x31:HR(0,1) 0007\n0x32:IR(5,1) 0009\n0x31:IR(0,1) 0003\n"
+    assert parse_compact(dump) == {
+        0x31: RegisterCache({HR(0): 7, IR(0): 3}),
+        0x32: RegisterCache({IR(5): 9}),
+    }
 
 
 def test_from_json_skips_unknown_register_prefix():

--- a/tests/model/test_register_cache.py
+++ b/tests/model/test_register_cache.py
@@ -48,6 +48,17 @@ def test_to_compact_grammar_and_60_aligned_blocking():
     assert not any("probe @ device" in line for line in lines)  # no header
 
 
+def test_to_compact_skips_none_valued_registers():
+    """A None-valued register (the 'unset' sentinel) isn't emitted; the gap splits the run."""
+    out = to_compact({0x31: RegisterCache({HR(0): 5, HR(1): None, HR(2): 7})})
+    assert out == "0x31:HR(0,1) 0005\n0x31:HR(2,1) 0007\n"
+
+
+def test_parse_compact_skips_legacy_row_without_header():
+    """A legacy colon row with no preceding device header is skipped (no device context)."""
+    assert parse_compact("HR(0,1): 0005\n") == {}
+
+
 def test_parse_compact_inline_sample():
     """Parse the device-inline format."""
     dump = "0x31:HR(0,3) 000000050234\n"


### PR DESCRIPTION
## What

Adds `to_compact` / `parse_compact` to `model/register_cache.py` — a modbus-owned serialisation format for the compact register probe-dump, peer to `RegisterCache.json()`/`from_json()` but multi-device (`dict[device_address, RegisterCache]`). Pure `str` ↔ caches; file I/O stays with the caller.

## Why

givenergy-cli's new offline `shell`/`load_capture` parses these dumps to rebuild a `Plant`, and the parser lived CLI-side — so modbus/hass/any tooling analysing a user's pasted probe would reimplement it. This makes the format canonical where the data model lives. Kept as text (not json) because users paste these **redacted** dumps into bug reports and can eyeball plaintext register values.

## Format (device-inline)

```
0x32:HR(0,60) 0000000500ff…
```

Each row is **self-describing** — device address inline, not in a separable comment header. The old format put the device in a `# … @ device 0x31 on host:port` header; that's exactly the line a user drops or censors (it carries their IP), silently corrupting the parse. Backwards-incompatible, but nothing's been captured in the old format yet — and `parse_compact` still accepts it as a transitional fallback (marked `TODO` for removal).

- **Emit:** blocks split on the 60-register grid GivEnergy probes read on (60-aligned, ≤60 long), so whole-block caches round-trip as clean, **non-overlapping** rows; sorted for stable/diffable output.
- **Parse:** lenient and order-agnostic (human-pasted diagnostic input) — reassembles hex reflowed across lines by copy-paste, skips an unparseable row without aborting the rest, ignores `#` comments / `Probing…` / `..` timed-out ranges / blanks.

## Tests

8 cases: round-trip (multi-device/bank, full blocks), 60-aligned non-overlapping emit, inline parse, legacy-header fallback, diagnostics/provenance ignored, line-wrap tolerance + garbled-row drop, order-agnostic, concatenated-section merge. Full suite green; py311–314 + mypy + bandit clean on the changed files.

## Follow-up

The format is device-inline and backwards-incompatible — I'll coordinate with the cli agent to adopt `to_compact`/`parse_compact` as the canonical pair (their `_render_probe_compact`/`parse_probe_dump` become thin callers) and switch `probe --compact` output to the inline grammar. Originated from their request.

Relates to #268 (the discovery half of the same refactor).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added compact serialisation and parsing functions for register cache data, enabling users to export and import configuration state in a human-readable, space-efficient format that handles multiple devices and gracefully tolerates format variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->