### PR TITLE
fix(plant): de-noise #256 splice-guard singleton path (thresholds + logging)

### DIFF
--- a/givenergy_modbus/model/battery_splice.py
+++ b/givenergy_modbus/model/battery_splice.py
@@ -16,13 +16,23 @@ This module is the single source of truth for those thresholds. ``Plant._commit_
 imports it to guard live commits; ``tests/debug/physics_delta_classify.py`` imports it to
 re-validate the corpus separation against the very same constants.
 
-Thresholds are in raw register units and set at roughly 10x what the quantity can really do
-in a ~30 s poll interval — cell voltages barely move (electrochemical inertia), cell-mass
+Thresholds are in raw register units, set comfortably above what the quantity can really do
+in a ~30 s poll interval — cell voltages move little near idle but sag under load, cell-mass
 temperatures drift, the junction-adjacent MOSFET sensor steps (hence its much wider
-threshold), capacities move with charge current (~0.5 Ah/poll at LV power). Status/bitfield
+threshold), capacities move with charge current and step on recalibration. Status/bitfield
 words carry no physics and are exempt (IR(91) legitimately toggles 0x0E10 <-> 0x0610 every
 few minutes). ``num_cells``, ``bms_firmware_version`` and the serial block are constant —
 ANY transient change is corruption on its own.
+
+The original Gen1-calibrated corpus separated cleanly, but field reports from higher-power
+hardware (hass#186, an AC3 + 2x Giv-Bat 5.2: a ~103 mV cell sag on a load step, a ~10 Ah
+capacity recalibration) showed legitimate per-poll deltas just past the ``cell_mV`` (100) and
+``cap_centiAh`` (1000) thresholds — caught by the singleton escrow but noisy. Both were widened
+(cell_mV->150, cap_centiAh->1500). This is safe because the corpus's *only* corruption signature
+is the temperature-zero cohort (>=2 temp registers -> rejected outright): no corruption has ever
+presented as a lone ``cell_mV`` or ``cap_centiAh`` delta, so widening exactly these two classes
+(temps untouched) cannot weaken detection, and any residual over-threshold singleton still
+escrows.
 
 Indices throughout are **bank-relative** (``i`` == register ``IR(60 + i)``); the trips
 returned carry the **absolute** IR number for logging.
@@ -35,7 +45,9 @@ BANK_BASE = 60
 
 # (class name, bank-relative indices, threshold on |delta| in raw units).
 SCALAR_RULES: list[tuple[str, list[int], int]] = [
-    ("cell_mV", list(range(0, 16)), 100),  # IR(60-75) cells: ~10 mV/poll real max
+    # IR(60-75) cells: ~10 mV/poll at idle, but a higher-power inverter (e.g. AC3) sags a cell
+    # ~100+ mV on a charge<->discharge load step (I×R) — see hass#186; 150 clears that with margin.
+    ("cell_mV", list(range(0, 16)), 150),
     ("cell_temp_deci", [16, 17, 18, 19, 43, 44], 50),  # IR(76-79,103,104): thermal mass
     ("mosfet_temp_deci", [21], 200),  # IR(81): junction-adjacent, steps with load
     ("v_cells_sum_mV", [20], 1600),  # IR(80)
@@ -43,12 +55,14 @@ SCALAR_RULES: list[tuple[str, list[int], int]] = [
     ("e_total_deci", [45, 46], 50),  # IR(105/106) lifetime energy
 ]
 # uint32 pairs: (class name, (high index, low index), threshold on the assembled pair value).
+# cap_centiAh 1500: capacity recalibration (coulomb-count correction) can step ~10 Ah in one poll
+# on a larger pack — see hass#186.
 PAIR_RULES: list[tuple[str, tuple[int, int], int]] = [
     ("v_out_mV", (22, 23), 2000),  # IR(82-83)
-    ("cap_centiAh", (24, 25), 1000),  # IR(84-85) cap_calibrated
-    ("cap_centiAh", (26, 27), 1000),  # IR(86-87) cap_design
-    ("cap_centiAh", (28, 29), 1000),  # IR(88-89) cap_remaining
-    ("cap_centiAh", (41, 42), 1000),  # IR(101-102) cap_design2
+    ("cap_centiAh", (24, 25), 1500),  # IR(84-85) cap_calibrated
+    ("cap_centiAh", (26, 27), 1500),  # IR(86-87) cap_design
+    ("cap_centiAh", (28, 29), 1500),  # IR(88-89) cap_remaining
+    ("cap_centiAh", (41, 42), 1500),  # IR(101-102) cap_design2
 ]
 # num_cells IR(97), bms_firmware_version IR(98), serial block IR(110-114) — ANY change is
 # corruption on its own. IR(115) is deliberately NOT here: the corpus treated it as a

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -879,17 +879,29 @@ class Plant(GivEnergyBaseModel):
                 )
                 return True
             self._splice_escrow[device_address] = (ir_no, new_val)
