### PR TITLE
fix(mock): give multi-instance devices distinct serials to avoid collisions

### DIFF
--- a/givenergy_modbus/testing/mock_plant.py
+++ b/givenergy_modbus/testing/mock_plant.py
@@ -25,12 +25,15 @@ from __future__ import annotations
 import argparse
 import asyncio
 import logging
+from collections import Counter
 from pathlib import Path
 from typing import cast
 
 from givenergy_modbus.framer import ServerFramer
+from givenergy_modbus.model.aio_battery import AioBatteryModuleRegisterGetter
+from givenergy_modbus.model.battery import BatteryRegisterGetter
 from givenergy_modbus.model.plant import Plant
-from givenergy_modbus.model.register import HR, IR, MR, Register
+from givenergy_modbus.model.register import HR, IR, MR, Register, RegisterGetter
 from givenergy_modbus.model.register_cache import RegisterCache
 from givenergy_modbus.pdu import (
     ClientIncomingMessage,
@@ -108,6 +111,58 @@ def plant_from_capture(*paths: str | Path) -> Plant:
     return plant
 
 
+# Device-address ranges that can host multiple instances of one serial-bearing device type,
+# each mapped to the getter whose ``serial_number`` Def locates the serial registers. Capture
+# fixtures redact every serial to an identical placeholder (and the byte-level fixture policy
+# forbids editing them — see scripts/regen_fixture_crcs.py), so replayed multi-instance devices
+# collide on serial, which breaks consumers that key entities by serial (e.g. AIO modules in
+# Home Assistant). Only IR/``C.serial`` 5-register devices are handled here; meters (MR/
+# ``C.string``) and HV BMUs (stride within a single 0x70 cache) use other layouts — out of scope.
+_SERIAL_DEVICE_GETTERS: tuple[tuple[range, type[RegisterGetter]], ...] = (
+    (range(0x33, 0x38), BatteryRegisterGetter),  # LV battery packs (bare-plant addressing)
+    (range(0x50, 0x54), AioBatteryModuleRegisterGetter),  # AIO battery modules
+)
+
+
+def _decode_serial(cache: RegisterCache, regs: tuple[Register, ...] | list[Register]) -> str | None:
+    """Decode a serial from its registers in a cache (mirrors the model serial converter)."""
+    values = [cache.get(r) for r in regs]
+    if any(v is None for v in values):
+        return None
+    raw = b"".join(v.to_bytes(2, "big") for v in values if v is not None)
+    return raw.decode("latin1").replace("\x00", "").upper() or None
+
+
+def _encode_serial(serial: str, n_regs: int) -> list[int]:
+    """Encode a serial string into ``n_regs`` big-endian uint16 registers (inverse of decode)."""
+    data = serial.encode("latin1")[: n_regs * 2].ljust(n_regs * 2, b"\x00")
+    return [int.from_bytes(data[i * 2 : i * 2 + 2], "big") for i in range(n_regs)]
+
+
+def _make_device_serials_distinct(plant: Plant) -> None:
+    """Give each instance of a multi-instance device a distinct serial where the capture collides.
+
+    Fixtures redact every serial to the same placeholder, so replayed packs/modules share a serial
+    and collide downstream. For each device group with duplicate non-empty serials, re-tail each
+    member's serial with its device address — preserving the real prefix, making it unique, and
+    keeping it obviously synthetic. Distinct or singular serials are left untouched; only the
+    in-memory mock caches are changed, never the fixture bytes.
+    """
+    caches = plant.register_caches
+    for addr_range, getter in _SERIAL_DEVICE_GETTERS:
+        regs = getter.registers_of("serial_number")
+        if not regs:
+            continue
+        serials = {addr: _decode_serial(caches[addr], regs) for addr in addr_range if addr in caches}
+        named = {addr: s for addr, s in serials.items() if s}
+        shared = {s for s, n in Counter(named.values()).items() if n > 1}
+        for addr, serial in named.items():
+            if serial in shared and len(serial) >= 2:  # only re-tail the colliding members
+                distinct = serial[:-2] + f"{addr:02x}"
+                for reg, value in zip(regs, _encode_serial(distinct, len(regs))):
+                    caches[addr][reg] = value
+
+
 class MockPlant:
     """A TCP server impersonating a GivEnergy plant, seeded from a capture."""
 
@@ -131,6 +186,7 @@ class MockPlant:
     def from_capture(cls, *paths: str | Path) -> MockPlant:
         """Build a mock plant seeded from one or more capture ``.log`` files."""
         plant = plant_from_capture(*paths)
+        _make_device_serials_distinct(plant)
         return cls(
             plant.register_caches,
             inverter_serial=plant.inverter_serial_number,

--- a/givenergy_modbus/testing/mock_plant.py
+++ b/givenergy_modbus/testing/mock_plant.py
@@ -111,19 +111,6 @@ def plant_from_capture(*paths: str | Path) -> Plant:
     return plant
 
 
-# Device-address ranges that can host multiple instances of one serial-bearing device type,
-# each mapped to the getter whose ``serial_number`` Def locates the serial registers. Capture
-# fixtures redact every serial to an identical placeholder (and the byte-level fixture policy
-# forbids editing them — see scripts/regen_fixture_crcs.py), so replayed multi-instance devices
-# collide on serial, which breaks consumers that key entities by serial (e.g. AIO modules in
-# Home Assistant). Only IR/``C.serial`` 5-register devices are handled here; meters (MR/
-# ``C.string``) and HV BMUs (stride within a single 0x70 cache) use other layouts — out of scope.
-_SERIAL_DEVICE_GETTERS: tuple[tuple[range, type[RegisterGetter]], ...] = (
-    (range(0x33, 0x38), BatteryRegisterGetter),  # LV battery packs (bare-plant addressing)
-    (range(0x50, 0x54), AioBatteryModuleRegisterGetter),  # AIO battery modules
-)
-
-
 def _decode_serial(cache: RegisterCache, regs: tuple[Register, ...] | list[Register]) -> str | None:
     """Decode a serial from its registers in a cache (mirrors the model serial converter)."""
     values = [cache.get(r) for r in regs]
@@ -147,9 +134,22 @@ def _make_device_serials_distinct(plant: Plant) -> None:
     member's serial with its device address — preserving the real prefix, making it unique, and
     keeping it obviously synthetic. Distinct or singular serials are left untouched; only the
     in-memory mock caches are changed, never the fixture bytes.
+
+    Only IR/``C.serial`` 5-register devices are handled (LV battery packs, AIO modules); meters
+    (MR/``C.string``) and HV BMUs (stride within a single 0x70 cache) use other layouts and are
+    out of scope.
     """
     caches = plant.register_caches
-    for addr_range, getter in _SERIAL_DEVICE_GETTERS:
+    # Unified addressing (inverter at 0x11/0x31) puts LV battery pack #1 at 0x32; legacy bare-plant
+    # addressing keeps the inverter facade at 0x32 (pack #1 at 0x33). Gate strictly on the canonical
+    # inverter addresses present in the caches so a legacy capture never has its inverter serial
+    # rewritten as if it were a battery pack (#283 review).
+    lv_start = 0x32 if (0x11 in caches or 0x31 in caches) else 0x33
+    serial_device_getters: tuple[tuple[range, type[RegisterGetter]], ...] = (
+        (range(lv_start, 0x38), BatteryRegisterGetter),  # LV battery packs
+        (range(0x50, 0x54), AioBatteryModuleRegisterGetter),  # AIO battery modules
+    )
+    for addr_range, getter in serial_device_getters:
         regs = getter.registers_of("serial_number")
         if not regs:
             continue

--- a/tests/client/test_mock_plant_integration.py
+++ b/tests/client/test_mock_plant_integration.py
@@ -203,3 +203,54 @@ async def test_respond_returns_none_for_unknown_pdus():
     mock = MockPlant(devices={})
     hb = HeartbeatResponse(data_adapter_serial_number="AB1234G567", data_adapter_type=0)
     assert mock._respond(hb) is None
+
+
+# --- distinct device serials ------------------------------------------------
+
+
+def test_serial_encode_decode_roundtrip():
+    """`_encode_serial` is the inverse of `_decode_serial` over a 5-register IR serial."""
+    from givenergy_modbus.model.register import IR
+    from givenergy_modbus.testing.mock_plant import _decode_serial, _encode_serial
+
+    regs = [IR(114 + i) for i in range(5)]
+    cache = RegisterCache(dict(zip(regs, _encode_serial("HX2414G832", len(regs)))))
+    assert _decode_serial(cache, regs) == "HX2414G832"
+
+
+def test_make_device_serials_distinct_rewrites_only_collisions():
+    """Collided LV-pack serials become distinct (address-tailed); already-distinct ones are left."""
+    from givenergy_modbus.model.battery import BatteryRegisterGetter
+    from givenergy_modbus.model.plant import Plant
+    from givenergy_modbus.testing.mock_plant import (
+        _decode_serial,
+        _encode_serial,
+        _make_device_serials_distinct,
+    )
+
+    regs = BatteryRegisterGetter.registers_of("serial_number")  # IR(110-114)
+    plant = Plant()
+    for addr in (0x33, 0x34):  # share an identical redacted serial → collision
+        plant.register_caches[addr] = RegisterCache(dict(zip(regs, _encode_serial("BG0000G000", len(regs)))))
+    plant.register_caches[0x35] = RegisterCache(dict(zip(regs, _encode_serial("BG0000G999", len(regs)))))
+
+    _make_device_serials_distinct(plant)
+
+    assert _decode_serial(plant.register_caches[0x33], regs) == "BG0000G033"
+    assert _decode_serial(plant.register_caches[0x34], regs) == "BG0000G034"
+    assert _decode_serial(plant.register_caches[0x35], regs) == "BG0000G999"  # distinct already → untouched
+
+
+def test_aio_mock_serves_distinct_module_serials():
+    """The AIO mock gives each battery module its own serial (was all `HX0000G000`)."""
+    from givenergy_modbus.model.aio_battery import AioBatteryModule
+
+    mock = MockPlant.from_capture(_CAPTURES / "aio_a" / "aio_arm612_5min.log")
+    serials = {
+        addr: AioBatteryModule.from_register_cache(mock.devices[addr], addr).serial_number
+        for addr in (0x50, 0x51, 0x52, 0x53)
+    }
+    assert len(set(serials.values())) == 4, f"module serials must be distinct: {serials}"
+    for addr in (0x50, 0x51, 0x52, 0x53):
+        assert serials[addr].startswith("HX"), serials[addr]  # real prefix preserved
+        assert serials[addr].endswith(f"{addr:02x}"), serials[addr]  # address-tailed, distinct

--- a/tests/client/test_mock_plant_integration.py
+++ b/tests/client/test_mock_plant_integration.py
@@ -254,3 +254,48 @@ def test_aio_mock_serves_distinct_module_serials():
     for addr in (0x50, 0x51, 0x52, 0x53):
         assert serials[addr].startswith("HX"), serials[addr]  # real prefix preserved
         assert serials[addr].endswith(f"{addr:02x}"), serials[addr]  # address-tailed, distinct
+
+
+def test_make_device_serials_distinct_includes_0x32_under_unified_addressing():
+    """With a 0x11 inverter present, pack #1 lives at 0x32 and must join the collision set (#283)."""
+    from givenergy_modbus.model.battery import BatteryRegisterGetter
+    from givenergy_modbus.model.plant import Plant
+    from givenergy_modbus.testing.mock_plant import (
+        _decode_serial,
+        _encode_serial,
+        _make_device_serials_distinct,
+    )
+
+    regs = BatteryRegisterGetter.registers_of("serial_number")
+    plant = Plant()
+    plant.register_caches[0x11] = RegisterCache()  # canonical inverter present → 0x32 is a pack
+    for addr in (0x32, 0x33):  # both packs share the redacted placeholder → collision
+        plant.register_caches[addr] = RegisterCache(dict(zip(regs, _encode_serial("BG0000G000", len(regs)))))
+
+    _make_device_serials_distinct(plant)
+
+    assert _decode_serial(plant.register_caches[0x32], regs) == "BG0000G032"
+    assert _decode_serial(plant.register_caches[0x33], regs) == "BG0000G033"
+
+
+def test_make_device_serials_distinct_leaves_legacy_inverter_at_0x32():
+    """Without a canonical inverter address, 0x32 is the inverter facade and must not be rewritten."""
+    from givenergy_modbus.model.battery import BatteryRegisterGetter
+    from givenergy_modbus.model.plant import Plant
+    from givenergy_modbus.testing.mock_plant import (
+        _decode_serial,
+        _encode_serial,
+        _make_device_serials_distinct,
+    )
+
+    regs = BatteryRegisterGetter.registers_of("serial_number")
+    plant = Plant()  # no 0x11/0x31 → legacy bare-plant addressing, 0x32 is the inverter
+    plant.register_caches[0x32] = RegisterCache(dict(zip(regs, _encode_serial("SA0000G000", len(regs)))))
+    for addr in (0x33, 0x34):  # the actual packs collide
+        plant.register_caches[addr] = RegisterCache(dict(zip(regs, _encode_serial("BG0000G000", len(regs)))))
+
+    _make_device_serials_distinct(plant)
+
+    assert _decode_serial(plant.register_caches[0x32], regs) == "SA0000G000"  # inverter untouched
+    assert _decode_serial(plant.register_caches[0x33], regs) == "BG0000G033"
+    assert _decode_serial(plant.register_caches[0x34], regs) == "BG0000G034"


### PR DESCRIPTION
## The problem

Reported by the Home Assistant integration: when testing against the AIO mock server, all four AIO battery modules report the **same** placeholder serial `HX0000G000`, so HA — which keys per-module entities by serial — rejected the 2nd–4th with "unique ID already exists" (~36 errors per duplicate on every reload).

The root cause generalises beyond AIO: capture fixtures are redacted at capture time (every serial zeroed to an identical placeholder), and a documented policy (`scripts/regen_fixture_crcs.py`, `tests/fixtures/captures/README.md`) forbids editing the fixture bytes. So **any** multi-instance, serial-bearing device the mock replays collides the same way — AIO modules today, LV battery packs the same shape. The fix belongs in the mock, and should cover the class rather than just AIO.

## The fix

`MockPlant.from_capture` now runs a collision-only transform. For each multi-instance device group it decodes the members' serials, and where two or more **share** a serial it re-tails each colliding member with its device address — preserving the real prefix, making it unique, and keeping it obviously synthetic (`HX0000G050/051/052/053`).

- **Model-driven, no hardcoded register offsets** — the serial registers come from each getter's `registers_of("serial_number")`.
- **Collision-only** — serials that are already distinct, and singular devices (the inverter), are left untouched.
- **Fixture-safe** — only the in-memory mock caches change; the committed capture bytes are never touched.

Scoped to the IR/`C.serial` 5-register family (AIO modules `0x50–0x53`, LV packs `0x33–0x37`). Meters use a different scheme (`MR` registers, `C.string`) and HV BMUs live as strides inside one cache — both noted as out-of-scope follow-ups rather than expanded here.

## Tests

Encode/decode round-trip; a collision-only unit test (two LV packs sharing a serial become distinct while an already-distinct third is left alone); and an AIO integration test asserting the four modules serve distinct, address-tailed serials. Full suite green, tox green across py311–py314.

🤖 Generated with [Claude Code](https://claude.com/claude-code)