### PR TITLE
fix(client): tear down connection when detect() fails (atomic connect+detect, #274)

### DIFF
--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -676,7 +676,40 @@ class Client:
         Uses a two-tier timeout: `timeout`/`retries` for the known inverter device
         (where a response is expected), and `probe_timeout`/`probe_retries` for
         speculative probes where absence is the common case.
+
+        On a connection-level failure (TimeoutError / CommunicationError) the
+        connection is torn down via close(), so connect()+detect() is atomic:
+        `connected` flips to False and the standard "reconnect if not connected"
+        idiom recovers (#274). A PlantTopologyMismatch is raised on a healthy
+        connection (only the hint was wrong) and leaves it up so the caller can
+        retry a cold detect().
         """
+        try:
+            return await self._detect(
+                timeout=timeout,
+                retries=retries,
+                probe_timeout=probe_timeout,
+                probe_retries=probe_retries,
+                prior=prior,
+            )
+        except PlantTopologyMismatch:
+            # Healthy connection — only the hint was wrong; capabilities already cleared.
+            raise
+        except (TimeoutError, CommunicationError):
+            # A connection-level failure leaves a half-open socket with capabilities
+            # unset. Tear down so connect()+detect() is atomic (#274).
+            await self.close()
+            raise
+
+    async def _detect(
+        self,
+        timeout: float,
+        retries: int,
+        probe_timeout: float,
+        probe_retries: int,
+        prior: PlantCapabilities | None,
+    ) -> PlantCapabilities:
+        """Implementation of detect(); see detect() for the contract and error semantics."""
         if prior is not None:
             _logger.info(
                 "detect: hinted mode — assuming device_type=Model.%s, inverter=0x%02x, "
@@ -887,6 +920,11 @@ class Client:
 
         Returns the populated plant on full success. On partial/total read
         failure raises ``RefreshPartiallySucceeded`` / ``RefreshFailed``.
+
+        Success does not imply *fresh*: the keep-last-good guards (CRC #255, sub-bus
+        splice #256, bank holds) report a successful poll while serving last-known-good
+        content for a device whose live read was rejected. Display consumers should gate
+        on ``Plant.register_age()`` / ``Plant.block_age()``, not on a poll returning.
         """
         caps = self.plant.capabilities
         if caps is None:
@@ -951,6 +989,11 @@ class Client:
 
         Returns the populated plant on full success. On partial/total read
         failure raises ``RefreshPartiallySucceeded`` / ``RefreshFailed``.
+
+        Success does not imply *fresh*: the keep-last-good guards (CRC #255, sub-bus
+        splice #256, bank holds) report a successful poll while serving last-known-good
+        content for a device whose live read was rejected. Display consumers should gate
+        on ``Plant.register_age()`` / ``Plant.block_age()``, not on a poll returning.
 
         The ``timeout=2.0, retries=1`` defaults are tuned for a contended bus: the
         inverter serialises requests, so when other clients (GivTCP, the vendor app,

--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -697,8 +697,13 @@ class Client:
             raise
         except (TimeoutError, CommunicationError):
             # A connection-level failure leaves a half-open socket with capabilities
-            # unset. Tear down so connect()+detect() is atomic (#274).
-            await self.close()
+            # unset. Tear down so connect()+detect() is atomic (#274). Guard close()
+            # so a teardown error (e.g. a flaky writer.wait_closed()) can't mask the
+            # original failure we're propagating.
+            try:
+                await self.close()
+            except Exception:
+                _logger.exception("detect: error during connection teardown after failure")
             raise
 
     async def _detect(

--- a/tests/client/test_detect.py
+++ b/tests/client/test_detect.py
@@ -1302,6 +1302,19 @@ async def test_detect_timeout_closes_connection():
 
 
 @pytest.mark.asyncio
+async def test_detect_teardown_error_does_not_mask_original():
+    """If close() raises during teardown, the original detect() error still propagates."""
+    client = _make_client()
+    _prime_live_connection(client)
+
+    with patch.object(client, "send_request_and_await_response", side_effect=TimeoutError):
+        with patch.object(client, "_probe", new=AsyncMock(return_value=False)):
+            with patch.object(client, "close", new=AsyncMock(side_effect=RuntimeError("teardown boom"))):
+                with pytest.raises(TimeoutError):  # not RuntimeError
+                    await client.detect()
+
+
+@pytest.mark.asyncio
 async def test_detect_missing_hr0_closes_connection():
     """A CommunicationError ("HR(0) not populated") tears the connection down."""
     client = _make_client()

--- a/tests/client/test_detect.py
+++ b/tests/client/test_detect.py
@@ -1,6 +1,6 @@
 """Tests for Client.detect() and PlantCapabilities."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -1260,3 +1260,104 @@ async def test_detect_lv_batteries_invalid_slot_skipped_not_aborted():
     assert 0x32 in caps.lv_battery_addresses
     assert 0x33 not in caps.lv_battery_addresses  # ghost — skipped
     assert 0x34 in caps.lv_battery_addresses
+
+
+# ---------------------------------------------------------------------------
+# connect()+detect() atomicity (#274): a connection-level detect() failure must
+# tear the connection down so connect()+detect() is atomic. A PlantTopologyMismatch
+# is raised on a healthy connection, so it must leave `connected` untouched.
+# ---------------------------------------------------------------------------
+
+
+def _prime_live_connection(client: Client) -> MagicMock:
+    """Put the client in a post-connect() state so the real close() can run.
+
+    Mirrors the mock-socket setup in tests/client/test_client.py — a MagicMock
+    writer whose wait_closed is awaitable, a reader, both background tasks, and
+    connected=True. Returns the writer for teardown assertions.
+    """
+    writer = MagicMock()
+    writer.wait_closed = AsyncMock()
+    client.writer = writer
+    client.reader = MagicMock()
+    client.network_producer_task = MagicMock()
+    client.network_consumer_task = MagicMock()
+    client.connected = True
+    return writer
+
+
+@pytest.mark.asyncio
+async def test_detect_timeout_closes_connection():
+    """A TimeoutError during detect() tears the connection down (connected=False)."""
+    client = _make_client()
+    writer = _prime_live_connection(client)
+
+    with patch.object(client, "send_request_and_await_response", side_effect=TimeoutError):
+        with patch.object(client, "_probe", new=AsyncMock(return_value=False)):
+            with pytest.raises(TimeoutError):
+                await client.detect()
+
+    assert client.connected is False
+    writer.close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_detect_missing_hr0_closes_connection():
+    """A CommunicationError ("HR(0) not populated") tears the connection down."""
+    client = _make_client()
+    _prime_live_connection(client)
+    # Don't prime any cache — HR(0) will be absent → CommunicationError.
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
+        with patch.object(client, "_probe", new=AsyncMock(return_value=False)):
+            with pytest.raises(CommunicationError, match="HR\\(0\\)"):
+                await client.detect()
+
+    assert client.connected is False
+
+
+@pytest.mark.asyncio
+async def test_detect_topology_mismatch_keeps_connection():
+    """A PlantTopologyMismatch is raised on a healthy connection — leave it up.
+
+    The hint was wrong, not the link; capabilities is cleared, but the caller can
+    retry a cold detect() on the same live socket, so connected must stay True.
+    """
+    client = _make_client()
+    _prime_live_connection(client)
+    _prime_cache(client, 0x11, {HR(0): 0x2001, HR(21): 0})
+    _prime_battery_serial(client, 0x32)
+    _prime_meter_voltage(client, 0x01)
+
+    prior = PlantCapabilities(
+        device_type=Model.HYBRID_GEN1,
+        meter_addresses=[0x01, 0x02],  # 0x02 won't confirm → mismatch
+        lv_battery_addresses=[0x32],
+    )
+
+    async def _probe_side_effect(request, *, timeout, retries):
+        return request.device_address == 0x01
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
+        with patch.object(client, "_probe", side_effect=_probe_side_effect):
+            with pytest.raises(PlantTopologyMismatch):
+                await client.detect(prior=prior)
+
+    assert client.connected is True
+    assert client.plant.capabilities is None
+
+
+@pytest.mark.asyncio
+async def test_detect_success_leaves_connected():
+    """A successful detect() leaves the connection up (regression guard)."""
+    client = _make_client()
+    _prime_live_connection(client)
+    _prime_cache(client, 0x11, {HR(0): 0x2001, HR(21): 0})
+    _prime_battery_serial(client, 0x32)
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
+        with patch.object(client, "_probe", new=AsyncMock(return_value=False)):
+            caps = await client.detect()
+
+    assert client.connected is True
+    assert client.plant.capabilities is caps


### PR DESCRIPTION
## Summary

Closes #274. Makes `connect()` + `detect()` atomic: a `detect()` that fails on a connection-level error now tears the connection down, instead of leaving the client half-initialised with `connected=True` / `capabilities=None`.

The footgun: a `detect()` timing out *after* `connect()` opened the socket left `connected=True` but `capabilities=None`. The natural consumer idiom — "reconnect if `not connected`, otherwise `refresh()`" — then skipped reconnecting and called `refresh()`, which raised `PlantNotDetected`. On a flaky/contended RS485 bus this fired repeatedly. `givenergy-hass` worked around it by discarding the client on any connect-failure, but every consumer hits the same wire.

## What changed

- **`detect()` now closes the connection on a connection-level failure** (`TimeoutError` / `CommunicationError`), so `connected` flips to `False` and the standard reconnect idiom recovers with no consumer-side guard.
- **`PlantTopologyMismatch` is exempt** — it's raised on a *healthy* connection (the registers read fine, only the `prior` hint was wrong), already clears `capabilities`, and is a deliberately caller-handled signal. The socket is left up so the caller can retry a cold `detect()`.
- The body moved into a private `_detect()`; `detect()` is now a thin try/except wrapper — the implementation is otherwise unchanged.
- **Docs:** the "success ≠ fresh" contract is now stated on `refresh()` / `load_config()` — the keep-last-good guards (CRC #255, splice #256, bank holds) report a *successful* poll while serving last-known-good data, so display consumers should gate on `Plant.register_age()` / `Plant.block_age()`.

## Test plan

- [ ] `uv run pytest tests/client/test_detect.py -v` — 4 new tests: timeout closes, missing-HR(0) closes, topology-mismatch keeps connection, success keeps connection
- [ ] `uv run pytest -q` — full suite (1079) green
- [ ] `uv run tox` — py311–py314 + lint + build green

Surfaced via a cross-repo report from the `givenergy-hass` side (hass#183), driven by a tester on a deficient RS485 bus where the #255/#256 guards were working as intended but the half-init window opened repeatedly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