-            _logger.warning(
-                "Held battery bank for device 0x%02x — single physics-impossible delta (%s) held pending "
-                "confirmation next poll; keeping last-good. Please report if seen.",
+            # A lone out-of-threshold delta is the self-healing escrow path: held one poll, then
+            # committed if it persists (genuine step) or dropped if it reverts (transient). It is
+            # NOT confirmed corruption — the >=2/immutable REJECT above is — so it logs at INFO to
+            # avoid alarming on legitimate load-step sag / recalibration (#256, hass#186).
+            _logger.info(
+                "Battery bank for device 0x%02x: single out-of-threshold delta (%s) held one poll pending "
+                "confirmation; serving last-good meanwhile.",
                 device_address,
                 self._format_splice_trips(phys),
             )
             return False
 
         # Clean transition (no trips): a previously-held step that snapped back lands here, so
-        # drop any escrow and commit.
-        self._splice_escrow.pop(device_address, None)
+        # drop any escrow and commit. Log the reversion so the held->resolved story is visible at
+        # one level (the hold is INFO too).
+        reverted = self._splice_escrow.pop(device_address, None)
+        if reverted is not None:
+            _logger.info(
+                "Battery bank for device 0x%02x: previously-held delta at IR(%d) reverted on re-read "
+                "(transient); committing clean bank.",
+                device_address,
+                reverted[0],
+            )
         return True
 
     @staticmethod

--- a/tests/model/test_battery_splice.py
+++ b/tests/model/test_battery_splice.py
@@ -48,7 +48,7 @@ def test_ir115_is_dropped_from_immutable():
 def test_single_cell_voltage_step_is_one_physics_trip():
     base = _baseline()
     new = list(base)
-    new[5] = 3600  # +300 mV > 100 mV threshold
+    new[5] = 3600  # +300 mV > 150 mV threshold
     phys, immut = classify_transition(base, new)
     assert immut == []
     assert phys == [(BANK_BASE + 5, "cell_mV", 3300, 3600)]
@@ -57,7 +57,7 @@ def test_single_cell_voltage_step_is_one_physics_trip():
 def test_within_threshold_jitter_does_not_trip():
     base = _baseline()
     new = list(base)
-    new[5] = 3399  # +99 mV, within the 100 mV threshold
+    new[5] = 3449  # +149 mV, within the 150 mV threshold
     new[16] = 299  # +49 deci, within the 50 threshold
     assert classify_transition(base, new) == ([], [])
 

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -2540,13 +2540,13 @@ def test_splice_clean_bank_commits_no_false_trip(plant: Plant, caplog):
     import logging
 
     _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)
-    # +99 mV cell (≤ 100 threshold), +49 deci temp (≤ 50 threshold) — both within limits.
-    jitter = _coherent_battery_bank({60: 3399, 76: 299})
+    # +149 mV cell (≤ 150 threshold), +49 deci temp (≤ 50 threshold) — both within limits.
+    jitter = _coherent_battery_bank({60: 3449, 76: 299})
     with caplog.at_level(logging.WARNING, logger="givenergy_modbus.model.plant"):
         _feed_bank(plant, jitter, device_address=_BATT, received_at=_T0 + timedelta(seconds=30))
     warns = [r for r in caplog.records if "splice" in r.message.lower() or "Held battery bank" in r.message]
     assert not warns
-    assert plant.register_caches[_BATT][IR(60)] == 3399
+    assert plant.register_caches[_BATT][IR(60)] == 3449
     assert plant.register_caches[_BATT][IR(76)] == 299
 
 
@@ -2557,41 +2557,47 @@ def test_splice_single_step_escrow_then_confirm(plant: Plant, caplog):
     _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)
     t1 = _T0 + timedelta(seconds=30)
     t2 = _T0 + timedelta(seconds=60)
