### PR TITLE
fix: hold scalar-immutable battery disagreements, heal only after long (tunable) insistence

### DIFF
--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -325,7 +325,7 @@ class Client:
         tx_message_wait: float = 0.25,
         tx_jitter: float = 0.1,
         plant: Plant | None = None,
-        splice_heal_seconds: float = 900.0,
+        splice_heal_seconds: float | None = None,
     ) -> None:
         self.host = host
         self.port = port
@@ -348,12 +348,14 @@ class Client:
         # multi-Client path is separate Plants + plant.add_direct_source().
         self.plant = plant if plant is not None else Plant()
         # How long to hold last-good for a disputed *constant* battery register (num_cells,
-        # bms_firmware_version) before healing to a sustained new value (#286). Applied whether the
-        # plant was injected or freshly created. Larger = more robust against ongoing splice
-        # corruption (which reverts in minutes); smaller = faster recovery from a genuinely poisoned
-        # cold-start baseline. Consumers can watch plant.splice_held_count + plant.block_age() to see
-        # when data is being held.
-        self.plant.splice_heal_seconds = splice_heal_seconds
+        # bms_firmware_version) before healing to a sustained new value (#286). Applied only when
+        # explicitly given, so an injected plant's own splice_heal_seconds isn't silently clobbered;
+        # otherwise the Plant field's own default (900 s) stands. Larger = more robust against
+        # ongoing splice corruption (which reverts in minutes); smaller = faster recovery from a
+        # genuinely poisoned cold-start baseline. Consumers can watch plant.splice_held_count +
+        # plant.block_age() to see when data is being held.
+        if splice_heal_seconds is not None:
+            self.plant.splice_heal_seconds = splice_heal_seconds
         self.tx_queue = Queue(maxsize=20)
         self.expected_responses = {}
         self._shutting_down = False

--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -325,6 +325,7 @@ class Client:
         tx_message_wait: float = 0.25,
         tx_jitter: float = 0.1,
         plant: Plant | None = None,
+        splice_heal_seconds: float = 900.0,
     ) -> None:
         self.host = host
         self.port = port
@@ -346,6 +347,13 @@ class Client:
         # inverter both at 0x11) will overwrite each other's cache. The safe
         # multi-Client path is separate Plants + plant.add_direct_source().
         self.plant = plant if plant is not None else Plant()
+        # How long to hold last-good for a disputed *constant* battery register (num_cells,
+        # bms_firmware_version) before healing to a sustained new value (#286). Applied whether the
+        # plant was injected or freshly created. Larger = more robust against ongoing splice
+        # corruption (which reverts in minutes); smaller = faster recovery from a genuinely poisoned
+        # cold-start baseline. Consumers can watch plant.splice_held_count + plant.block_age() to see
+        # when data is being held.
+        self.plant.splice_heal_seconds = splice_heal_seconds
         self.tx_queue = Queue(maxsize=20)
         self.expected_responses = {}
         self._shutting_down = False

