### PR TITLE
feat(client): model-aware write rejection at Client boundary (Pillar A)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -55,6 +55,17 @@
           }
         ]
       }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_CONFIG_DIR/scripts/check-inbox.sh",
+            "statusMessage": "Checking coordination inbox..."
+          }
+        ]
+      }
     ]
   }
 }

--- a/docs/post-v2.2-plan.md
+++ b/docs/post-v2.2-plan.md
@@ -42,18 +42,20 @@ are ordered by value and by their interlocks; the hardware-gated work floats.
 highest-value hardening left: writes hit real inverters, and the only protection
 today is register-level.
 
-- **Model-aware write policy at the `Client` boundary.** `Client.one_shot_command()`
-  / `execute()` should reject writes that aren't valid for the *detected* inverter
-  model, complementing the global `WRITE_SAFE_REGISTERS` allowlist enforced in
-  `pdu/write_registers.py::ensure_valid_state()`. A caller can still hand-build a
-  write PDU that bypasses the model-specific command mixins; this closes that gap.
-  Conservative default when capabilities are unknown. Tests must cover direct
-  `WriteHoldingRegisterRequest` construction, not just the high-level helpers.
-- **Dry-run validation.** A supported way to encode and validate a request list
-  without transmitting — `client.validate_requests(...)` or
-  `one_shot_command(..., dry_run=True)` — reporting register, value, device
-  address and rejection reason. Lets downstream integrations check before
-  enabling live writes.
+- ~~**Model-aware command routing (#203)**~~ — **shipped PR #215 (2026-06-07).**
+  `_ThreePhaseCommands` now overrides `set_mode_storage`, `set_battery_soc_reserve`,
+  `set_charge_target`, and `set_battery_reserve_soc` to target the correct three-phase
+  registers; `_ThreePhaseCommands.WRITE_SAFE_REGISTERS` is defined. `set_battery_reserve_soc`
+  (HR 1078) moved off the universal mixin where it didn't belong.
+- ~~**Model-aware write policy at the `Client` boundary.**~~ — **shipped 2026-06-17.**
+  `one_shot_command()` now validates every `WriteHoldingRegisterRequest` against
+  `_ThreePhaseCommands.WRITE_SAFE_REGISTERS` (three-phase) or
+  `_InverterCommands.WRITE_SAFE_REGISTERS` (single-phase / undetected), raising
+  `InvalidPduState` before any frame hits the wire. Closes the bypass path where
+  a hand-built PDU skipped the command-mixin checks.
+- ~~**Dry-run validation.**~~ — **shipped 2026-06-17.**
+  `one_shot_command(..., dry_run=True)` validates but does not transmit; lets
+  downstream integrations check a request list without a live connection.
 - **Interlock:** high-risk writes gate on register provenance (Pillar B).
 
 ### Pillar B — Register provenance and confidence
@@ -80,9 +82,9 @@ inherited mappings),
 [#185](https://github.com/dewet22/givenergy-modbus/issues/185) (scale/unit
 corrections),
 [#200](https://github.com/dewet22/givenergy-modbus/issues/200) (BMS fault
-bitfield) and
-[#209](https://github.com/dewet22/givenergy-modbus/issues/209) (power-factor
-formula).
+bitfield), and
+~~[#209](https://github.com/dewet22/givenergy-modbus/issues/209) (power-factor
+formula) — shipped 2026-06-12~~.
 
 ### Pillar C — Unified data-trust layer
 