-    wild = _coherent_battery_bank({60: 3500})  # IR60: +200 mV > 100 threshold — one trip
+    wild = _coherent_battery_bank({60: 3500})  # IR60: +200 mV > 150 threshold — one trip
 
-    with caplog.at_level(logging.WARNING, logger="givenergy_modbus.model.plant"):
+    # The singleton self-healing path is INFO, never WARNING (#256/hass#186).
+    with caplog.at_level(logging.INFO, logger="givenergy_modbus.model.plant"):
         _feed_bank(plant, wild, device_address=_BATT, received_at=t1)
-    holds = [r for r in caplog.records if "Held battery bank" in r.message and "0x33" in r.message]
-    assert len(holds) == 1, "single impossible delta must emit one 'held' WARNING"
+    holds = [r for r in caplog.records if "held one poll pending confirmation" in r.message and "0x33" in r.message]
+    assert len(holds) == 1, "single out-of-threshold delta must emit one 'held' log"
+    assert holds[0].levelno == logging.INFO, "self-healing hold must be INFO, not WARNING"
     assert plant.register_caches[_BATT][IR(60)] == 3300, "escrowed bank must not commit"
 
     caplog.clear()
-    # Re-read the same value: |3500 − 3500| = 0 ≤ 100 → value-consistent → confirm.
+    # Re-read the same value: |3500 − 3500| = 0 ≤ 150 → value-consistent → confirm.
     with caplog.at_level(logging.INFO, logger="givenergy_modbus.model.plant"):
         _feed_bank(plant, wild, device_address=_BATT, received_at=t2)
-    confirms = [r for r in caplog.records if "confirmed" in r.message and "0x33" in r.message]
+    confirms = [r for r in caplog.records if "confirmed on re-read" in r.message and "0x33" in r.message]
     assert len(confirms) == 1, "confirmed step must emit one INFO log"
     assert plant.register_caches[_BATT][IR(60)] == 3500, "confirmed step must commit"
 
 
 def test_splice_single_step_escrow_then_snapback(plant: Plant, caplog):
-    """A transient splice that snaps back clears the escrow and commits the clean bank."""
+    """A transient splice that snaps back clears the escrow, logs the reversion (INFO), commits clean."""
     import logging
 
     _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)
     t1 = _T0 + timedelta(seconds=30)
     t2 = _T0 + timedelta(seconds=60)
     wild = _coherent_battery_bank({60: 3500})
-    with caplog.at_level(logging.WARNING, logger="givenergy_modbus.model.plant"):
+    with caplog.at_level(logging.INFO, logger="givenergy_modbus.model.plant"):
         _feed_bank(plant, wild, device_address=_BATT, received_at=t1)
     assert plant.register_caches[_BATT][IR(60)] == 3300
 
     caplog.clear()
     clean = _coherent_battery_bank()  # IR60 back to seed value
-    with caplog.at_level(logging.WARNING, logger="givenergy_modbus.model.plant"):
+    with caplog.at_level(logging.INFO, logger="givenergy_modbus.model.plant"):
         _feed_bank(plant, clean, device_address=_BATT, received_at=t2)
-    warns = [r for r in caplog.records if "splice" in r.message.lower() or "Held battery bank" in r.message]
-    assert not warns, "snapback to seed must commit cleanly with no WARNING"
+    plant_warns = [
+        r for r in caplog.records if r.levelno >= logging.WARNING and r.name == "givenergy_modbus.model.plant"
+    ]
+    assert not plant_warns, "snapback must emit no WARNING from the splice guard"
+    reverts = [r for r in caplog.records if "reverted on re-read" in r.message and "0x33" in r.message]
+    assert len(reverts) == 1, "snapback must emit one INFO reversion log"
     assert plant.register_caches[_BATT][IR(60)] == 3300
 
 
@@ -2602,15 +2608,15 @@ def test_splice_two_wild_values_in_a_row_held(plant: Plant, caplog):
     _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)
     t1 = _T0 + timedelta(seconds=30)
     t2 = _T0 + timedelta(seconds=60)
