### PR TITLE
fix: recover a poisoned scalar-immutable battery baseline (#281)

### DIFF
--- a/givenergy_modbus/model/battery_splice.py
+++ b/givenergy_modbus/model/battery_splice.py
@@ -71,6 +71,16 @@ PAIR_RULES: list[tuple[str, tuple[int, int], int]] = [
 # corruption cohort it was meant to catch already trips the >=2-physics rule on the
 # temperatures themselves (#256 discussion).
 IMMUTABLE: list[int] = [37, 38, *range(50, 55)]
+# Scalar immutables — num_cells IR(97), bms_firmware_version IR(98). Constant in normal
+# operation, but a corrupt first frame can poison the cold-start baseline (#281), and a
+# genuine BMS firmware upgrade legitimately changes IR(98). Unlike the serial block these
+# are single uint16 scalars a healthy pack reports *stably*, so a sustained stable
+# disagreement is the real value and is recoverable (escrow / backstop in
+# Plant._splice_guard). ABSOLUTE IR numbers, to match a trip's ``trip[0]``.
+IMMUTABLE_SCALAR: frozenset[int] = frozenset({BANK_BASE + 37, BANK_BASE + 38})  # {97, 98}
+# Serial block IR(110-114). A genuine change means a different pack answered or a re-address
+# — never recoverable; always hard-reject. ABSOLUTE IR numbers.
+IMMUTABLE_SERIAL: frozenset[int] = frozenset(range(BANK_BASE + 50, BANK_BASE + 55))  # {110..114}
 # Exempt (no physics): status/warning words IR(90-94), i_battery IR(95), num_cycles IR(96),
 # usb_device_inserted IR(115), unknown/reserved IR(99,107-109,116-119).
 
@@ -93,6 +103,17 @@ THRESHOLD_BY_CLASS: dict[str, int] = {name: thr for name, _, thr in SCALAR_RULES
 #: Value: 10× the nominal ~30 s poll interval — survives transient hiccups, recovers a real outage
 #: on the first post-reconnect poll.
 STALE_BYPASS_SECONDS: int = 300
+
+#: Backstop recovery bound for a poisoned scalar-immutable baseline (IR97/IR98) that ALSO trips
+#: physics (#281), so the coherent-physics escrow can't engage. A *stable* scalar-immutable
+#: disagreement (the same incoming value every poll) that persists this many consecutive polls —
+#: OR this many seconds since the streak began, whichever first — forces a re-baseline. Both
+#: bounds resolve strictly inside STALE_BYPASS_SECONDS so a real poison self-heals well before the
+#: coarse stale bypass would, while oscillating garbage (changing value) resets the streak and
+#: never reaches either bound. Field report (#281): ~6-15 s poll cadence, so 6 polls ≈ 36-90 s and
+#: the 120 s ceiling both land comfortably under 300 s even at the slow end.
+SCALAR_IMMUT_STREAK_POLLS: int = 6
+SCALAR_IMMUT_STREAK_SECONDS: int = 120
 
 #: A single trip: (absolute IR number, class name, old comparable value, new comparable value).
 #: For pair rules the comparable values are the assembled uint32s, not the high word alone.

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -896,6 +896,11 @@ class Plant(GivEnergyBaseModel):
         if scalar_immut:
             return self._handle_scalar_immutable(device_address, scalar_immut, phys, now_ts)
 
+        # No scalar-immutable trip this poll: any in-progress scalar disagreement is interrupted, so
+        # the backstop streak resets here — it requires an *uninterrupted* stable signature. Covers
+        # both the physics-singleton path below and the clean-transition path (#281 review).
+        self._splice_immut_streak.pop(device_address, None)
+
         if len(phys) == 1:
             ir_no, name, _old, new_val = phys[0]
             held = self._splice_escrow.get(device_address)
@@ -924,8 +929,7 @@ class Plant(GivEnergyBaseModel):
 
         # Clean transition (no trips): a previously-held step that snapped back lands here, so
         # drop any escrow and commit. Log the reversion so the held->resolved story is visible at
-        # one level (the hold is INFO too).
-        self._splice_immut_streak.pop(device_address, None)  # baseline no longer disputed (#281)
+        # one level (the hold is INFO too). The scalar-immut streak was already cleared above.
         reverted = self._splice_escrow.pop(device_address, None)
         if reverted is not None:
             _logger.info(

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -10,6 +10,10 @@ from givenergy_modbus.model.aio_battery import AioBatteryModule
 from givenergy_modbus.model.battery import Battery, BatteryRegisterGetter
 from givenergy_modbus.model.battery_splice import (
     BANK_BASE,
+    IMMUTABLE_SCALAR,
+    IMMUTABLE_SERIAL,
+    SCALAR_IMMUT_STREAK_POLLS,
+    SCALAR_IMMUT_STREAK_SECONDS,
     STALE_BYPASS_SECONDS,
     THRESHOLD_BY_CLASS,
     classify_transition,
@@ -552,6 +556,18 @@ class Plant(GivEnergyBaseModel):
     # with a fresh Plant on reconnect; not serialised.
     _splice_last_seen: dict[int, datetime] = PrivateAttr(default_factory=dict)
 
+    # Scalar-immutable poison-recovery streak (#281): per battery device address,
+    # (signature, started_at, consecutive_count) where signature is the sorted tuple of
+    # (IR number, incoming value) over the poll's scalar-immutable trips (IR97/IR98). Tracks a
+    # *stable* disagreement on a constant scalar — a real value a healthy pack keeps reporting
+    # after a poisoned cold-start baseline, or a genuine BMS firmware upgrade. A changing
+    # signature (oscillating garbage) resets it, so corruption never accumulates a streak. Used
+    # by both the coherent-physics escrow (confirm on the second identical read) and the
+    # physics-drift backstop (force re-baseline once stable). Ephemeral; not serialised.
+    _splice_immut_streak: dict[int, tuple[tuple[tuple[int, int], ...], datetime, int]] = PrivateAttr(
+        default_factory=dict
+    )
+
     # Direct-inverter register caches injected by add_direct_source() for multi-Client
     # reconciliation (#106 Phase 3). Stored separately from register_caches to avoid the
     # Modbus address collision (both EMS controller and direct inverter live at 0x11).
@@ -843,6 +859,7 @@ class Plant(GivEnergyBaseModel):
         # but prev_seen stays ~one poll old, so this does NOT fire and the corruption stays rejected.
         if prev_seen is not None and (now_ts - prev_seen).total_seconds() > STALE_BYPASS_SECONDS:
             self._splice_escrow.pop(device_address, None)
+            self._splice_immut_streak.pop(device_address, None)
             _logger.info(
                 "Battery bank for device 0x%02x: %.0f s since the last observed bank — splice guard "
                 "bypassed (stale baseline); adopting as new baseline.",
@@ -853,17 +870,31 @@ class Plant(GivEnergyBaseModel):
 
         phys, immut = classify_transition(prev, new, present)
 
-        if immut or len(phys) >= 2:
+        # Split immutable trips by recoverability (#281): the serial block (IR110-114) genuinely
+        # can't change, but the scalar immutables (num_cells IR97, bms_firmware_version IR98) can be
+        # poisoned by a corrupt cold-start frame — or change legitimately on a BMS firmware upgrade —
+        # and a healthy pack reports them *stably*, so a sustained stable disagreement is recoverable.
+        serial_immut = [t for t in immut if t[0] in IMMUTABLE_SERIAL]
+        scalar_immut = [t for t in immut if t[0] in IMMUTABLE_SCALAR]
+
+        # Hard reject: a serial-block change (wrong pack / re-address), OR >=2 physics deltas with no
+        # recoverable scalar immutable (the temp-zero corruption cohort) — neither ever self-adopts.
+        if serial_immut or (len(phys) >= 2 and not scalar_immut):
             self._splice_escrow.pop(device_address, None)
-            reason = "constant-register change" if immut else ">=2 physics-impossible deltas"
+            self._splice_immut_streak.pop(device_address, None)
+            reason = "serial-block change" if serial_immut else ">=2 physics-impossible deltas"
             _logger.warning(
                 "Rejected battery bank for device 0x%02x — sub-bus splice (%s); keeping last-good. "
                 "Trips: %s. Please report if seen.",
                 device_address,
                 reason,
-                self._format_splice_trips(immut + phys),
+                self._format_splice_trips(serial_immut + phys),
             )
             return False
+
+        # Scalar-immutable change (no serial trip): escrow + re-baseline rather than reject (#281).
+        if scalar_immut:
+            return self._handle_scalar_immutable(device_address, scalar_immut, phys, now_ts)
 
         if len(phys) == 1:
             ir_no, name, _old, new_val = phys[0]
@@ -894,6 +925,7 @@ class Plant(GivEnergyBaseModel):
         # Clean transition (no trips): a previously-held step that snapped back lands here, so
         # drop any escrow and commit. Log the reversion so the held->resolved story is visible at
         # one level (the hold is INFO too).
+        self._splice_immut_streak.pop(device_address, None)  # baseline no longer disputed (#281)
         reverted = self._splice_escrow.pop(device_address, None)
         if reverted is not None:
             _logger.info(
@@ -903,6 +935,90 @@ class Plant(GivEnergyBaseModel):
                 reverted[0],
             )
         return True
+
+    def _handle_scalar_immutable(
+        self,
+        device_address: int,
+        scalar_immut: list[tuple[int, str, int, int]],
+        phys: list[tuple[int, str, int, int]],
+        now_ts: datetime,
+    ) -> bool:
+        """Escrow / re-baseline a scalar-immutable (IR97/IR98) disagreement instead of rejecting (#281).
+
+        A scalar immutable that reads the same incoming value identically across polls is the real
+        value — the cached baseline was poisoned by a corrupt cold-start frame, or the BMS firmware
+        was legitimately upgraded — so adopt it rather than rejecting forever (the bug this fixes).
+        Two paths share one streak counter keyed on the incoming signature:
+
+        * coherent physics (no other trips) — adopt on the second identical read (~2 polls), a
+          high-confidence poison signal;
+        * with physics drift — keep rejecting, but adopt once the same signature persists
+          ``SCALAR_IMMUT_STREAK_POLLS`` polls or ``SCALAR_IMMUT_STREAK_SECONDS`` seconds (whichever
+          first, both inside the 300 s stale window).
+
+        A *changing* signature (oscillating garbage) restarts the streak and never adopts, so genuine
+        corruption can't self-heal into the cache. Returns True to commit (adopt), False to hold.
+        """
+        sig = tuple(sorted((ir_no, new_val) for ir_no, _name, _old, new_val in scalar_immut))
+        streak = self._splice_immut_streak.get(device_address)
+
+        # Coherent physics: a single identical re-read is enough (high-confidence poison signal).
+        if not phys:
+            if streak is not None and streak[0] == sig:
+                self._splice_escrow.pop(device_address, None)
+                self._splice_immut_streak.pop(device_address, None)
+                _logger.info(
+                    "Battery bank for device 0x%02x: constant register(s) %s read identically twice "
+                    "with coherent physics — cold-start baseline was poisoned; adopting incoming as "
+                    "new baseline.",
+                    device_address,
+                    self._fmt_scalar_sig(scalar_immut),
+                )
+                return True
+            self._splice_immut_streak[device_address] = (sig, now_ts, 1)
+            _logger.info(
+                "Battery bank for device 0x%02x: constant register(s) %s disagree with baseline "
+                "(coherent physics) — held one poll pending an identical re-read.",
+                device_address,
+                self._fmt_scalar_sig(scalar_immut),
+            )
+            return False
+
+        # Physics also drifted: less confident, so require a sustained stable streak before adopting.
+        if streak is not None and streak[0] == sig:
+            started, count = streak[1], streak[2] + 1
+            elapsed = (now_ts - started).total_seconds()
+            if count >= SCALAR_IMMUT_STREAK_POLLS or elapsed >= SCALAR_IMMUT_STREAK_SECONDS:
+                self._splice_escrow.pop(device_address, None)
+                self._splice_immut_streak.pop(device_address, None)
+                _logger.info(
+                    "Battery bank for device 0x%02x: constant register(s) %s stably disagreed with "
+                    "baseline for %d consecutive polls (%.0f s) — cold-start baseline was poisoned; "
+                    "adopting incoming as new baseline.",
+                    device_address,
+                    self._fmt_scalar_sig(scalar_immut),
+                    count,
+                    elapsed,
+                )
+                return True
+            self._splice_immut_streak[device_address] = (sig, started, count)
+        else:
+            # New device, or the signature changed (oscillating garbage): (re)start the streak.
+            self._splice_immut_streak[device_address] = (sig, now_ts, 1)
+
+        self._splice_escrow.pop(device_address, None)
+        _logger.warning(
+            "Rejected battery bank for device 0x%02x — sub-bus splice (constant-register change with "
+            "physics drift); keeping last-good. Trips: %s. Please report if seen.",
+            device_address,
+            self._format_splice_trips(scalar_immut + phys),
+        )
+        return False
+
+    @staticmethod
+    def _fmt_scalar_sig(scalar_immut: list[tuple[int, str, int, int]]) -> str:
+        """Render scalar-immutable trips compactly for the INFO logs, e.g. ``IR(98) 3005->3010``."""
+        return ", ".join(f"IR({ir_no}) {old}->{new}" for ir_no, _name, old, new in scalar_immut)
 
     @staticmethod
     def _format_splice_trips(trips: list[tuple[int, str, int, int]]) -> str:

--- a/tests/model/test_battery_splice.py
+++ b/tests/model/test_battery_splice.py
@@ -8,6 +8,8 @@ is exercised in test_plant.py.
 from givenergy_modbus.model.battery_splice import (
     BANK_BASE,
     IMMUTABLE,
+    IMMUTABLE_SCALAR,
+    IMMUTABLE_SERIAL,
     THRESHOLD_BY_CLASS,
     classify_transition,
 )
@@ -43,6 +45,18 @@ def test_ir115_is_dropped_from_immutable():
     """IR(115) (bank index 55) must not be immutable — it's a mutable usb_device_inserted field."""
     assert 55 not in IMMUTABLE
     assert IMMUTABLE == [37, 38, 50, 51, 52, 53, 54]
+
+
+def test_immutable_scalar_serial_partition_covers_immutable():
+    """The scalar/serial split (#281) partitions IMMUTABLE exactly — no overlap, no gap.
+
+    Scalar/serial sets are ABSOLUTE IR numbers (to match a trip's ``trip[0]``); IMMUTABLE is
+    the bank-relative union the classifier loops over.
+    """
+    assert IMMUTABLE_SCALAR == {97, 98}  # num_cells, bms_firmware_version
+    assert IMMUTABLE_SERIAL == {110, 111, 112, 113, 114}  # serial block
+    assert IMMUTABLE_SCALAR.isdisjoint(IMMUTABLE_SERIAL)
+    assert {BANK_BASE + i for i in IMMUTABLE} == IMMUTABLE_SCALAR | IMMUTABLE_SERIAL
 
 
 def test_single_cell_voltage_step_is_one_physics_trip():

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -2483,14 +2483,19 @@ _BATT = 0x33  # battery pack #1 on bare Plant; 0x32 → inverter getter on bare 
 
 
 def test_splice_capacity_cohort_rejected(plant: Plant, caplog):
-    """A cap-pair physics step + immutable mutation is rejected outright (constant-register change)."""
+    """A cap-pair physics step + scalar-immutable mutation rejects on the first poll (#281).
+
+    With the scalar-immutable split this is no longer a hard reject — it's the backstop's
+    first poll (1 physics trip, not >=2), so the bank is held and the streak armed. Recovery
+    only happens if the same value persists (see the backstop test); a lone poll stays rejected.
+    """
     import logging
 
     _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)
     corrupted = _coherent_battery_bank(
         {
-            89: 36000,  # IR89: cap_remaining low word 16000 → 36000, pair delta 20000 > 1000 threshold
-            98: 3006,  # IR98: bms_fw IMMUTABLE violation
+            89: 36000,  # IR89: cap_remaining low word 16000 → 36000, pair delta 20000 > 1500 threshold
+            98: 3006,  # IR98: bms_fw scalar-immutable violation
         }
     )
     with caplog.at_level(logging.WARNING, logger="givenergy_modbus.model.plant"):
@@ -2499,7 +2504,87 @@ def test_splice_capacity_cohort_rejected(plant: Plant, caplog):
     assert plant.register_caches[_BATT][IR(98)] == 3005
     warns = [r for r in caplog.records if "Rejected battery bank" in r.message and "0x33" in r.message]
     assert len(warns) == 1
-    assert "constant-register change" in warns[0].message
+    assert "constant-register change with physics drift" in warns[0].message
+
+
+def test_splice_poisoned_scalar_immut_self_heals_via_escrow(plant: Plant, caplog):
+    """A poisoned cold-start IR98 baseline self-heals via escrow once the true value reads twice (#281).
+
+    Cold start commits a corrupt IR98 (9999); every later poll reports the true 3005 with
+    otherwise-coherent physics. Two identical reads ⇒ the baseline was poisoned ⇒ adopt.
+    """
+    import logging
+
+    poisoned = _coherent_battery_bank({98: 9999})  # corrupt first frame adopted at cold start
+    _feed_bank(plant, poisoned, device_address=_BATT, received_at=_T0)
+    assert plant.register_caches[_BATT][IR(98)] == 9999
+
+    healthy = _coherent_battery_bank()  # true IR98 == 3005, otherwise identical → coherent physics
+    with caplog.at_level(logging.INFO, logger="givenergy_modbus.model.plant"):
+        _feed_bank(plant, healthy, device_address=_BATT, received_at=_T0 + timedelta(seconds=10))
+        assert plant.register_caches[_BATT][IR(98)] == 9999  # held one poll, not yet adopted
+        _feed_bank(plant, healthy, device_address=_BATT, received_at=_T0 + timedelta(seconds=20))
+    assert plant.register_caches[_BATT][IR(98)] == 3005  # confirmed identical re-read → adopted
+    adopts = [r for r in caplog.records if "baseline was poisoned" in r.message and "0x33" in r.message]
+    assert len(adopts) == 1 and adopts[0].levelno == logging.INFO
+    assert not [r for r in caplog.records if "Rejected battery bank" in r.message]  # never a WARNING
+
+
+def test_splice_poisoned_scalar_immut_with_drift_self_heals_via_backstop(plant: Plant, caplog):
+    """A poisoned IR98 baseline that also trips physics self-heals via the backstop (#281).
+
+    The healthy polls carry the true IR98 *and* a sustained out-of-threshold cell delta, so the
+    coherent-physics escrow can't engage. The stable-signature streak forces a re-baseline at
+    the bound (6 polls @ 15 s = 90 s, well inside the 300 s stale window).
+    """
+    import logging
+
+    poisoned = _coherent_battery_bank({98: 9999})
+    _feed_bank(plant, poisoned, device_address=_BATT, received_at=_T0)
+    healthy = _coherent_battery_bank({98: 3005, 60: 3600})  # IR60 +300 mV > 150 → 1 physics trip every poll
+    with caplog.at_level(logging.INFO, logger="givenergy_modbus.model.plant"):
+        for n in range(1, 7):  # 6 polls @ 15 s
+            _feed_bank(plant, healthy, device_address=_BATT, received_at=_T0 + timedelta(seconds=15 * n))
+    assert plant.register_caches[_BATT][IR(98)] == 3005  # whole bank adopted on the 6th poll
+    assert plant.register_caches[_BATT][IR(60)] == 3600
+    adopts = [
+        r
+        for r in caplog.records
+        if "stably disagreed" in r.message and "0x33" in r.message and r.levelno == logging.INFO
+    ]
+    assert len(adopts) == 1
+    rejects = [r for r in caplog.records if "physics drift" in r.message and "0x33" in r.message]
+    assert len(rejects) == 5  # polls 1-5 rejected, poll 6 adopted
+
+
+def test_splice_oscillating_scalar_immut_never_adopts(plant: Plant, caplog):
+    """Oscillating IR98 garbage never self-adopts — a changing signature resets the streak (#281)."""
+    import logging
+
+    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)  # clean seed: IR98 3005
+    with caplog.at_level(logging.INFO, logger="givenergy_modbus.model.plant"):
+        for n in range(1, 13):  # 12 polls @ 15 s = 180 s, still < 300 s (no stale bypass)
+            garbage = _coherent_battery_bank({98: 9000 + (n % 2) * 500, 60: 3600})  # IR98 flips each poll
+            _feed_bank(plant, garbage, device_address=_BATT, received_at=_T0 + timedelta(seconds=15 * n))
+    assert plant.register_caches[_BATT][IR(98)] == 3005  # last-good held; garbage never adopted
+    assert not [r for r in caplog.records if "baseline was poisoned" in r.message]
+    assert not [r for r in caplog.records if "stably disagreed" in r.message]
+
+
+def test_splice_serial_block_change_always_rejected(plant: Plant, caplog):
+    """A serial-block change is hard-rejected forever — wrong-pack / re-address protection (#281)."""
+    import logging
+
+    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)
+    swapped = _coherent_battery_bank({110: 0x4248})  # serial first word BG.. → a different pack
+    with caplog.at_level(logging.INFO, logger="givenergy_modbus.model.plant"):
+        for n in range(1, 25):  # 24 polls @ 15 s = 360 s; observation clock refreshes so bypass never fires
+            _feed_bank(plant, swapped, device_address=_BATT, received_at=_T0 + timedelta(seconds=15 * n))
+    assert plant.register_caches[_BATT][IR(110)] == 0x4247  # last-good serial held forever
+    serial_rejects = [r for r in caplog.records if "serial-block change" in r.message and "0x33" in r.message]
+    assert len(serial_rejects) == 24
+    assert not [r for r in caplog.records if "baseline was poisoned" in r.message]
+    assert not [r for r in caplog.records if "stably disagreed" in r.message]
 
 
 def test_splice_cell_and_temp_cohort_rejected(plant: Plant, caplog):

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -2587,6 +2587,30 @@ def test_splice_serial_block_change_always_rejected(plant: Plant, caplog):
     assert not [r for r in caplog.records if "stably disagreed" in r.message]
 
 
+def test_splice_backstop_streak_requires_uninterrupted_signature(plant: Plant, caplog):
+    """An interrupting poll with no scalar-immut trip resets the backstop streak (#281 review).
+
+    The backstop must require an *uninterrupted* stable scalar signature: 5 drift polls, then one
+    poll where IR98 momentarily matches the (still-poisoned) baseline — no scalar trip — then 5
+    more drift polls. Without the reset the streak would reach 6 and adopt on the first
+    post-interruption poll; with it the count restarts, so the poison baseline is NOT adopted.
+    """
+    import logging
+
+    poisoned = _coherent_battery_bank({98: 9999})
+    _feed_bank(plant, poisoned, device_address=_BATT, received_at=_T0)
+    drift = _coherent_battery_bank({98: 3005, 60: 3600})  # scalar trip (IR98) + 1 physics trip (IR60)
+    interrupt = _coherent_battery_bank({98: 9999, 60: 3600})  # IR98 == baseline → no scalar trip
+    with caplog.at_level(logging.INFO, logger="givenergy_modbus.model.plant"):
+        for n in range(1, 6):  # polls 1-5: streak builds to 5 (need 6)
+            _feed_bank(plant, drift, device_address=_BATT, received_at=_T0 + timedelta(seconds=10 * n))
+        _feed_bank(plant, interrupt, device_address=_BATT, received_at=_T0 + timedelta(seconds=60))  # reset
+        for n in range(7, 12):  # polls 7-11: streak restarts 1-5, still short of 6
+            _feed_bank(plant, drift, device_address=_BATT, received_at=_T0 + timedelta(seconds=10 * n))
+    assert plant.register_caches[_BATT][IR(98)] == 9999  # never adopted — streak was interrupted
+    assert not [r for r in caplog.records if "stably disagreed" in r.message]
+
+
 def test_splice_cell_and_temp_cohort_rejected(plant: Plant, caplog):
     """Two independent physics trips (a cell + a temperature) are rejected outright (≥2-physics rule)."""
     import logging


### PR DESCRIPTION
Fixes #281.

## The bug

A healthy battery pack could be stuck "unavailable" until a dongle power-cycle. If a corrupt first frame after a restart was adopted as the cold-start baseline for a constant register — here `bms_firmware_version` (IR98) baselined as `2241` instead of the real `3009` — then every subsequent *correct* frame disagreed on that immutable, tripped the splice guard, and the bank was rejected indefinitely. The stale-baseline bypass can't recover it, because the observation clock refreshes on every (rejected) poll, so only a real comms gap clears it.

Worth flagging: the same code path also bricks a *legitimate* BMS firmware upgrade — IR98 changing in-range trips the immutable check just as hard — so this isn't only about corruption.

## The fix

Split immutable handling by recoverability:

- **Serial block (IR110-114)** — genuinely can't change (a different pack, or a re-address); stays a hard reject.
- **Scalar immutables (IR97 `num_cells`, IR98 `bms_firmware_version`)** — a healthy pack reports these stably, so a *stable* disagreement is the real value and re-baselines rather than rejecting:
  - coherent physics → adopt on the second identical read (~2 polls);
  - with physics drift (the baseline's been pinned long enough that SoC/cap have moved too) → keep rejecting, but adopt once the same signature persists 6 polls / 120 s — both inside the existing 300 s stale window.
- A *changing* (oscillating) signature restarts the streak and never self-adopts, so genuine corruption can't heal into the cache; `>=2`-physics corruption (the temp-zero cohort) still rejects forever.

I kept this model-agnostic on purpose — no per-model firmware-range or `num_cells` bounds. The recovery is needed regardless (the firmware-upgrade case above), and per-model validity wants a declarative home rather than being bolted onto the guard, so I've deferred that.

## Tests

New regression coverage mirroring the existing splice harness: poisoned cold-start self-heals via escrow; poisoned + drift self-heals via the backstop; oscillating garbage never adopts; serial-block change rejects forever; and the existing temp-zero corruption test still never recovers. Full suite green, tox green across py311-py314.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced battery data corruption detection and recovery logic. The system now gracefully handles corrupted scalar-immutable battery register values by monitoring for stable disagreements across consecutive polls before re-establishing baselines, improving reliability and reducing false rejections.

* **Tests**
  * Added comprehensive test coverage for scalar-immutable register partitioning and regression scenarios, including poisoning recovery paths and oscillating value handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->