### PR TITLE
docs: sweep — fix drift, surface 2.4.0 API, retire stale pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ ENV/
 # Claude Code — local-only, not shared
 .claude/settings.local.json
 .claude/worktrees/
+
+# Internal design-doc scaffolding — not user docs, excluded from the mkdocs build
+docs/superpowers/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,7 @@ moves to 2.4.x. Two behaviour changes lead it, both capture-proven.
   evidence via the displacement-PF identity, and pinned by a golden-master
   test so they can't silently regress.
 - **Migration guide for fork consumers**
-  ([docs/migrating-from-the-async-fork.md](../migrating-from-the-async-fork.md), #244):
+  ([migrating-from-the-async-fork](https://dewet22.github.io/givenergy-modbus/migrating-from-the-async-fork/), #244):
   the import map, polling-lifecycle change, command mapping and attribute
   rename table for moving from the community `givenergy_modbus_async` fork to
   this library — written for GivTCP's port, useful to any fork descendant.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.md.
-3. The pull request should work for Python 3.13 and above. Check
+3. The pull request should work for Python 3.11 and above. Check
    https://github.com/dewet22/givenergy-modbus/actions
    and make sure that the tests pass for all supported Python versions.
 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ async def main():
     client = Client(host="192.168.99.99", port=8899)
     await client.connect()
 
-    # Read current state first (needed for slot_map)
-    await client.refresh_plant(full_refresh=True)
+    # Detect the topology once, then read the config banks (needed for slot_map)
+    await client.detect()
+    await client.load_config()
     plant = client.plant
 
     # Write configuration to the device

--- a/docs/api.md
+++ b/docs/api.md
@@ -16,6 +16,8 @@
 
 ::: givenergy_modbus.model.battery
 
+::: givenergy_modbus.model.register_cache
+
 ::: givenergy_modbus.model
 
 ## PDU

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -163,7 +163,7 @@ Each device model is backed by a `RegisterGetter` subclass that holds a `REGISTE
 - **Register address(es)** — one or more `HR`/`IR`/`MR` addresses; multi-register fields (e.g. `uint32`, strings) list all constituent registers.
 - **Bounds** — optional `min`/`max` in real-world units (post-conversion), used to detect physically impossible values and log violations before committing a bank.
 
-`RegisterCache` is a plain `dict[HR|IR|MR, int]` with coherence checking (serial-number validity) and bounds validation on each incoming bank. Violations are currently logged at ERROR and the bank committed; a future enforcement step will discard the whole bank on any violation.
+`RegisterCache` is a plain `defaultdict[HR|IR|MR, int]` — just storage. Coherence (serial-number validity) and bounds validation live on the `RegisterGetter`, applied by `Plant._commit_bank` as each bank arrives. Several classes of bad bank are already **rejected** outright: an invalid serial, a CRC failure, an all-zero dropout of a previously-populated bank, and a battery sub-bus splice. Bounds violations are the remaining exception — they're logged (at DEBUG) and the bank is still committed, pending the enforcement step tracked by a `TODO` in `_commit_bank`.
 
 ## References
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-Requires **Python 3.14 or later**.
+Requires **Python 3.11 or later**.
 
 ## Stable release
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -4,6 +4,11 @@ The client is async — all network operations must run inside an `asyncio` even
 Commands are plain functions in `givenergy_modbus.client.commands` that return lists of
 requests, which you send via `one_shot_command` or `execute`.
 
+> Coming from the `givenergy-modbus-async` fork? See
+> [Migrating from the async fork](migrating-from-the-async-fork.md) for the lifecycle
+> change (`detect()` + `load_config()`/`refresh()` replacing `refresh_plant`) and the
+> attribute renames.
+
 ## Basic example
 
 ```python
@@ -122,6 +127,14 @@ grid_export` (IR24 = IR42 + IR30) holds at the busbar. These node assignments we
 established empirically against a single-phase Hybrid Gen 1; the three-phase layout
 (whether `p_grid_out` aggregates the inverter phases or stays a separate CT register)
 is not yet confirmed.
+
+### Directional power accessors
+
+If you just want non-negative, sign-resolved power for display, prefer the computed
+accessors over the raw signed registers — they read the same on single- and three-phase:
+`battery_charge_power` / `battery_discharge_power` (split `p_battery` by direction) and
+`grid_import_power` / `grid_export_power` (split the net grid register). Each returns the
+magnitude in its direction and `0` otherwise, so a consumer needn't handle the sign.
 
 ## Tuning timeouts and retries
 
@@ -356,6 +369,32 @@ All model objects are pydantic v2 models:
 plant.inverter.model_dump()       # dict
 plant.inverter.model_dump_json()  # JSON string
 ```
+
+### Register caches
+
+A `RegisterCache` (`plant.register_caches[device_address]`) round-trips two ways:
+
+```python
+from givenergy_modbus.model.register_cache import RegisterCache, to_compact, parse_compact
+
+cache.json()                   # JSON string of {register: value}
+RegisterCache.from_json(text)  # inverse
+
+to_compact({0x32: cache})      # compact hex probe-dump (str), human-legible
+parse_compact(text)            # inverse → {device_address: RegisterCache}
+```
+
+`json()`/`from_json()` are single-cache; `to_compact`/`parse_compact` are multi-device and
+emit the same compact hex format the CLI's `probe --compact` produces, so a register dump
+pasted into a bug report can be reconstructed and replayed offline.
+
+### Sharing a redacted dump
+
+Before sharing a cache or a whole plant, strip the serial numbers. `cache.redact_serials()`
+returns a copy with serial registers date-redacted (family prefix + manufacture week kept,
+unit digits zeroed — the same scheme as the capture-frame redaction below), and
+`plant.redact()` redacts the whole plant. Combine with the serialisers above for a
+share-safe export.
 
 ## Capturing frames for bug reports
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,16 @@ site_name: GivEnergy Modbus
 site_url: https://dewet22.github.io/givenergy-modbus
 repo_url: https://github.com/dewet22/givenergy-modbus
 repo_name: dewet22/givenergy-modbus
+# Kept in the repo as history but excluded from the published site:
+# - release-notes/*: retired per-version pages — CHANGELOG.md is the single source of truth.
+# - the roadmap docs: superseded planning under trunk-based dev (no version-pinned roadmaps).
+# - superpowers/: untracked internal design-doc scaffolding, never user docs.
+exclude_docs: |
+  release-notes/
+  superpowers/
+  post-v2.2-plan.md
+  v2.1-roadmap.md
+  post-v2-improvement-plan.md
 nav:
   - Home: index.md
   - Installation: installation.md
@@ -12,16 +22,10 @@ nav:
       - Register identification: register-identification.md
       - Hardware & firmware quirks: hardware-firmware-quirks.md
       - Migrating from the async fork: migrating-from-the-async-fork.md
-  - Contributing: contributing.md
-  - Changelog: changelog.md
-  - Release notes:
-      - v2.0: release-notes/v2.0.md
-  - Planning:
-      - Post-v2.2 unified roadmap: post-v2.2-plan.md
-      - v2.1 roadmap: v2.1-roadmap.md
-      - Post-v2.0 improvement plan: post-v2-improvement-plan.md
       - Graph-shaped Plant (#106): plant-device-graph.md
       - Power-flow state (shared spec): flow-state-spec.md
+  - Contributing: contributing.md
+  - Changelog: changelog.md
 theme:
   name: material
   language: en


### PR DESCRIPTION
Broad documentation audit (three parallel agents, cross-checked against current code) + fixes. No code changes.

## Corrections (were wrong / misleading)
- **README** led with the deprecated `refresh_plant(full_refresh=True)` → now `detect()` + `load_config()` (the current lifecycle).
- **Python floor** corrected 3.14/3.13 → **3.11** (`installation.md`, `CONTRIBUTING.md`).
- **architecture.md** `RegisterCache` paragraph rewritten: it's bare `defaultdict` storage; coherence/CRC/all-zero/splice banks are already *rejected* by `Plant._commit_bank`, only bounds is log-and-commit (DEBUG) pending the `TODO`. The old "logged at ERROR, future enforcement will discard" was stale.
- **Broken link** `changelog → migrating-from-the-async-fork` fixed (absolute docs-site URL — resolves on both GitHub and the rendered site, given the root CHANGELOG is include-markdown'd into `docs/changelog.md`).

## New public surface documented
- `docs/api.md`: added `::: givenergy_modbus.model.register_cache` — `to_compact`/`parse_compact` (2.4.0), `json`/`from_json`, `redact_serials` were undocumented.
- `docs/usage.md`: directional-power accessors (#205) as the recommended consumer API; register-cache (de)serialisation; sharing a redacted dump (`redact_serials`/`Plant.redact`); migration-guide link.

## Curation
- **Retired** per-version release-notes from nav — CHANGELOG is the single source of truth (the work since 2.2.0 arrived as steady increments well-captured there; no flagship narrative needed).
- **Archived** the superseded roadmap docs (`v2.1-roadmap`, `post-v2-improvement-plan`, `post-v2.2-plan`) — trunk-based dev no longer pins work to minors.
- Both done via mkdocs `exclude_docs` **in place** (nothing deleted); `plant-device-graph` + `flow-state-spec` (current docs, were mis-filed under Planning) re-homed under Reference.
- `docs/superpowers/` gitignored (untracked internal scaffolding).

## Verification
`mkdocs build --strict` is now **clean** (previously emitted orphan-nav + broken-link warnings); `pytest` 1053 passed (no code touched); prek clean.