### PR TITLE
feat: per-device comms-quality counters on Plant (CRC, splice, retries)

### DIFF
--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -1451,11 +1451,17 @@ class Client:
                     f"Timeout awaiting {expected_response} (future: {response_future}), "
                     f"attempting retry {tries} of {retries}"
                 )
-                if tries <= retries and retry_delay > 0:
-                    # Discard the orphaned future so a late response from this attempt
-                    # doesn't accidentally resolve into the next attempt's future.
-                    response_future.cancel()
-                    await asyncio.sleep(retry_delay)
+                if tries <= retries:
+                    # Count the consumed retry (#284), but only where a response was genuinely
+                    # expected — absent-device detect probes pass warn_timeout=False and their
+                    # expected timeouts shouldn't pollute the per-device retry noise floor.
+                    if warn_timeout:
+                        self.plant.record_retry(request.device_address)
+                    if retry_delay > 0:
+                        # Discard the orphaned future so a late response from this attempt
+                        # doesn't accidentally resolve into the next attempt's future.
+                        response_future.cancel()
+                        await asyncio.sleep(retry_delay)
                 continue
             response = response_future.result()
             if tries > 0:
@@ -1466,8 +1472,11 @@ class Client:
                 # Unlike the timeout path above, no response_future.cancel() is needed here:
                 # the future is already resolved (we just called .result()), so cancel() would
                 # be a no-op, and the next attempt overwrites expected_responses[hash] anyway.
-                if tries <= retries and retry_delay > 0:
-                    await asyncio.sleep(retry_delay)
+                if tries <= retries:
+                    if warn_timeout:  # count the consumed retry (#284); skip absent-device probes
+                        self.plant.record_retry(request.device_address)
+                    if retry_delay > 0:
+                        await asyncio.sleep(retry_delay)
                 continue
             return response
 

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -530,6 +530,18 @@ class Plant(GivEnergyBaseModel):
     # model_dump(): it's ephemeral runtime bookkeeping, not part of the plant's dumpable state.
     register_block_updated_at: dict[tuple[int, str, int, int], datetime] = Field(default_factory=dict, exclude=True)
 
+    # Per-device comms-quality counters (#284): cumulative, monotonic event counts keyed by
+    # device_address, for a consumer to surface a plant's "noise floor" without grepping logs.
+    # Each counter mirrors a log event one-for-one (so logs and counters always agree) and only
+    # ever increments — splice_held_count counts *hold events*, not currently-held banks. In-memory
+    # and cumulative-since-construction (a reconnect re-instantiates the Plant; consumers track
+    # reset-aware deltas). Excluded from model_dump() like the bookkeeping above — they're runtime
+    # diagnostics, not dumpable plant state, but remain public gettable attributes.
+    crc_failure_count: dict[int, int] = Field(default_factory=dict, exclude=True)
+    splice_reject_count: dict[int, int] = Field(default_factory=dict, exclude=True)
+    splice_held_count: dict[int, int] = Field(default_factory=dict, exclude=True)
+    retry_count: dict[int, int] = Field(default_factory=dict, exclude=True)
+
     # Content-staleness tracker — the duration substrate for frozen-BMS-cache detection (#91).
     # Keyed identically to register_block_updated_at; each value is (content_hash, unchanged_since)
     # where unchanged_since is the ingestion time of the FIRST commit in the current
@@ -633,6 +645,15 @@ class Plant(GivEnergyBaseModel):
             }
         )
 