--- a/givenergy_modbus/model/battery_splice.py
+++ b/givenergy_modbus/model/battery_splice.py
@@ -104,16 +104,14 @@ THRESHOLD_BY_CLASS: dict[str, int] = {name: thr for name, _, thr in SCALAR_RULES
 #: on the first post-reconnect poll.
 STALE_BYPASS_SECONDS: int = 300
 
-#: Backstop recovery bound for a poisoned scalar-immutable baseline (IR97/IR98) that ALSO trips
-#: physics (#281), so the coherent-physics escrow can't engage. A *stable* scalar-immutable
-#: disagreement (the same incoming value every poll) that persists this many consecutive polls —
-#: OR this many seconds since the streak began, whichever first — forces a re-baseline. Both
-#: bounds resolve strictly inside STALE_BYPASS_SECONDS so a real poison self-heals well before the
-#: coarse stale bypass would, while oscillating garbage (changing value) resets the streak and
-#: never reaches either bound. Field report (#281): ~6-15 s poll cadence, so 6 polls ≈ 36-90 s and
-#: the 120 s ceiling both land comfortably under 300 s even at the slow end.
-SCALAR_IMMUT_STREAK_POLLS: int = 6
-SCALAR_IMMUT_STREAK_SECONDS: int = 120
+#: Minimum consecutive-poll count before a sustained scalar-immutable (IR97/IR98) disagreement is
+#: healed (#286). A scalar-immutable change is held (last-good) and only adopted once the same
+#: value has been insisted upon uninterrupted for BOTH this many polls AND ``Plant.splice_heal_
+#: seconds`` (the time bound — consumer-tunable — is the primary discriminator: ongoing splice
+#: corruption reverts within minutes, a genuine poisoned baseline persists indefinitely). This
+#: poll floor only guards the degenerate "a few polls far apart" case; at any cadence ≤90 s the
+#: seconds bound dominates. A changing signature or a clean poll resets the streak.
+SCALAR_IMMUT_HEAL_POLLS: int = 10
 
 #: A single trip: (absolute IR number, class name, old comparable value, new comparable value).
 #: For pair rules the comparable values are the assembled uint32s, not the high word alone.

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -12,8 +12,7 @@ from givenergy_modbus.model.battery_splice import (
     BANK_BASE,
     IMMUTABLE_SCALAR,
     IMMUTABLE_SERIAL,
-    SCALAR_IMMUT_STREAK_POLLS,
-    SCALAR_IMMUT_STREAK_SECONDS,
+    SCALAR_IMMUT_HEAL_POLLS,
     STALE_BYPASS_SECONDS,
     THRESHOLD_BY_CLASS,
     classify_transition,
@@ -542,6 +541,14 @@ class Plant(GivEnergyBaseModel):
     splice_held_count: dict[int, int] = Field(default_factory=dict, exclude=True)
     retry_count: dict[int, int] = Field(default_factory=dict, exclude=True)
 
+    # How long (seconds) to hold last-good for a disputed *constant* battery register (num_cells,
+    # bms_firmware_version) before healing to a sustained new value (#286). Splice corruption that
+    # flips a constant register reverts within minutes (the bank is held meanwhile, protecting the
+    # co-corrupted physics like SOC), while a genuinely poisoned cold-start baseline — or a real
+    # firmware upgrade — persists indefinitely and heals after this long. Consumer-tunable via
+    # Client(splice_heal_seconds=…). Runtime config; excluded from model_dump.
+    splice_heal_seconds: float = Field(default=900.0, exclude=True)
+
     # Content-staleness tracker — the duration substrate for frozen-BMS-cache detection (#91).
     # Keyed identically to register_block_updated_at; each value is (content_hash, unchanged_since)
     # where unchanged_since is the ingestion time of the FIRST commit in the current
@@ -971,59 +978,39 @@ class Plant(GivEnergyBaseModel):
         phys: list[tuple[int, str, int, int]],
         now_ts: datetime,
     ) -> bool:
-        """Escrow / re-baseline a scalar-immutable (IR97/IR98) disagreement instead of rejecting (#281).
+        """Hold a scalar-immutable (IR97/IR98) disagreement; heal only after long insistence (#286).
 
-        A scalar immutable that reads the same incoming value identically across polls is the real
-        value — the cached baseline was poisoned by a corrupt cold-start frame, or the BMS firmware
-        was legitimately upgraded — so adopt it rather than rejecting forever (the bug this fixes).
-        Two paths share one streak counter keyed on the incoming signature:
+        Supersedes the #281 fast paths (coherent 2-read / 6-poll backstop), which adopted ongoing
+        corruption that happened to stay stable for a few polls.
 
-        * coherent physics (no other trips) — adopt on the second identical read (~2 polls), a
-          high-confidence poison signal;
-        * with physics drift — keep rejecting, but adopt once the same signature persists
-          ``SCALAR_IMMUT_STREAK_POLLS`` polls or ``SCALAR_IMMUT_STREAK_SECONDS`` seconds (whichever
-          first, both inside the 300 s stale window).
+        A constant register (num_cells, bms_firmware_version) changing is treated as corruption
+        until proven otherwise: ongoing splice corruption reverts within minutes, while a genuinely
+        poisoned cold-start baseline — or a real firmware upgrade — persists indefinitely. So every
+        poll holds the *whole* bank at last-good (return False), which also protects any
+        co-corrupted physics (e.g. SOC) riding in the same bank; the new value is adopted only once
+        the SAME incoming signature has been insisted upon, uninterrupted, for at least
+        ``SCALAR_IMMUT_HEAL_POLLS`` polls AND ``self.splice_heal_seconds`` seconds. A changing
+        signature or a clean (baseline-matching) poll resets the streak, so corruption — which
+        reverts well inside the heal window — never self-heals into the cache.
 
-        A *changing* signature (oscillating garbage) restarts the streak and never adopts, so genuine
-        corruption can't self-heal into the cache. Returns True to commit (adopt), False to hold.
+        Always a *recoverable hold* (INFO + ``splice_held_count``), never a WARNING reject. The hold
+        deliberately does not re-stamp the block's ingestion time, so ``block_age`` grows and a
+        consumer can see the data is cached/stale and decide what to do. Returns True to adopt
+        (heal), False to hold.
         """
         sig = tuple(sorted((ir_no, new_val) for ir_no, _name, _old, new_val in scalar_immut))
         streak = self._splice_immut_streak.get(device_address)
 
-        # Coherent physics: a single identical re-read is enough (high-confidence poison signal).
-        if not phys:
-            if streak is not None and streak[0] == sig:
-                self._splice_escrow.pop(device_address, None)
-                self._splice_immut_streak.pop(device_address, None)
-                _logger.info(
-                    "Battery bank for device 0x%02x: constant register(s) %s read identically twice "
-                    "with coherent physics — cold-start baseline was poisoned; adopting incoming as "
-                    "new baseline.",
-                    device_address,
-                    self._fmt_scalar_sig(scalar_immut),
-                )
-                return True
-            self._splice_immut_streak[device_address] = (sig, now_ts, 1)
-            self._bump(self.splice_held_count, device_address)
-            _logger.info(
-                "Battery bank for device 0x%02x: constant register(s) %s disagree with baseline "
-                "(coherent physics) — held one poll pending an identical re-read.",
-                device_address,
-                self._fmt_scalar_sig(scalar_immut),
-            )
-            return False
-
-        # Physics also drifted: less confident, so require a sustained stable streak before adopting.
         if streak is not None and streak[0] == sig:
             started, count = streak[1], streak[2] + 1
             elapsed = (now_ts - started).total_seconds()
-            if count >= SCALAR_IMMUT_STREAK_POLLS or elapsed >= SCALAR_IMMUT_STREAK_SECONDS:
+            if count >= SCALAR_IMMUT_HEAL_POLLS and elapsed >= self.splice_heal_seconds:
                 self._splice_escrow.pop(device_address, None)
                 self._splice_immut_streak.pop(device_address, None)
                 _logger.info(
-                    "Battery bank for device 0x%02x: constant register(s) %s stably disagreed with "
-                    "baseline for %d consecutive polls (%.0f s) — cold-start baseline was poisoned; "
-                    "adopting incoming as new baseline.",
+                    "Battery bank for device 0x%02x: constant register(s) %s held the same value for "
+                    "%d consecutive polls (%.0f s) — adopting as new baseline (poisoned baseline or "
+                    "firmware change).",
                     device_address,
                     self._fmt_scalar_sig(scalar_immut),
                     count,
@@ -1031,18 +1018,25 @@ class Plant(GivEnergyBaseModel):
                 )
                 return True
             self._splice_immut_streak[device_address] = (sig, started, count)
+            new_streak = False
         else:
             # New device, or the signature changed (oscillating garbage): (re)start the streak.
             self._splice_immut_streak[device_address] = (sig, now_ts, 1)
+            new_streak = True
 
         self._splice_escrow.pop(device_address, None)
-        self._bump(self.splice_reject_count, device_address)
-        _logger.warning(
-            "Rejected battery bank for device 0x%02x — sub-bus splice (constant-register change with "
-            "physics drift); keeping last-good. Trips: %s. Please report if seen.",
-            device_address,
-            self._format_splice_trips(scalar_immut + phys),
-        )
+        self._bump(self.splice_held_count, device_address)
+        if new_streak:
+            # Log once per insistence run (not every poll) to avoid spamming a long hold; the
+            # per-poll signal is splice_held_count + the growing block_age.
+            _logger.info(
+                "Battery bank for device 0x%02x: constant register(s) %s disagree with baseline — "
+                "holding last-good, will adopt only after %.0f s of sustained agreement. Trips: %s.",
+                device_address,
+                self._fmt_scalar_sig(scalar_immut),
+                self.splice_heal_seconds,
+                self._format_splice_trips(scalar_immut + phys),
+            )
         return False
 
     @staticmethod

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -561,6 +561,12 @@ async def test_retry_count_excludes_probe_on_error_response_with_delay():
     assert client.plant.retry_count == {}
 
 
+def test_client_forwards_splice_heal_seconds():
+    """Client(splice_heal_seconds=…) is applied to its plant, default 900 (#286)."""
+    assert Client(host="foo", port=4321).plant.splice_heal_seconds == 900.0
+    assert Client(host="foo", port=4321, splice_heal_seconds=42.0).plant.splice_heal_seconds == 42.0
+
+
 async def test_send_request_sleeps_between_retries_on_timeout():
     """A retry_delay > 0 must impose a sleep between a timed-out attempt and the next.
 

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -562,9 +562,21 @@ async def test_retry_count_excludes_probe_on_error_response_with_delay():
 
 
 def test_client_forwards_splice_heal_seconds():
-    """Client(splice_heal_seconds=…) is applied to its plant, default 900 (#286)."""
-    assert Client(host="foo", port=4321).plant.splice_heal_seconds == 900.0
+    """Client(splice_heal_seconds=…) overrides the plant's value only when explicitly given (#286)."""
+    from givenergy_modbus.model.plant import Plant
+
+    assert Client(host="foo", port=4321).plant.splice_heal_seconds == 900.0  # Plant default stands
     assert Client(host="foo", port=4321, splice_heal_seconds=42.0).plant.splice_heal_seconds == 42.0
+    # An injected plant's own value is preserved when the Client param is omitted (not clobbered).
+    injected = Plant(splice_heal_seconds=123.0)
+    assert Client(host="foo", port=4321, plant=injected).plant.splice_heal_seconds == 123.0
+    # An explicit Client param still wins over an injected plant's value.
+    assert (
+        Client(
+            host="foo", port=4321, plant=Plant(splice_heal_seconds=123.0), splice_heal_seconds=7.0
+        ).plant.splice_heal_seconds
+        == 7.0
+    )
 
 
 async def test_send_request_sleeps_between_retries_on_timeout():

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -2530,79 +2530,109 @@ def _coherent_battery_bank(overrides: dict[int, int] | None = None) -> dict[int,
 _BATT = 0x33  # battery pack #1 on bare Plant; 0x32 → inverter getter on bare Plant
 
 
-def test_splice_capacity_cohort_rejected(plant: Plant, caplog):
-    """A cap-pair physics step + scalar-immutable mutation rejects on the first poll (#281).
+def test_splice_scalar_immut_with_physics_held_not_rejected(plant: Plant, caplog):
+    """A cap-pair physics step + scalar-immutable mutation is HELD as last-good, not rejected (#286).
 
-    With the scalar-immutable split this is no longer a hard reject — it's the backstop's
-    first poll (1 physics trip, not >=2), so the bank is held and the streak armed. Recovery
-    only happens if the same value persists (see the backstop test); a lone poll stays rejected.
+    The whole bank is kept last-good — protecting the co-corrupted physics — and logged at INFO
+    (a recoverable hold, never a WARNING). It heals only after a long sustained insistence.
     """
     import logging
 
     _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)
-    corrupted = _coherent_battery_bank(
-        {
-            89: 36000,  # IR89: cap_remaining low word 16000 → 36000, pair delta 20000 > 1500 threshold
-            98: 3006,  # IR98: bms_fw scalar-immutable violation
-        }
-    )
-    with caplog.at_level(logging.WARNING, logger="givenergy_modbus.model.plant"):
+    corrupted = _coherent_battery_bank({89: 36000, 98: 3006})  # cap-pair physics + IR98 immutable
+    with caplog.at_level(logging.INFO, logger="givenergy_modbus.model.plant"):
         _feed_bank(plant, corrupted, device_address=_BATT, received_at=_T0 + timedelta(seconds=30))
-    assert plant.register_caches[_BATT][IR(89)] == 16000  # last-good retained
-    assert plant.register_caches[_BATT][IR(98)] == 3005
-    warns = [r for r in caplog.records if "Rejected battery bank" in r.message and "0x33" in r.message]
-    assert len(warns) == 1
-    assert "constant-register change with physics drift" in warns[0].message
+    assert plant.register_caches[_BATT][IR(89)] == 16000  # co-corrupted physics protected
+    assert plant.register_caches[_BATT][IR(98)] == 3005  # last-good held
+    assert plant.splice_held_count == {_BATT: 1}
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING and "0x33" in r.message]
+    assert [r for r in caplog.records if "holding last-good" in r.message and "0x33" in r.message]
 
 
-def test_splice_poisoned_scalar_immut_self_heals_via_escrow(plant: Plant, caplog):
-    """A poisoned cold-start IR98 baseline self-heals via escrow once the true value reads twice (#281).
+def test_splice_poisoned_scalar_immut_heals_after_long_insistence(plant: Plant, caplog):
+    """A poisoned cold-start IR98 baseline heals only after a long sustained insistence (#286).
 
-    Cold start commits a corrupt IR98 (9999); every later poll reports the true 3005 with
-    otherwise-coherent physics. Two identical reads ⇒ the baseline was poisoned ⇒ adopt.
+    It heals once the true value persists past splice_heal_seconds (default 900 s) with
+    >= SCALAR_IMMUT_HEAL_POLLS frames.
     """
     import logging
 
     poisoned = _coherent_battery_bank({98: 9999})  # corrupt first frame adopted at cold start
     _feed_bank(plant, poisoned, device_address=_BATT, received_at=_T0)
-    assert plant.register_caches[_BATT][IR(98)] == 9999
-
-    healthy = _coherent_battery_bank()  # true IR98 == 3005, otherwise identical → coherent physics
+    healthy = _coherent_battery_bank()  # true IR98 == 3005, coherent
     with caplog.at_level(logging.INFO, logger="givenergy_modbus.model.plant"):
-        _feed_bank(plant, healthy, device_address=_BATT, received_at=_T0 + timedelta(seconds=10))
-        assert plant.register_caches[_BATT][IR(98)] == 9999  # held one poll, not yet adopted
-        _feed_bank(plant, healthy, device_address=_BATT, received_at=_T0 + timedelta(seconds=20))
-    assert plant.register_caches[_BATT][IR(98)] == 3005  # confirmed identical re-read → adopted
-    adopts = [r for r in caplog.records if "baseline was poisoned" in r.message and "0x33" in r.message]
+        for n in range(1, 10):  # polls 1-9 @ 100 s: streak started at poll 1, elapsed <= 800 s < 900
+            _feed_bank(plant, healthy, device_address=_BATT, received_at=_T0 + timedelta(seconds=100 * n))
+        assert plant.register_caches[_BATT][IR(98)] == 9999  # still held — not yet healed
+        # poll 10 @ 1000 s: count 10 >= 10 AND elapsed 900 >= 900 → heal.
+        _feed_bank(plant, healthy, device_address=_BATT, received_at=_T0 + timedelta(seconds=1000))
+    assert plant.register_caches[_BATT][IR(98)] == 3005  # healed
+    adopts = [r for r in caplog.records if "adopting as new baseline" in r.message and "0x33" in r.message]
     assert len(adopts) == 1 and adopts[0].levelno == logging.INFO
-    assert not [r for r in caplog.records if "Rejected battery bank" in r.message]  # never a WARNING
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING and "0x33" in r.message]
 
 
-def test_splice_poisoned_scalar_immut_with_drift_self_heals_via_backstop(plant: Plant, caplog):
-    """A poisoned IR98 baseline that also trips physics self-heals via the backstop (#281).
-
-    The healthy polls carry the true IR98 *and* a sustained out-of-threshold cell delta, so the
-    coherent-physics escrow can't engage. The stable-signature streak forces a re-baseline at
-    the bound (6 polls @ 15 s = 90 s, well inside the 300 s stale window).
-    """
+def test_splice_poisoned_baseline_with_drift_heals_whole_bank(plant: Plant, caplog):
+    """A poisoned baseline with co-drifting physics heals after the long insistence — whole bank adopts (#286)."""
     import logging
 
     poisoned = _coherent_battery_bank({98: 9999})
     _feed_bank(plant, poisoned, device_address=_BATT, received_at=_T0)
-    healthy = _coherent_battery_bank({98: 3005, 60: 3600})  # IR60 +300 mV > 150 → 1 physics trip every poll
+    healthy = _coherent_battery_bank({98: 3005, 60: 3600})  # true fw + a sustained real cell delta
     with caplog.at_level(logging.INFO, logger="givenergy_modbus.model.plant"):
-        for n in range(1, 7):  # 6 polls @ 15 s
-            _feed_bank(plant, healthy, device_address=_BATT, received_at=_T0 + timedelta(seconds=15 * n))
-    assert plant.register_caches[_BATT][IR(98)] == 3005  # whole bank adopted on the 6th poll
-    assert plant.register_caches[_BATT][IR(60)] == 3600
-    adopts = [
-        r
-        for r in caplog.records
-        if "stably disagreed" in r.message and "0x33" in r.message and r.levelno == logging.INFO
-    ]
-    assert len(adopts) == 1
-    rejects = [r for r in caplog.records if "physics drift" in r.message and "0x33" in r.message]
-    assert len(rejects) == 5  # polls 1-5 rejected, poll 6 adopted
+        for n in range(1, 11):  # 10 polls @ 100 s → poll 10: count 10, elapsed 900 → heal
+            _feed_bank(plant, healthy, device_address=_BATT, received_at=_T0 + timedelta(seconds=100 * n))
+    assert plant.register_caches[_BATT][IR(98)] == 3005  # healed
+    assert plant.register_caches[_BATT][IR(60)] == 3600  # whole bank adopted
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING and "0x33" in r.message]
+
+
+def test_splice_transient_corruption_held_not_adopted_soc_protected(plant: Plant, caplog):
+    """The field drift episode (#286): transient drift corruption is held, never adopted; SOC protected.
+
+    A sustained-but-transient drift splice (fw + SOC both corrupt) that reverts within minutes is
+    held — never adopted — and the co-corrupted SOC stays at last-good.
+    """
+    import logging
+
+    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)  # baseline: fw 3005, soc 55
+    corrupt = _coherent_battery_bank({98: 2241, 100: 13})  # IR98 immutable + IR100 soc 55->13 (>10 thresh)
+    with caplog.at_level(logging.INFO, logger="givenergy_modbus.model.plant"):
+        for n in range(1, 7):  # 6 polls @ 30 s = 180 s, far inside the 900 s heal window
+            _feed_bank(plant, corrupt, device_address=_BATT, received_at=_T0 + timedelta(seconds=30 * n))
+        assert plant.register_caches[_BATT][IR(98)] == 3005  # fw never adopted
+        assert plant.register_caches[_BATT][IR(100)] == 55  # SOC protected — no dip
+        # corruption reverts: a clean good frame is accepted and clears the hold.
+        _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0 + timedelta(seconds=210))
+    assert plant.register_caches[_BATT][IR(98)] == 3005
+    assert plant.register_caches[_BATT][IR(100)] == 55
+    assert not [r for r in caplog.records if "adopting as new baseline" in r.message]  # never healed
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING and "0x33" in r.message]
+    assert plant.splice_held_count[_BATT] == 6  # held each corrupt poll — diagnostic climbs
+
+
+def test_splice_heal_seconds_knob_tunes_hold_duration(plant: Plant):
+    """splice_heal_seconds tunes how long a scalar-immutable disagreement is held before healing (#286)."""
+    plant.splice_heal_seconds = 60.0  # much shorter than the 900 s default
+    poisoned = _coherent_battery_bank({98: 9999})
+    _feed_bank(plant, poisoned, device_address=_BATT, received_at=_T0)
+    healthy = _coherent_battery_bank()
+    for n in range(1, 11):  # 10 polls @ 10 s → poll 10: count 10, elapsed 90 >= 60 → heal
+        _feed_bank(plant, healthy, device_address=_BATT, received_at=_T0 + timedelta(seconds=10 * n))
+    assert plant.register_caches[_BATT][IR(98)] == 3005  # healed within 90 s thanks to the lower knob
+
+
+def test_splice_block_age_grows_during_scalar_immut_hold(plant: Plant):
+    """A held scalar-immutable bank records no ingestion timestamp, so block_age keeps growing (#286).
+
+    A consumer can therefore see the data is cached/stale (#65).
+    """
+    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)  # commits at t0
+    corrupt = _coherent_battery_bank({98: 2241, 100: 13})  # held (not re-stamped)
+    for n in range(1, 4):
+        _feed_bank(plant, corrupt, device_address=_BATT, received_at=_T0 + timedelta(seconds=30 * n))
+    # block_age reflects the last *committed* bank (t0), not the held ones.
+    assert plant.block_age(_BATT, "IR", 60, 60, now=_T0 + timedelta(seconds=120)) == 120.0
 
 
 def test_splice_oscillating_scalar_immut_never_adopts(plant: Plant, caplog):
@@ -2615,8 +2645,7 @@ def test_splice_oscillating_scalar_immut_never_adopts(plant: Plant, caplog):
             garbage = _coherent_battery_bank({98: 9000 + (n % 2) * 500, 60: 3600})  # IR98 flips each poll
             _feed_bank(plant, garbage, device_address=_BATT, received_at=_T0 + timedelta(seconds=15 * n))
     assert plant.register_caches[_BATT][IR(98)] == 3005  # last-good held; garbage never adopted
-    assert not [r for r in caplog.records if "baseline was poisoned" in r.message]
-    assert not [r for r in caplog.records if "stably disagreed" in r.message]
+    assert not [r for r in caplog.records if "adopting as new baseline" in r.message]  # never healed
 
 
 def test_splice_serial_block_change_always_rejected(plant: Plant, caplog):
@@ -2631,32 +2660,30 @@ def test_splice_serial_block_change_always_rejected(plant: Plant, caplog):
     assert plant.register_caches[_BATT][IR(110)] == 0x4247  # last-good serial held forever
     serial_rejects = [r for r in caplog.records if "serial-block change" in r.message and "0x33" in r.message]
     assert len(serial_rejects) == 24
-    assert not [r for r in caplog.records if "baseline was poisoned" in r.message]
-    assert not [r for r in caplog.records if "stably disagreed" in r.message]
+    assert not [r for r in caplog.records if "adopting as new baseline" in r.message]  # never healed
 
 
-def test_splice_backstop_streak_requires_uninterrupted_signature(plant: Plant, caplog):
-    """An interrupting poll with no scalar-immut trip resets the backstop streak (#281 review).
+def test_splice_heal_requires_uninterrupted_signature(plant: Plant, caplog):
+    """Healing requires an *uninterrupted* signature — an interrupting poll resets the streak (#286).
 
-    The backstop must require an *uninterrupted* stable scalar signature: 5 drift polls, then one
-    poll where IR98 momentarily matches the (still-poisoned) baseline — no scalar trip — then 5
-    more drift polls. Without the reset the streak would reach 6 and adopt on the first
-    post-interruption poll; with it the count restarts, so the poison baseline is NOT adopted.
+    splice_heal_seconds is set low so the poll-count floor (10) is the operative gate: 9 drift polls,
+    an interrupt, then 9 more — each run stays at 9 < 10, so the poison baseline is never adopted.
     """
     import logging
 
+    plant.splice_heal_seconds = 1.0  # make the 10-poll floor the operative gate
     poisoned = _coherent_battery_bank({98: 9999})
     _feed_bank(plant, poisoned, device_address=_BATT, received_at=_T0)
     drift = _coherent_battery_bank({98: 3005, 60: 3600})  # scalar trip (IR98) + 1 physics trip (IR60)
-    interrupt = _coherent_battery_bank({98: 9999, 60: 3600})  # IR98 == baseline → no scalar trip
+    interrupt = _coherent_battery_bank({98: 9999, 60: 3600})  # IR98 == baseline → no scalar trip → resets streak
     with caplog.at_level(logging.INFO, logger="givenergy_modbus.model.plant"):
-        for n in range(1, 6):  # polls 1-5: streak builds to 5 (need 6)
+        for n in range(1, 10):  # 9 drift polls: count reaches 9 (one short of 10)
             _feed_bank(plant, drift, device_address=_BATT, received_at=_T0 + timedelta(seconds=10 * n))
-        _feed_bank(plant, interrupt, device_address=_BATT, received_at=_T0 + timedelta(seconds=60))  # reset
-        for n in range(7, 12):  # polls 7-11: streak restarts 1-5, still short of 6
+        _feed_bank(plant, interrupt, device_address=_BATT, received_at=_T0 + timedelta(seconds=100))  # reset
+        for n in range(11, 20):  # 9 more drift polls: streak restarts, never reaches 10
             _feed_bank(plant, drift, device_address=_BATT, received_at=_T0 + timedelta(seconds=10 * n))
-    assert plant.register_caches[_BATT][IR(98)] == 9999  # never adopted — streak was interrupted
-    assert not [r for r in caplog.records if "stably disagreed" in r.message]
+    assert plant.register_caches[_BATT][IR(98)] == 9999  # never adopted — interruption reset the streak
+    assert not [r for r in caplog.records if "adopting as new baseline" in r.message]
 
 
 def test_splice_cell_and_temp_cohort_rejected(plant: Plant, caplog):


### PR DESCRIPTION
Closes #286.

## The bug

#281 turned the battery splice guard's scalar-immutable handling (`num_cells` IR97, `bms_firmware_version` IR98) from a hard-reject *canary* into a *recoverable* signal — adopting a constant-register change after 2 identical reads (coherent) or a 6-poll backstop (drift). Field data shows that backstop now **adopts sustained-but-transient splice corruption**: the firmware sensor bounces, and because the co-corrupted *bank* is committed, SOC dips to implausible values before self-healing.

Cross-checked against a parallel GivTCP install (different library, no guard, same pack): the corruption is genuinely wire-level — GivTCP bounces *more* than we do. #281 itself is a net win (the old "stuck on a poisoned baseline for hours" is gone), but removing IR(98)'s canary lost the incidental protection it gave the co-corrupted physics in the same bank. The clean discriminator: corruption reverts within ~3 min, a genuine poison persists for hours.

## The fix

Collapse the scalar-immutable handling to one rule: **hold the whole bank at last-good every poll** (which also holds any co-corrupted physics, e.g. SOC), and **heal only after the same value has persisted uninterrupted** for `≥ SCALAR_IMMUT_HEAL_POLLS` (10) **and** `≥ splice_heal_seconds`. Corruption reverts before the window (rejected, never adopted); a genuine poison outlasts it (heals, no reboot). A changing or interrupted signature resets the streak.

- **New knob:** `Client(splice_heal_seconds=900.0)` → `Plant.splice_heal_seconds` — consumers tune how long to hold cached values for a disputed constant register before healing.
- **Staleness stays visible:** a held bank doesn't re-stamp its ingestion time, so `block_age()` grows during a hold, and `splice_held_count` (the #284 diagnostic) climbs — a consumer can tell "responding but holding corruption" from "device offline" and surface a cached/stale state. Documented + tested.
- Scalar-immutable handling is now a recoverable **hold** (INFO + `splice_held_count`), never a WARNING reject. The genuine hard-reject branch (serial change / ≥2-physics) is unchanged.

## Tests

The field regression (transient drift held → firmware unchanged, **SOC protected, no dip**); long-insistence heal (poison still auto-heals); the knob; `block_age` grows during a hold; uninterrupted-signature reset. The old 2-poll / 6-poll heal tests are rewritten for the new threshold. Full suite green, tox green across py311–py314.

## Follow-up
Cold-start hardening (don't baseline the first frame unconditionally) — would let `splice_heal_seconds` be shorter; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)