@@ -94,9 +96,11 @@ re-deriving its own ad-hoc checks.
 | Signal | Mechanism | Status |
 |---|---|---|
 | Freshness | `Plant.block_age()` (#65) | shipped |
-| Staleness / freeze | `Plant.content_unchanged_seconds()` (#91 primitive) → freeze *verdict* | primitive shipped; [verdict deferred](https://github.com/dewet22/givenergy-modbus/issues/91) |
+| Staleness / freeze | `Plant.content_unchanged_seconds()` (#91 primitive) → freeze *verdict* | primitive shipped (v2.2.0; #91 closed); verdict deliberately not auto-thresholded — healthy batteries hold static content for 7–26 polls; one freeze capture is insufficient to calibrate a threshold that won't false-fire on healthy-but-static hardware |
 | Bank dropout | Pattern A/B rejection ([#78](https://github.com/dewet22/givenergy-modbus/issues/78) / [#147](https://github.com/dewet22/givenergy-modbus/issues/147)) | shipped |
-| Bounds | field-level out-of-range suppression + bank-level detection (#57); whole-bank discard still gated behind a `TODO(enforcement)` in `_commit_bank()` | detection shipped; discard deferred |
+| CRC guard | three-state policy: default=skip-commit, `strict_crc`=raise, `lenient_crc_commit`=opt-in ([#255](https://github.com/dewet22/givenergy-modbus/issues/255)) | shipped 2.3.1 |
+| Sub-bus splice guard | valid-CRC windowed splice rejection + singleton escrow ([#256](https://github.com/dewet22/givenergy-modbus/issues/256)) | shipped 2.3.2 |
+| Bounds | field-level OOB suppression shipped (#57 closed); bank-level whole-bank discard still gated behind `TODO(enforcement)` in `_commit_bank()` — prerequisites (#65 freshness, #91 primitive) now met; flip is the residual open work | field-level shipped; discard deferred |
 | Present-but-unavailable | placeholder for transiently-absent devices ([#213](https://github.com/dewet22/givenergy-modbus/issues/213)) | open |
 | Transient zeros | home-load debounce ([#199](https://github.com/dewet22/givenergy-modbus/issues/199)) | open |
 
@@ -134,7 +138,7 @@ pillar in their own right:
 | Item | Status |
 |---|---|
 | §3 internal refresh serialization (`asyncio.Lock` around detect/load_config/refresh) | not started |
-| §6 broaden golden-frame fixtures (have EMS, single-phase hybrid, AIO; need three-phase, gateway, write success/error) | partial |
+| §6 broaden golden-frame fixtures (have EMS, single-phase hybrid, AIO, three-phase [#270/2.4.0]; still need gateway, write success/error) | partial |
 | §7 mypy `check_untyped_defs` | partial — production on; `tests.*` deferred (58 findings) |
 | §10 public API compatibility tests | partial — `test_deprecation_aliases.py` covers aliases; documented imports + command-helper signatures untested |
 | §4 fail CI on async resource warnings | **done** (`pyproject.toml` filterwarnings) |
@@ -145,17 +149,17 @@ Adjacent protocol-citizen work, tracked independently:
 [#207](https://github.com/dewet22/givenergy-modbus/issues/207) (self-tuning
 skip-if-fresh), [#198](https://github.com/dewet22/givenergy-modbus/issues/198)
 (heartbeat-ACK dropout investigation),
-[#205](https://github.com/dewet22/givenergy-modbus/issues/205) (signed
-directional power sensors).
+~~[#205](https://github.com/dewet22/givenergy-modbus/issues/205) (signed
+directional power sensors) — shipped 2026-06-12~~.
 
 ## Hardware-gated backlog
 
 Throttled by capture availability rather than engineering time — listed so the
 gating is explicit, not scheduled:
 [#193](https://github.com/dewet22/givenergy-modbus/issues/193) (Gen-1 gateway),
-[#169](https://github.com/dewet22/givenergy-modbus/issues/169) /
-[#189](https://github.com/dewet22/givenergy-modbus/issues/189) (inverter
-addressing), [#114](https://github.com/dewet22/givenergy-modbus/issues/114) /
+[#169](https://github.com/dewet22/givenergy-modbus/issues/169) (inverter
+addressing — HYBRID_GEN2/GEN3 verification; ~~[#189](https://github.com/dewet22/givenergy-modbus/issues/189) 0x31 retire shipped 2.3.0~~),
+[#114](https://github.com/dewet22/givenergy-modbus/issues/114) /
 [#115](https://github.com/dewet22/givenergy-modbus/issues/115) (undecoded
 function codes), [#141](https://github.com/dewet22/givenergy-modbus/issues/141)
 (three-phase grid-power nodes),
@@ -178,9 +182,15 @@ as captures arrive.
   fork-migration guide, provenance accessors
   [#248](https://github.com/dewet22/givenergy-modbus/issues/248)). Pillar A
   moves down a line.
-- **2.4.x** — Pillar A (write safety) and Foundations §3.
-- **2.5.x** — Pillar B (provenance) feeding Pillar C (data-trust consolidation),
-  with Foundations §6/§7/§10 alongside.
+- **2.4.0** — shipped 2026-06-17. Diverged again from slated Pillar A: compact
+  probe-dump serialiser `to_compact`/`parse_compact` (#269, new public API) and
+  the first real three-phase capture fixture (#270). Proper semver from here —
+  roadmap items are prioritised, not version-pinned.
+- **2.4.x** — Pillar A remaining (client-boundary model-aware write rejection +
+  dry-run validation) and Foundations §3 (asyncio.Lock refresh serialisation).
+- **2.5.x** — Pillar B (provenance) feeding Pillar C (data-trust consolidation,
+  including the `_commit_bank` discard flip and freeze verdict once threshold is
+  calibrated), with Foundations §6/§7/§10 alongside.
 - **3.0** — Pillar D, only once a second vendor or transport makes the extraction
   real.
 

--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -8,9 +8,11 @@ from asyncio import Future, Queue, StreamReader, StreamWriter, Task
 from collections.abc import Callable
 from typing import Literal
 
+from givenergy_modbus.client.commands import _InverterCommands, _ThreePhaseCommands
 from givenergy_modbus.exceptions import (
     CommunicationError,
     ExceptionBase,
+    InvalidPduState,
     PlantNotDetected,
     PlantTopologyMismatch,
     ReadFailure,
@@ -35,6 +37,7 @@ from givenergy_modbus.pdu import (
     TransparentResponse,
     WriteHoldingRegisterResponse,
 )
+from givenergy_modbus.pdu.write_registers import WriteHoldingRegisterRequest
 
 _logger = logging.getLogger(__name__)
 
@@ -1125,10 +1128,33 @@ class Client:
                 )
 
     async def one_shot_command(
-        self, requests: list[TransparentRequest], timeout=1.5, retries=0, retry_delay: float = 0.5
+        self,
+        requests: list[TransparentRequest],
+        timeout: float = 1.5,
+        retries: int = 0,
+        retry_delay: float = 0.5,
+        dry_run: bool = False,
     ) -> None:
-        """Execute a set of requests. Caller is responsible for connecting first."""
-        await self.execute(requests, timeout=timeout, retries=retries, retry_delay=retry_delay)
+        """Execute write requests, validating each against the detected inverter model.
+
+        Raises InvalidPduState for any write to a register not permitted for the
+        detected model. When capabilities are not yet known, falls back to the
+        universally-applicable single-phase register set (conservative).
+
+        If dry_run is True, validates but does not transmit.
+        """
+        caps = self.plant.capabilities
+        safe = (
+            _ThreePhaseCommands.WRITE_SAFE_REGISTERS
+            if caps is not None and caps.is_three_phase
+            else _InverterCommands.WRITE_SAFE_REGISTERS
+        )
+        model_label = caps.device_type.name if caps is not None else "undetected"
+        for req in requests:
+            if isinstance(req, WriteHoldingRegisterRequest) and req.register not in safe:
+                raise InvalidPduState(f"HR({req.register}) is not permitted for {model_label} inverter", req)
+        if not dry_run:
+            await self.execute(requests, timeout=timeout, retries=retries, retry_delay=retry_delay)
 
     def _emit_to_sink(self, direction: "Direction", data: bytes) -> None:
         """Hand redacted bytes to the active capture sink, swallowing sink errors.

--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -8,7 +8,7 @@ from asyncio import Future, Queue, StreamReader, StreamWriter, Task
 from collections.abc import Callable
 from typing import Literal
 
-from givenergy_modbus.client.commands import _InverterCommands, _ThreePhaseCommands
+from givenergy_modbus.client.commands import _EmsCommands, _InverterCommands, _ThreePhaseCommands
 from givenergy_modbus.exceptions import (
     CommunicationError,
     ExceptionBase,
@@ -1144,11 +1144,12 @@ class Client:
         If dry_run is True, validates but does not transmit.
         """
         caps = self.plant.capabilities
-        safe = (
-            _ThreePhaseCommands.WRITE_SAFE_REGISTERS
-            if caps is not None and caps.is_three_phase
-            else _InverterCommands.WRITE_SAFE_REGISTERS
-        )
+        if caps is not None and caps.is_ems:
+            safe = _EmsCommands.WRITE_SAFE_REGISTERS
+        elif caps is not None and caps.is_three_phase:
+            safe = _ThreePhaseCommands.WRITE_SAFE_REGISTERS
+        else:
+            safe = _InverterCommands.WRITE_SAFE_REGISTERS
         model_label = caps.device_type.name if caps is not None else "undetected"
         for req in requests:
             if isinstance(req, WriteHoldingRegisterRequest) and req.register not in safe:

--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -1141,7 +1141,9 @@ class Client:
         detected model. When capabilities are not yet known, falls back to the
         universally-applicable single-phase register set (conservative).
 
-        If dry_run is True, validates but does not transmit.
+        If dry_run is True, validates but does not transmit — running the same PDU
+        validation (``ensure_valid_state``) the live encode path runs, so a dry run
+        never passes for a request real execution would reject.
         """
         caps = self.plant.capabilities
         if caps is not None and caps.is_ems:
@@ -1154,6 +1156,9 @@ class Client:
         for req in requests:
             if isinstance(req, WriteHoldingRegisterRequest) and req.register not in safe:
                 raise InvalidPduState(f"HR({req.register}) is not permitted for {model_label} inverter", req)
+            # Run the same PDU-level validation encode() runs (value bounds, global
+            # safe-register set), so dry-run and live paths reject identically.
+            req.ensure_valid_state()
         if not dry_run:
             await self.execute(requests, timeout=timeout, retries=retries, retry_delay=retry_delay)
 

--- a/givenergy_modbus/client/commands.py
+++ b/givenergy_modbus/client/commands.py
@@ -1133,10 +1133,11 @@ class _EmsCommands:
     dependency.
 
     The EMS register block (HR 2040, 2044–2071) is decoded in
-    `givenergy_modbus.model.ems`; write-safety for those registers is enforced at
-    the PDU level (`pdu.write_registers.WRITE_SAFE_REGISTERS`). A per-model mixin
-    `WRITE_SAFE_REGISTERS` allowlist is deferred to #106 alongside the inverter ones.
+    `givenergy_modbus.model.ems`; write-safety for those registers is enforced
+    both here and at the PDU level (`pdu.write_registers.WRITE_SAFE_REGISTERS`).
     """
+
+    WRITE_SAFE_REGISTERS: ClassVar[frozenset[int]] = frozenset({2040, *range(2044, 2072)})
 
     # --- plant master enable -------------------------------------------------
 

--- a/tests/client/test_client_write_safety.py
+++ b/tests/client/test_client_write_safety.py
@@ -135,6 +135,20 @@ async def test_validation_fires_before_transmit():
 
 
 @pytest.mark.asyncio
+async def test_dry_run_validates_value_bounds():
+    """A model-allowed register with an out-of-range value is rejected in dry_run.
+
+    dry_run must run the same PDU validation (ensure_valid_state) the live encode
+    path runs, otherwise a dry run can pass for a request real execution rejects.
+    """
+    client = _client(_caps(Model.HYBRID_GEN1))
+    # HR 96 is model-allowed, but 70000 > 0xFFFF — only ensure_valid_state catches it.
+    req = WriteHoldingRegisterRequest(_SINGLE_PHASE_REG, 70000)
+    with pytest.raises(InvalidPduState, match=r"16-bit"):
+        await client.one_shot_command([req], dry_run=True)
+
+
+@pytest.mark.asyncio
 async def test_dry_run_false_calls_execute(monkeypatch):
     """When dry_run=False and all registers are valid, execute() is called."""
     client = _client(_caps(Model.HYBRID_GEN1))

--- a/tests/client/test_client_write_safety.py
+++ b/tests/client/test_client_write_safety.py
@@ -1,0 +1,133 @@
+"""Tests for model-aware write safety at the Client boundary.
+
+one_shot_command() validates every WriteHoldingRegisterRequest against the
+model-specific WRITE_SAFE_REGISTERS set before transmitting. A caller who
+bypasses the command mixins and hand-builds a WriteHoldingRegisterRequest still
+gets rejected if the register is not valid for the detected inverter model.
+
+Uses dry_run=True throughout so no network transport is needed.
+"""
+
+import pytest
+
+from givenergy_modbus.client.client import Client
+from givenergy_modbus.client.commands import _InverterCommands, _ThreePhaseCommands
+from givenergy_modbus.exceptions import InvalidPduState
+from givenergy_modbus.model.inverter import Model
+from givenergy_modbus.model.plant import PlantCapabilities
+from givenergy_modbus.pdu.write_registers import WriteHoldingRegisterRequest
+
+# HR 96 = ENABLE_CHARGE — in _InverterCommands.WRITE_SAFE_REGISTERS (single-phase)
+# HR 1112 = AC_CHARGE_ENABLE — in _ThreePhaseCommands.WRITE_SAFE_REGISTERS only
+_SINGLE_PHASE_REG = 96
+_THREE_PHASE_REG = 1112
+# HR 1078 = BATTERY_RESERVE_SOC — three-phase-only; not in base _InverterCommands set
+_THREE_PHASE_ONLY_REG = 1078
+
+
+def _client(caps: PlantCapabilities | None) -> Client:
+    c = Client("localhost", 8899)
+    c.plant.capabilities = caps
+    return c
+
+
+def _caps(model: Model) -> PlantCapabilities:
+    return PlantCapabilities(device_type=model)
+
+
+# ---------------------------------------------------------------------------
+# Single-phase model
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_single_phase_accepts_single_phase_register():
+    client = _client(_caps(Model.HYBRID_GEN1))
+    req = WriteHoldingRegisterRequest(_SINGLE_PHASE_REG, 1)
+    await client.one_shot_command([req], dry_run=True)  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_single_phase_rejects_three_phase_register():
+    client = _client(_caps(Model.HYBRID_GEN1))
+    req = WriteHoldingRegisterRequest(_THREE_PHASE_REG, 1)
+    with pytest.raises(InvalidPduState, match=r"HR\(1112\)"):
+        await client.one_shot_command([req], dry_run=True)
+
+
+# ---------------------------------------------------------------------------
+# Three-phase model
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_three_phase_accepts_three_phase_register():
+    client = _client(_caps(Model.HYBRID_3PH))
+    req = WriteHoldingRegisterRequest(_THREE_PHASE_REG, 1)
+    await client.one_shot_command([req], dry_run=True)  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_three_phase_rejects_single_phase_register():
+    client = _client(_caps(Model.HYBRID_3PH))
+    req = WriteHoldingRegisterRequest(_SINGLE_PHASE_REG, 1)
+    with pytest.raises(InvalidPduState, match=r"HR\(96\)"):
+        await client.one_shot_command([req], dry_run=True)
+
+
+# ---------------------------------------------------------------------------
+# Undetected model (capabilities not set) — conservative fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_undetected_accepts_single_phase_register():
+    client = _client(None)
+    req = WriteHoldingRegisterRequest(_SINGLE_PHASE_REG, 1)
+    await client.one_shot_command([req], dry_run=True)  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_undetected_rejects_three_phase_only_register():
+    client = _client(None)
+    req = WriteHoldingRegisterRequest(_THREE_PHASE_ONLY_REG, 1)
+    with pytest.raises(InvalidPduState, match=r"HR\(1078\)"):
+        await client.one_shot_command([req], dry_run=True)
+
+
+# ---------------------------------------------------------------------------
+# dry_run=False path still validates (just also transmits, so we only test
+# the synchronous validation part; actual transmission would need a live socket)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_validation_fires_before_transmit():
+    """Rejected register raises immediately — before any network I/O."""
+    client = _client(_caps(Model.HYBRID_GEN1))
+    req = WriteHoldingRegisterRequest(_THREE_PHASE_REG, 1)
+    # Even without dry_run, InvalidPduState must be raised (no network needed
+    # because the raise happens before execute() is called).
+    with pytest.raises(InvalidPduState):
+        await client.one_shot_command([req])
+
+
+# ---------------------------------------------------------------------------
+# Sanity: register sets are consistent with expectations
+# ---------------------------------------------------------------------------
+
+
+def test_single_phase_reg_in_base_set():
+    assert _SINGLE_PHASE_REG in _InverterCommands.WRITE_SAFE_REGISTERS
+
+
+def test_three_phase_reg_not_in_base_set():
+    assert _THREE_PHASE_REG not in _InverterCommands.WRITE_SAFE_REGISTERS
+
+
+def test_three_phase_reg_in_three_phase_set():
+    assert _THREE_PHASE_REG in _ThreePhaseCommands.WRITE_SAFE_REGISTERS
+
+
+def test_single_phase_reg_not_in_three_phase_set():
+    assert _SINGLE_PHASE_REG not in _ThreePhaseCommands.WRITE_SAFE_REGISTERS

--- a/tests/client/test_client_write_safety.py
+++ b/tests/client/test_client_write_safety.py
@@ -15,6 +15,7 @@ from givenergy_modbus.client.commands import _EmsCommands, _InverterCommands, _T
 from givenergy_modbus.exceptions import InvalidPduState
 from givenergy_modbus.model.inverter import Model
 from givenergy_modbus.model.plant import PlantCapabilities
+from givenergy_modbus.pdu.write_registers import WRITE_SAFE_REGISTERS as PDU_WRITE_SAFE_REGISTERS
 from givenergy_modbus.pdu.write_registers import WriteHoldingRegisterRequest
 
 # HR 96 = ENABLE_CHARGE — in _InverterCommands.WRITE_SAFE_REGISTERS (single-phase)
@@ -194,3 +195,27 @@ def test_ems_reg_not_in_base_set():
 
 def test_ems_set_covers_full_range():
     assert _EmsCommands.WRITE_SAFE_REGISTERS == frozenset({2040, *range(2044, 2072)})
+
+
+# ---------------------------------------------------------------------------
+# Encode-path drift guard: every model command set must be a subset of the PDU
+# allowlist, else ensure_valid_state()/encode() would reject a model-"safe"
+# register at transmit time. Encoding an EMS request exercises that path directly.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "command_set",
+    [
+        _InverterCommands.WRITE_SAFE_REGISTERS,
+        _ThreePhaseCommands.WRITE_SAFE_REGISTERS,
+        _EmsCommands.WRITE_SAFE_REGISTERS,
+    ],
+)
+def test_model_command_set_subset_of_pdu_allowlist(command_set):
+    assert command_set <= PDU_WRITE_SAFE_REGISTERS
+
+
+def test_ems_write_request_encodes():
+    """An EMS write encodes cleanly — ensure_valid_state() accepts the register."""
+    WriteHoldingRegisterRequest(_EMS_REG, 1).encode()

--- a/tests/client/test_client_write_safety.py
+++ b/tests/client/test_client_write_safety.py
@@ -11,7 +11,7 @@ Uses dry_run=True throughout so no network transport is needed.
 import pytest
 
 from givenergy_modbus.client.client import Client
-from givenergy_modbus.client.commands import _InverterCommands, _ThreePhaseCommands
+from givenergy_modbus.client.commands import _EmsCommands, _InverterCommands, _ThreePhaseCommands
 from givenergy_modbus.exceptions import InvalidPduState
 from givenergy_modbus.model.inverter import Model
 from givenergy_modbus.model.plant import PlantCapabilities
@@ -23,6 +23,8 @@ _SINGLE_PHASE_REG = 96
 _THREE_PHASE_REG = 1112
 # HR 1078 = BATTERY_RESERVE_SOC — three-phase-only; not in base _InverterCommands set
 _THREE_PHASE_ONLY_REG = 1078
+# HR 2040 = EMS_PLANT_ENABLE — EMS-only
+_EMS_REG = 2040
 
 
 def _client(caps: PlantCapabilities | None) -> Client:
@@ -96,6 +98,26 @@ async def test_undetected_rejects_three_phase_only_register():
 
 
 # ---------------------------------------------------------------------------
+# EMS model
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ems_accepts_ems_register():
+    client = _client(_caps(Model.EMS))
+    req = WriteHoldingRegisterRequest(_EMS_REG, 1)
+    await client.one_shot_command([req], dry_run=True)  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_ems_rejects_inverter_register():
+    client = _client(_caps(Model.EMS))
+    req = WriteHoldingRegisterRequest(_SINGLE_PHASE_REG, 1)
+    with pytest.raises(InvalidPduState, match=r"HR\(96\)"):
+        await client.one_shot_command([req], dry_run=True)
+
+
+# ---------------------------------------------------------------------------
 # dry_run=False path still validates (just also transmits, so we only test
 # the synchronous validation part; actual transmission would need a live socket)
 # ---------------------------------------------------------------------------
@@ -110,6 +132,21 @@ async def test_validation_fires_before_transmit():
     # because the raise happens before execute() is called).
     with pytest.raises(InvalidPduState):
         await client.one_shot_command([req])
+
+
+@pytest.mark.asyncio
+async def test_dry_run_false_calls_execute(monkeypatch):
+    """When dry_run=False and all registers are valid, execute() is called."""
+    client = _client(_caps(Model.HYBRID_GEN1))
+    req = WriteHoldingRegisterRequest(_SINGLE_PHASE_REG, 1)
+    calls = []
+
+    async def fake_execute(requests, timeout, retries, retry_delay):
+        calls.append(requests)
+
+    monkeypatch.setattr(client, "execute", fake_execute)
+    await client.one_shot_command([req])
+    assert len(calls) == 1 and calls[0] == [req]
 
 
 # ---------------------------------------------------------------------------
@@ -131,3 +168,15 @@ def test_three_phase_reg_in_three_phase_set():
 
 def test_single_phase_reg_not_in_three_phase_set():
     assert _SINGLE_PHASE_REG not in _ThreePhaseCommands.WRITE_SAFE_REGISTERS
+
+
+def test_ems_reg_in_ems_set():
+    assert _EMS_REG in _EmsCommands.WRITE_SAFE_REGISTERS
+
+
+def test_ems_reg_not_in_base_set():
+    assert _EMS_REG not in _InverterCommands.WRITE_SAFE_REGISTERS
+
+
+def test_ems_set_covers_full_range():
+    assert _EmsCommands.WRITE_SAFE_REGISTERS == frozenset({2040, *range(2044, 2072)})


### PR DESCRIPTION
## Summary

Closes the bypass path in `Client.one_shot_command()` where a hand-built `WriteHoldingRegisterRequest` could skip the per-model `WRITE_SAFE_REGISTERS` checks that the command mixins enforce. Ships both remaining Pillar A items from `docs/post-v2.2-plan.md`.

- **Model-aware write rejection** — `one_shot_command()` now validates every `WriteHoldingRegisterRequest` against the detected inverter model's safe-register set before anything hits the wire. Three-phase models use `_ThreePhaseCommands.WRITE_SAFE_REGISTERS`; single-phase and undetected models fall back to `_InverterCommands.WRITE_SAFE_REGISTERS` (the universally-applicable subset — conservative when capabilities are unknown). `InvalidPduState` is raised immediately on mismatch.
- **Dry-run validation** — `one_shot_command(..., dry_run=True)` runs the same validation without transmitting, letting downstream integrations preflight a request list without a live connection.

The second commit wires `SubagentStop` alongside the existing `Stop` hook in `.claude/settings.json` so pending inbox items surface as each dispatched subagent finishes (unrelated housekeeping, kept separate).

## Test plan

- [ ] `uv run pytest tests/client/test_client_write_safety.py -v` — 11 new tests covering single-phase accept/reject, three-phase accept/reject, undetected fallback, and validation-before-transmit
- [ ] `uv run pytest --cov` — full suite (1064 tests) green
- [ ] `uv run tox` — py311–py314 matrix clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Write safety validation now blocks unsafe holding-register writes at the client boundary, using model-aware allowlists.
  * Added `dry_run` mode to validate write requests without transmitting commands.
* **Tests**
  * Added comprehensive coverage for register allow/deny behaviour, validation timing, and `dry_run` execution.
* **Documentation**
  * Updated the post‑v2.2 roadmap with newly shipped items and clarified implementation notes.
* **Chores**
  * Enhanced subagent stop handling to check the coordination inbox when stopping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->