+    @staticmethod
+    def _bump(counter: dict[int, int], device_address: int) -> None:
+        """Increment a per-device comms-quality counter (#284)."""
+        counter[device_address] = counter.get(device_address, 0) + 1
+
+    def record_retry(self, device_address: int) -> None:
+        """Record a consumed read retry for a device (#284); called by the Client per retry."""
+        self._bump(self.retry_count, device_address)
+
     def update(self, pdu: ClientIncomingMessage, *, received_at: datetime | None = None):
         """Update the Plant state from a PDU message.
 
@@ -655,6 +676,7 @@ class Plant(GivEnergyBaseModel):
         # address and serial fields in the envelope, so those are untrusted on exactly the frames
         # that fail here — a corrupt 0x11 response must not clobber the stable inverter identity.
         if getattr(pdu, "crc_failed", False) and not getattr(pdu, "lenient_crc_commit", False):
+            self._bump(self.crc_failure_count, pdu.device_address)
             _logger.warning(
                 "Skipping CRC-failed response from 0x%02x (base=%d) — no Plant state updated",
                 pdu.device_address,
@@ -882,6 +904,7 @@ class Plant(GivEnergyBaseModel):
         if serial_immut or (len(phys) >= 2 and not scalar_immut):
             self._splice_escrow.pop(device_address, None)
             self._splice_immut_streak.pop(device_address, None)
+            self._bump(self.splice_reject_count, device_address)
             reason = "serial-block change" if serial_immut else ">=2 physics-impossible deltas"
             _logger.warning(
                 "Rejected battery bank for device 0x%02x — sub-bus splice (%s); keeping last-good. "
@@ -915,6 +938,7 @@ class Plant(GivEnergyBaseModel):
                 )
                 return True
             self._splice_escrow[device_address] = (ir_no, new_val)
+            self._bump(self.splice_held_count, device_address)
             # A lone out-of-threshold delta is the self-healing escrow path: held one poll, then
             # committed if it persists (genuine step) or dropped if it reverts (transient). It is
             # NOT confirmed corruption — the >=2/immutable REJECT above is — so it logs at INFO to
@@ -980,6 +1004,7 @@ class Plant(GivEnergyBaseModel):
                 )
                 return True
             self._splice_immut_streak[device_address] = (sig, now_ts, 1)
+            self._bump(self.splice_held_count, device_address)
             _logger.info(
                 "Battery bank for device 0x%02x: constant register(s) %s disagree with baseline "
                 "(coherent physics) — held one poll pending an identical re-read.",
@@ -1011,6 +1036,7 @@ class Plant(GivEnergyBaseModel):
             self._splice_immut_streak[device_address] = (sig, now_ts, 1)
 
         self._splice_escrow.pop(device_address, None)
+        self._bump(self.splice_reject_count, device_address)
         _logger.warning(
             "Rejected battery bank for device 0x%02x — sub-bus splice (constant-register change with "
             "physics drift); keeping last-good. Trips: %s. Please report if seen.",

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -479,6 +479,58 @@ async def test_send_request_retries_on_error_response():
         drainer.cancel()
 
 
+async def test_retry_count_increments_on_consumed_retry():
+    """A consumed retry bumps the plant's per-device retry_count (#284)."""
+    client = Client(host="foo", port=4321)
+    req = WriteHoldingRegisterRequest(register=35, value=20)
+    expected_hash = req.expected_response().shape_hash()
+    attempt = 0
+
+    async def drain_and_respond():
+        nonlocal attempt
+        while True:
+            _, frame_sent, _ = await client.tx_queue.get()
+            client.tx_queue.task_done()
+            if frame_sent and not frame_sent.done():
+                frame_sent.set_result(True)
+            attempt += 1
+            if attempt >= 2:  # first attempt times out; resolve on the retry
+                await asyncio.sleep(0)
+                future = client.expected_responses.get(expected_hash)
+                if future and not future.done():
+                    future.set_result(WriteHoldingRegisterResponse(inverter_serial_number="", register=35, value=20))
+
+    drainer = asyncio.create_task(drain_and_respond())
+    try:
+        await client.send_request_and_await_response(req, timeout=0.02, retries=2, retry_delay=0)
+    finally:
+        drainer.cancel()
+    assert client.plant.retry_count == {req.device_address: 1}
+
+
+async def test_retry_count_excludes_probe_retries():
+    """Absent-device probes (warn_timeout=False) must not pollute retry_count (#284)."""
+    client = Client(host="foo", port=4321)
+    req = WriteHoldingRegisterRequest(register=35, value=20)
+
+    async def drain_queue():
+        while True:
+            _, frame_sent, _ = await client.tx_queue.get()
+            client.tx_queue.task_done()
+            if frame_sent and not frame_sent.done():
+                frame_sent.set_result(True)
+
+    drainer = asyncio.create_task(drain_queue())
+    try:
+        with pytest.raises(TimeoutError):
+            await client.send_request_and_await_response(
+                req, timeout=0.02, retries=1, retry_delay=0, warn_timeout=False
+            )
+    finally:
+        drainer.cancel()
+    assert client.plant.retry_count == {}
+
+
 async def test_send_request_sleeps_between_retries_on_timeout():
     """A retry_delay > 0 must impose a sleep between a timed-out attempt and the next.
 

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -531,6 +531,36 @@ async def test_retry_count_excludes_probe_retries():
     assert client.plant.retry_count == {}
 
 
+async def test_retry_count_excludes_probe_on_error_response_with_delay():
+    """An error-response retry with warn_timeout=False and a retry delay still skips retry_count (#284)."""
+    client = Client(host="foo", port=4321)
+    req = WriteHoldingRegisterRequest(register=35, value=20)
+    expected_hash = req.expected_response().shape_hash()
+
+    async def drain_and_error():
+        while True:
+            _, frame_sent, _ = await client.tx_queue.get()
+            client.tx_queue.task_done()
+            if frame_sent and not frame_sent.done():
+                frame_sent.set_result(True)
+            await asyncio.sleep(0)
+            future = client.expected_responses.get(expected_hash)
+            if future and not future.done():
+                error_resp = WriteHoldingRegisterResponse(inverter_serial_number="", register=35, value=20)
+                error_resp.error = True
+                future.set_result(error_resp)
+
+    drainer = asyncio.create_task(drain_and_error())
+    try:
+        with pytest.raises(TimeoutError):
+            await client.send_request_and_await_response(
+                req, timeout=0.02, retries=1, retry_delay=0.01, warn_timeout=False
+            )
+    finally:
+        drainer.cancel()
+    assert client.plant.retry_count == {}
+
+
 async def test_send_request_sleeps_between_retries_on_timeout():
     """A retry_delay > 0 must impose a sleep between a timed-out attempt and the next.
 

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -2134,6 +2134,54 @@ def test_crc_failed_lenient_commit_allows_data(plant: Plant):
     assert plant.register_caches[0x32][IR(61)] == 7
 
 
+# --- comms-quality counters (#284) ------------------------------------------
+
+
+def test_comms_quality_counters_initialised_empty():
+    plant = Plant()
+    assert plant.crc_failure_count == {}
+    assert plant.splice_reject_count == {}
+    assert plant.splice_held_count == {}
+    assert plant.retry_count == {}
+
+
+def test_crc_failure_count_increments_per_device(plant: Plant):
+    """Each skipped CRC-failed response bumps crc_failure_count for that device."""
+    pdu = _make_ir_pdu({60: 0}, base_register=60, register_count=60)
+    pdu.crc_failed = True
+    setattr(pdu, "lenient_crc_commit", False)
+    plant.update(pdu)
+    plant.update(pdu)
+    assert plant.crc_failure_count == {0x32: 2}
+
+
+def test_splice_reject_count_increments_on_hard_reject(plant: Plant):
+    """A hard-rejected battery bank bumps splice_reject_count, not splice_held_count."""
+    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)
+    corrupt = _coherent_battery_bank({76 + i: 0 for i in range(4)})  # 4 temp-zeros → >=2 physics
+    _feed_bank(plant, corrupt, device_address=_BATT, received_at=_T0 + timedelta(seconds=30))
+    assert plant.splice_reject_count == {_BATT: 1}
+    assert plant.splice_held_count == {}
+
+
+def test_splice_held_count_increments_on_escrow(plant: Plant):
+    """A single-delta escrow hold bumps splice_held_count, not splice_reject_count."""
+    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)
+    wild = _coherent_battery_bank({60: 3600})  # one out-of-threshold delta → hold one poll
+    _feed_bank(plant, wild, device_address=_BATT, received_at=_T0 + timedelta(seconds=30))
+    assert plant.splice_held_count == {_BATT: 1}
+    assert plant.splice_reject_count == {}
+
+
+def test_splice_held_count_tracks_scalar_immutable_coherent_hold(plant: Plant):
+    """The #281 coherent scalar-immutable hold counts as a held event."""
+    poisoned = _coherent_battery_bank({98: 9999})
+    _feed_bank(plant, poisoned, device_address=_BATT, received_at=_T0)  # cold-start adopts (no count)
+    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0 + timedelta(seconds=10))
+    assert plant.splice_held_count == {_BATT: 1}
+    assert plant.splice_reject_count == {}
+
+
 def test_content_unchanged_seconds_normalises_naive_now(plant: Plant):
     """A timezone-naive now is treated as UTC rather than raising TypeError (mirrors block_age)."""
     bank = {110: 0x4358, 111: 0x3232, 112: 0x3331, 113: 0x4734, 114: 0x3832}


