### PR TITLE
feat(model): AioBatteryModule.REGISTER_GETTER for staleness gating (#273)

### DIFF
--- a/givenergy_modbus/model/aio_battery.py
+++ b/givenergy_modbus/model/aio_battery.py
@@ -7,11 +7,28 @@ layout (modules offset within a single BCU cache); see ``model/hv_bcu.py``. The 
 decode is shared via :func:`decode_cells_temps_serial`.
 """
 
-from typing import Any
+from typing import Any, ClassVar
 
 from pydantic import ConfigDict, create_model
 
-from givenergy_modbus.model.hv_bcu import decode_cells_temps_serial, module_cell_temp_serial_fields
+from givenergy_modbus.model.hv_bcu import (
+    cell_temp_serial_register_lut,
+    decode_cells_temps_serial,
+    module_cell_temp_serial_fields,
+)
+from givenergy_modbus.model.register import RegisterGetter, RegisterMetadataMixin
+
+
+class AioBatteryModuleRegisterGetter(RegisterGetter):
+    """field→register metadata for AIO per-module data (#273).
+
+    Metadata only — `AioBatteryModule` still decodes imperatively via
+    :func:`decode_cells_temps_serial`; this LUT drives ``registers_of()`` /
+    ``precision_of()`` so a consumer can feed ``Plant.register_age()`` and gate a frozen
+    module unavailable (hass#192).
+    """
+
+    REGISTER_LUT = cell_temp_serial_register_lut(base=0)
 
 
 def _aio_module_fields() -> dict[str, tuple[Any, None]]:
@@ -27,12 +44,14 @@ _AioBatteryModuleBase = create_model(  # type: ignore[call-overload]
 )
 
 
-class AioBatteryModule(_AioBatteryModuleBase):  # type: ignore[misc,valid-type]
+class AioBatteryModule(_AioBatteryModuleBase, RegisterMetadataMixin):  # type: ignore[misc,valid-type]
     """One AIO battery module: 24 cell voltages + temperatures + the module serial.
 
     Decoded from the module's own device-address cache (``base=0``), keyed by its Modbus
     ``module_address`` (0x50-0x53).
     """
+
+    REGISTER_GETTER: ClassVar[type[RegisterGetter]] = AioBatteryModuleRegisterGetter
 
     @classmethod
     def from_register_cache(cls, register_cache, module_address: int) -> "AioBatteryModule":

--- a/givenergy_modbus/model/hv_bcu.py
+++ b/givenergy_modbus/model/hv_bcu.py
@@ -90,6 +90,12 @@ class Bcu(_BcuBase, RegisterMetadataMixin):  # type: ignore[misc,valid-type]
 _BMU_CELLS = 24
 # Register stride between BMUs within a BCU device's address space
 _BMU_STRIDE = 120
+# Base register addresses (relative to a module's ``base`` offset) for the per-cell block.
+# Shared by the field schema, the decode, and the register LUT so they can't drift (#273).
+_V_CELL_BASE = 60  # IR(60+base .. 83+base) — 24 cell voltages, milli (÷1000)
+_T_CELL_BASE = 90  # IR(90+base .. 113+base) — 24 cell temps, deci (÷10)
+_SERIAL_BASE = 114  # IR(114+base .. 118+base) — 5-register module serial
+_SERIAL_LEN = 5
 
 
 def module_cell_temp_serial_fields() -> dict[str, tuple[Any, None]]:
@@ -104,6 +110,23 @@ def module_cell_temp_serial_fields() -> dict[str, tuple[Any, None]]:
         fields[f"t_cell_{i:02d}"] = (float | None, None)
     fields["serial_number"] = (str | None, None)
     return fields
+
+
+def cell_temp_serial_register_lut(base: int = 0) -> dict[str, Def]:
+    """field→register LUT matching :func:`decode_cells_temps_serial` for the given ``base``.
+
+    Base-parametrised the same way the decode is, so a future `Bmu` getter could offset by
+    ``120 * bmu_index``; `AioBatteryModule` uses ``base = 0``. Converters mirror the decode:
+    voltages milli (÷1000), temperatures deci (÷10), serial the 5-register string decode.
+    Drives ``registers_of()`` / ``precision_of()`` for staleness gating (#273); the min/max on
+    voltages mirror `BatteryRegisterGetter` and are inert under the imperative decode.
+    """
+    lut: dict[str, Def] = {}
+    for i in range(_BMU_CELLS):
+        lut[f"v_cell_{i + 1:02d}"] = Def(C.milli, None, IR(_V_CELL_BASE + base + i), min=1.0, max=5.0)
+        lut[f"t_cell_{i + 1:02d}"] = Def(C.deci, None, IR(_T_CELL_BASE + base + i))
+    lut["serial_number"] = Def(C.serial, None, *(IR(_SERIAL_BASE + base + j) for j in range(_SERIAL_LEN)))
+    return lut
 
 
 def decode_cells_temps_serial(register_cache, base: int = 0) -> dict[str, Any]:
@@ -121,12 +144,12 @@ def decode_cells_temps_serial(register_cache, base: int = 0) -> dict[str, Any]:
         return register_cache.get(IR(reg_idx))
 
     for i in range(_BMU_CELLS):
-        v = _get(60 + base + i)
+        v = _get(_V_CELL_BASE + base + i)
         data[f"v_cell_{i + 1:02d}"] = v / 1000 if v is not None else None
     for i in range(_BMU_CELLS):
-        t = _get(90 + base + i)
+        t = _get(_T_CELL_BASE + base + i)
         data[f"t_cell_{i + 1:02d}"] = t / 10 if t is not None else None
-    sn_regs = [_get(114 + base + j) for j in range(5)]
+    sn_regs = [_get(_SERIAL_BASE + base + j) for j in range(_SERIAL_LEN)]
     if None not in sn_regs:
         data["serial_number"] = (
             b"".join(v.to_bytes(2, "big") for v in sn_regs)  # type: ignore[union-attr]

--- a/tests/model/test_aio_battery.py
+++ b/tests/model/test_aio_battery.py
@@ -8,8 +8,9 @@ against the real aio_a fixture.
 
 import pytest
 
-from givenergy_modbus.model.aio_battery import AioBatteryModule
+from givenergy_modbus.model.aio_battery import AioBatteryModule, AioBatteryModuleRegisterGetter
 from givenergy_modbus.model.devices import DeviceType
+from givenergy_modbus.model.hv_bcu import decode_cells_temps_serial
 from givenergy_modbus.model.inverter import Model
 from givenergy_modbus.model.plant import PlantCapabilities
 from givenergy_modbus.model.register import IR
@@ -66,6 +67,55 @@ def test_aio_module_serial_decodes_from_ir_114():
     assert module.serial_number == "HX2414G832"
     assert module.module_address == 0x52
     assert module.is_valid()
+
+
+# ---------------------------------------------------------------------------
+# Register-getter metadata (#273) — field→register map for staleness gating
+# ---------------------------------------------------------------------------
+
+
+def _regs(name: str) -> list[tuple[str, int]]:
+    return [(r.reg_type, r.index) for r in AioBatteryModule.REGISTER_GETTER.registers_of(name)]
+
+
+def test_aio_registers_of_resolves_boundary_fields():
+    """registers_of() maps each per-cell field to its backing IR register(s)."""
+    assert _regs("v_cell_01") == [("IR", 60)]
+    assert _regs("v_cell_24") == [("IR", 83)]
+    assert _regs("t_cell_01") == [("IR", 90)]
+    assert _regs("t_cell_24") == [("IR", 113)]
+    assert _regs("serial_number") == [("IR", 114), ("IR", 115), ("IR", 116), ("IR", 117), ("IR", 118)]
+
+
+def test_aio_registers_of_unknown_or_unbacked_is_empty():
+    """Non-register-backed (module_address) and unknown fields yield an empty tuple."""
+    assert AioBatteryModule.REGISTER_GETTER.registers_of("module_address") == ()
+    assert AioBatteryModule.REGISTER_GETTER.registers_of("nope") == ()
+
+
+def test_aio_precision_of_matches_scaling():
+    """precision_of() reflects the converter scaling (milli=3, deci=1)."""
+    assert AioBatteryModule.precision_of("v_cell_01") == 3
+    assert AioBatteryModule.precision_of("t_cell_01") == 1
+
+
+def test_aio_lut_field_set_matches_decode():
+    """Drift guard: the LUT's fields track exactly what decode_cells_temps_serial produces.
+
+    Adding/removing a cell in the decode loop without updating the LUT (or vice versa) fails here.
+    """
+    primed = RegisterCache({IR(i): 1 for i in range(60, 119)})
+    decoded = decode_cells_temps_serial(primed, base=0)
+    assert set(AioBatteryModuleRegisterGetter.REGISTER_LUT) == set(decoded)
+
+
+@pytest.mark.timeout(20)
+async def test_aio_registers_of_feeds_register_age():
+    """End-to-end: registers_of() yields a register that Plant.register_age() can age (the hass use-case)."""
+    plant = await _aio_plant_with_caps()
+    reg = AioBatteryModule.REGISTER_GETTER.registers_of("v_cell_01")[0]
+    age = plant.register_age(0x50, reg)
+    assert age is not None and age >= 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #273. Adds a register-getter to `AioBatteryModule` so consumers can resolve a per-module field's backing registers and feed `Plant.register_age()` — enabling AIO per-module sensors to be staleness-gated the same way LV packs now are (hass#192, mirroring hass#183).

Today `AioBatteryModule` has no `REGISTER_GETTER`: its fields come imperatively from `decode_cells_temps_serial()`, with no field→register map, so a consumer holding a module can't ask "how old is this cell's data?".

## What changed

- **`AioBatteryModuleRegisterGetter`** (metadata only) exposes `registers_of()` / `precision_of()` via `RegisterMetadataMixin` — mirroring the existing `Bcu`/`Battery` pattern. `AioBatteryModule.REGISTER_GETTER.registers_of("v_cell_01")` → `(IR(60),)`, etc.
- **The imperative decode is unchanged.** `registers_of()` / `precision_of()` read only the LUT (no `build()`), so there's no decode-path risk — the milli/deci/serial/None handling is untouched.
- **No drift:** the LUT comes from a new base-parametrised `cell_temp_serial_register_lut()` factory in `hv_bcu.py` that shares the per-cell base-address constants (`_V_CELL_BASE` etc.) with `decode_cells_temps_serial()`. A guard test asserts the LUT field-set equals the decode's output keys.

## Scope — Bmu deferred

The #273 issue noted the sibling `Bmu` "could be covered too". It's deferred here: `Bmu` can't take a static class-level getter (its registers are stride-offset by `120 * bmu_index`), and its per-cell decode is still suspect under #265 (HV BMU per-cell). The factory is base-parametrised so a future per-index `Bmu` accessor can reuse it.

## Test plan

- [ ] `uv run pytest tests/model/test_aio_battery.py -v` — new tests: `registers_of()` boundary fields, unknown/unbacked → `()`, `precision_of()` scaling, LUT-vs-decode drift guard, and an end-to-end `registers_of()` → `Plant.register_age()` check on the `aio_a` fixture
- [ ] `uv run pytest -q` — full suite (1085) green
- [ ] `uv run tox` — py311–py314 + lint + build green

Once merged I'll hand the new accessor back to the `givenergy-hass` side (the #192 gate) via the coordination channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Battery module metadata is now accessible through a standardised register system, enabling age-based module gating and improved metadata derivation.

* **Tests**
  * Added comprehensive test coverage for battery module register metadata, field resolution, precision scaling, and register aging logic to ensure consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->