-    # v1: IR60 → 3500 (|3500 − 3300| = 200 > 100) → escrow (IR60, 3500).
-    # v2: IR60 → 3700 (|3700 − 3500| = 200 > 100) → does NOT confirm → re-escrow (IR60, 3700).
+    # v1: IR60 → 3500 (|3500 − 3300| = 200 > 150) → escrow (IR60, 3500).
+    # v2: IR60 → 3700 (|3700 − 3500| = 200 > 150) → does NOT confirm → re-escrow (IR60, 3700).
     v1 = _coherent_battery_bank({60: 3500})
     v2 = _coherent_battery_bank({60: 3700})
-    with caplog.at_level(logging.WARNING, logger="givenergy_modbus.model.plant"):
+    with caplog.at_level(logging.INFO, logger="givenergy_modbus.model.plant"):
         _feed_bank(plant, v1, device_address=_BATT, received_at=t1)
         _feed_bank(plant, v2, device_address=_BATT, received_at=t2)
-    holds = [r for r in caplog.records if "Held battery bank" in r.message and "0x33" in r.message]
-    assert len(holds) == 2, "each wild read must emit its own 'held' WARNING"
+    holds = [r for r in caplog.records if "held one poll pending confirmation" in r.message and "0x33" in r.message]
+    assert len(holds) == 2, "each wild read must emit its own 'held' INFO log"
     assert plant.register_caches[_BATT][IR(60)] == 3300, "neither wild value must have committed"
 
 


### PR DESCRIPTION
## Summary

Addresses [givenergy-hass#186](https://github.com/dewet22/givenergy-hass/issues/186): holdestmade (AC3 + 2× Giv-Bat 5.2) is seeing repeated WARNINGs from the #256 battery splice guard's **singleton-escrow** path — lone, near-threshold deltas like `IR(67) cell_mV 3327->3224` (−103 mV) and `IR(84) cap_centiAh 10200->9190` (−1010).

Analysis (corpus + `tests/debug/physics_delta_classify.py`) shows these are **benign physics, not corruption**: legitimate AC3 load-step cell sag (I×R) and a capacity recalibration, grazing thresholds that were calibrated on calmer Gen1 data. The escrow already handles them correctly (held one poll, then committed) — so no data is lost; the problem is a false alarm plus an observability gap (the hold logged WARNING but its resolution logged INFO / was silent, so a self-healing event read as unresolved at HA's default level).

## Changes

**1. Widen two thresholds (`battery_splice.py`):** `cell_mV` 100→150, `cap_centiAh` 1000→1500.

This is safe by construction: the corpus's **only** corruption signature is the temperature-zero cohort (≥2 temp registers → rejected outright). Temp thresholds are untouched, and no corruption has ever presented as a lone `cell_mV` or `cap_centiAh` delta — so widening exactly these two classes cannot weaken detection.

Corpus re-validated under the new thresholds:
- 1086 clean / 17 corruption — unchanged.
- **Every one of the 17 still rejected outright** (each trips ≥2 physics or an immutable violation).
- **Zero** corruption demoted to a lone `1 physics + 0 immutable` (escrow) shape; zero false trips.

**2. De-alarm the self-healing singleton path to INFO (`plant.py`):**
- The lone-delta **hold**, its **confirm-on-re-read**, and a **new snapback reversion** log all emit at INFO — reworded to drop "physics-impossible" / "Please report if seen".
- The ≥2 / immutable **REJECT** stays at WARNING with "Please report if seen" — that's the genuine corruption signal.

So a self-healing one-poll hold no longer alarms, and the held→resolved story is told at one consistent level.

## Test plan

- [ ] `uv run pytest tests/model/test_battery_splice.py tests/model/test_plant.py -v` — updated boundary/level assertions + new snapback-INFO test
- [ ] `uv run python tests/debug/physics_delta_classify.py tests/fixtures/captures/*/*.log` — 1086/17 separation, all 17 rejected
- [ ] `uv run pytest -q` (1085) and `uv run tox` (py311–py314) green

The thresholds are calibrated on holdestmade's three field data points plus physics reasoning — I'll ask for a fuller AC3 capture over a charge↔discharge cycle to tighten the calibration if the singleton path keeps firing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved corruption detection accuracy for high-power battery systems by adjusting detection thresholds to reduce false positives from legitimate power fluctuations.
  * Enhanced diagnostic logging with clearer messages to distinguish between actual system issues and normal operational variations.
  * Refined escrow and revert handling to provide better visibility when temporary anomalies self-correct.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->