### PR DESCRIPTION
Closes #284.

## What

Four cumulative, per-device event counters on `Plant`, keyed by `device_address`, so a consumer can read a plant's comms "noise floor" without grepping WARNING logs after the fact:

- `crc_failure_count` — +1 each time a CRC-failed response is skipped
- `splice_reject_count` — +1 each time a battery bank is hard-rejected (keep-last-good)
- `splice_held_count` — +1 each time a bank is escrowed/held pending confirmation
- `retry_count` — +1 per consumed read retry, per device

Today these are log-only and invisible to a `refresh()` caller — the keep-last-good guards report a *successful* poll while skipping the bad frame, and a read that recovers on retry also looks clean — so a consumer can't see any of them.

## Design

- **Counter == log event.** Each increment sits next to the exact log line it mirrors (CRC-skip in `update()`; both "Rejected battery bank" WARNINGs including the #281 backstop; both "held one poll" INFOs including the #281 coherent scalar-immutable hold), so logs and counters always agree.
- **Monotonic, never decremented.** `splice_held_count` counts *hold events*, not currently-held banks.
- **`retry_count` is gated on `warn_timeout`.** Absent-device detect probes pass `warn_timeout=False` and time out by design, so they're excluded — only genuine reads/writes (where a response was expected) count toward the noise floor.
- **Public attributes**, `Field(default_factory=dict, exclude=True)` — live, gettable, but kept out of `model_dump()` like the sibling `register_block_updated_at` runtime bookkeeping. In-memory / cumulative-since-construction; the consumer tracks reset-aware deltas across reconnects.

## Consumer side

The givenergy-hass integration already reads all four defensively (`getattr(plant, …, {})`), so it ships as a no-op on current modbus and lights up once the floor bumps to whatever release adds these — no coordination window beyond the version bump.

## Tests

Per-counter coverage: CRC-skip increments per device; the hard-reject vs escrow-hold split; the #281 scalar-immutable coherent hold; a consumed retry bumps `retry_count`; and a `warn_timeout=False` probe does not. Full suite green, tox green across py311–py314.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added per-device communication quality diagnostics to monitor device connection reliability, including failure and retry counters.

* **Improvements**
  * Refined retry logic for improved fault handling and recovery accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->