### PR TITLE
fix(mock): disambiguate EMS managed-inverter slot serials by slot index

### DIFF
--- a/givenergy_modbus/testing/mock_plant.py
+++ b/givenergy_modbus/testing/mock_plant.py
@@ -174,9 +174,10 @@ def _make_device_serials_distinct(plant: Plant) -> None:
         (range(lv_start, 0x38), BatteryRegisterGetter),  # LV battery packs
         (range(0x50, 0x54), AioBatteryModuleRegisterGetter),  # AIO battery modules
     ):
+        # registers_of returns () for getters without a serial_number; _disambiguate_serials then
+        # decodes every member to None and no-ops, so we can iterate unconditionally (#247 contract).
         regs = getter.registers_of("serial_number")
-        if regs:
-            _disambiguate_serials([(caches[a], regs, f"{a:02x}") for a in addr_range if a in caches])
+        _disambiguate_serials([(caches[a], regs, f"{a:02x}") for a in addr_range if a in caches])
 
     # EMS managed-inverter slots (#288): up to 4 sub-slots in the single 0x11 EMS cache (not separate
     # device addresses), so address keying can't see them — re-tail by slot index instead. A non-EMS

--- a/givenergy_modbus/testing/mock_plant.py
+++ b/givenergy_modbus/testing/mock_plant.py
@@ -32,6 +32,7 @@ from typing import cast
 from givenergy_modbus.framer import ServerFramer
 from givenergy_modbus.model.aio_battery import AioBatteryModuleRegisterGetter
 from givenergy_modbus.model.battery import BatteryRegisterGetter
+from givenergy_modbus.model.ems import EmsRegisterGetter
 from givenergy_modbus.model.plant import Plant
 from givenergy_modbus.model.register import HR, IR, MR, Register, RegisterGetter
 from givenergy_modbus.model.register_cache import RegisterCache
@@ -135,9 +136,10 @@ def _make_device_serials_distinct(plant: Plant) -> None:
     keeping it obviously synthetic. Distinct or singular serials are left untouched; only the
     in-memory mock caches are changed, never the fixture bytes.
 
-    Only IR/``C.serial`` 5-register devices are handled (LV battery packs, AIO modules); meters
-    (MR/``C.string``) and HV BMUs (stride within a single 0x70 cache) use other layouts and are
-    out of scope.
+    Handles the IR/``C.serial`` 5-register devices: LV battery packs and AIO modules (re-tailed by
+    bus address), and EMS managed-inverter slots within the 0x11 cache (re-tailed by slot index,
+    since they share an address). Meters (MR/``C.string``) and HV BMUs (stride within a single 0x70
+    cache) use other layouts and are out of scope.
     """
     caches = plant.register_caches
     # Unified addressing (inverter at 0x11/0x31) puts LV battery pack #1 at 0x32; legacy bare-plant
@@ -161,6 +163,22 @@ def _make_device_serials_distinct(plant: Plant) -> None:
                 distinct = serial[:-2] + f"{addr:02x}"
                 for reg, value in zip(regs, _encode_serial(distinct, len(regs))):
                     caches[addr][reg] = value
+
+    # EMS managed-inverter slots (#288): up to 4 sub-slots in the single 0x11 EMS cache (not separate
+    # device addresses), so the address-keyed pass above can't see them. Re-tail collisions by slot
+    # index instead. Collision-only + register-presence gated, so a non-EMS 0x11 cache (no IR2066+
+    # managed-inverter serials) is a no-op; the EMS controller's own serial is never touched.
+    ems_cache = caches.get(0x11)
+    if ems_cache is not None:
+        slots = [(i, EmsRegisterGetter.registers_of(f"inverter_{i}_serial_number")) for i in range(1, 5)]
+        named = {i: s for i, regs in slots if regs and (s := _decode_serial(ems_cache, regs))}
+        shared = {s for s, n in Counter(named.values()).items() if n > 1}
+        for i, regs in slots:
+            slot_serial = named.get(i)
+            if slot_serial and slot_serial in shared and len(slot_serial) >= 2:  # only colliding slots
+                distinct = slot_serial[:-2] + f"{i:02d}"  # slot index (1..4), preserving the prefix
+                for reg, value in zip(regs, _encode_serial(distinct, len(regs))):
+                    ems_cache[reg] = value
 
 
 class MockPlant:

--- a/givenergy_modbus/testing/mock_plant.py
+++ b/givenergy_modbus/testing/mock_plant.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 import argparse
 import asyncio
 import logging
-from collections import Counter
 from pathlib import Path
 from typing import cast
 
@@ -34,7 +33,7 @@ from givenergy_modbus.model.aio_battery import AioBatteryModuleRegisterGetter
 from givenergy_modbus.model.battery import BatteryRegisterGetter
 from givenergy_modbus.model.ems import EmsRegisterGetter
 from givenergy_modbus.model.plant import Plant
-from givenergy_modbus.model.register import HR, IR, MR, Register, RegisterGetter
+from givenergy_modbus.model.register import HR, IR, MR, Register
 from givenergy_modbus.model.register_cache import RegisterCache
 from givenergy_modbus.pdu import (
     ClientIncomingMessage,
@@ -118,7 +117,10 @@ def _decode_serial(cache: RegisterCache, regs: tuple[Register, ...] | list[Regis
     if any(v is None for v in values):
         return None
     raw = b"".join(v.to_bytes(2, "big") for v in values if v is not None)
-    return raw.decode("latin1").replace("\x00", "").upper() or None
+    # Strip null AND whitespace padding (matching the model's serial handling, e.g. Ems
+    # managed_inverters' strip("\x00 ")), so an empty-but-space-padded slot reads as no serial
+    # rather than a whitespace string that would be mistaken for a real (colliding) value.
+    return raw.decode("latin1").replace("\x00", "").strip().upper() or None
 
 
 def _encode_serial(serial: str, n_regs: int) -> list[int]:
@@ -127,14 +129,35 @@ def _encode_serial(serial: str, n_regs: int) -> list[int]:
     return [int.from_bytes(data[i * 2 : i * 2 + 2], "big") for i in range(n_regs)]
 
 
+def _disambiguate_serials(members: list[tuple[RegisterCache, tuple[Register, ...], str]]) -> None:
+    """Make a group of multi-instance members carry distinct serials in the mock cache.
+
+    Each member is ``(cache, serial-registers, suffix)``, where ``suffix`` is a 2-char identity
+    unique within the group (bus address or slot index). If two or more members share a non-empty
+    serial, **every** populated member is re-tailed with its suffix — preserving the prefix and
+    keeping it obviously synthetic. Rewriting *only* the colliding members could mint a value that
+    matches an already-distinct member (#288 review); rewriting all, with each member's unique
+    suffix, guarantees no two collide. A fully-distinct group is left untouched; empty / sub-2-char
+    serials are skipped.
+    """
+    decoded = [(cache, regs, suffix, _decode_serial(cache, regs)) for cache, regs, suffix in members]
+    serials = [s for *_, s in decoded if s]
+    if len(set(serials)) == len(serials):
+        return  # no collision in this group
+    for cache, regs, suffix, serial in decoded:
+        if serial and len(serial) >= 2:
+            for reg, value in zip(regs, _encode_serial(serial[:-2] + suffix, len(regs))):
+                cache[reg] = value
+
+
 def _make_device_serials_distinct(plant: Plant) -> None:
     """Give each instance of a multi-instance device a distinct serial where the capture collides.
 
-    Fixtures redact every serial to the same placeholder, so replayed packs/modules share a serial
-    and collide downstream. For each device group with duplicate non-empty serials, re-tail each
-    member's serial with its device address — preserving the real prefix, making it unique, and
-    keeping it obviously synthetic. Distinct or singular serials are left untouched; only the
-    in-memory mock caches are changed, never the fixture bytes.
+    Fixtures redact every serial to the same placeholder, so replayed packs/modules/slots share a
+    serial and collide downstream. Where a group collides, each populated member is re-tailed with a
+    unique 2-char suffix (bus address, or EMS slot index) — preserving the real prefix, obviously
+    synthetic. A fully-distinct group is left untouched; only the in-memory mock caches change,
+    never the fixture bytes.
 
     Handles the IR/``C.serial`` 5-register devices: LV battery packs and AIO modules (re-tailed by
     bus address), and EMS managed-inverter slots within the 0x11 cache (re-tailed by slot index,
@@ -147,38 +170,27 @@ def _make_device_serials_distinct(plant: Plant) -> None:
     # inverter addresses present in the caches so a legacy capture never has its inverter serial
     # rewritten as if it were a battery pack (#283 review).
     lv_start = 0x32 if (0x11 in caches or 0x31 in caches) else 0x33
-    serial_device_getters: tuple[tuple[range, type[RegisterGetter]], ...] = (
+    for addr_range, getter in (
         (range(lv_start, 0x38), BatteryRegisterGetter),  # LV battery packs
         (range(0x50, 0x54), AioBatteryModuleRegisterGetter),  # AIO battery modules
-    )
-    for addr_range, getter in serial_device_getters:
+    ):
         regs = getter.registers_of("serial_number")
-        if not regs:
-            continue
-        serials = {addr: _decode_serial(caches[addr], regs) for addr in addr_range if addr in caches}
-        named = {addr: s for addr, s in serials.items() if s}
-        shared = {s for s, n in Counter(named.values()).items() if n > 1}
-        for addr, serial in named.items():
-            if serial in shared and len(serial) >= 2:  # only re-tail the colliding members
-                distinct = serial[:-2] + f"{addr:02x}"
-                for reg, value in zip(regs, _encode_serial(distinct, len(regs))):
-                    caches[addr][reg] = value
+        if regs:
+            _disambiguate_serials([(caches[a], regs, f"{a:02x}") for a in addr_range if a in caches])
 
     # EMS managed-inverter slots (#288): up to 4 sub-slots in the single 0x11 EMS cache (not separate
-    # device addresses), so the address-keyed pass above can't see them. Re-tail collisions by slot
-    # index instead. Collision-only + register-presence gated, so a non-EMS 0x11 cache (no IR2066+
-    # managed-inverter serials) is a no-op; the EMS controller's own serial is never touched.
+    # device addresses), so address keying can't see them — re-tail by slot index instead. A non-EMS
+    # 0x11 cache has no IR2066+ managed-inverter serials, so this is a no-op; the EMS controller's own
+    # serial is never touched.
     ems_cache = caches.get(0x11)
     if ems_cache is not None:
-        slots = [(i, EmsRegisterGetter.registers_of(f"inverter_{i}_serial_number")) for i in range(1, 5)]
-        named = {i: s for i, regs in slots if regs and (s := _decode_serial(ems_cache, regs))}
-        shared = {s for s, n in Counter(named.values()).items() if n > 1}
-        for i, regs in slots:
-            slot_serial = named.get(i)
-            if slot_serial and slot_serial in shared and len(slot_serial) >= 2:  # only colliding slots
-                distinct = slot_serial[:-2] + f"{i:02d}"  # slot index (1..4), preserving the prefix
-                for reg, value in zip(regs, _encode_serial(distinct, len(regs))):
-                    ems_cache[reg] = value
+        _disambiguate_serials(
+            [
+                (ems_cache, regs, f"{i:02d}")
+                for i in range(1, 5)
+                if (regs := EmsRegisterGetter.registers_of(f"inverter_{i}_serial_number"))
+            ]
+        )
 
 
 class MockPlant:

--- a/tests/client/test_mock_plant_integration.py
+++ b/tests/client/test_mock_plant_integration.py
@@ -299,3 +299,43 @@ def test_make_device_serials_distinct_leaves_legacy_inverter_at_0x32():
     assert _decode_serial(plant.register_caches[0x32], regs) == "SA0000G000"  # inverter untouched
     assert _decode_serial(plant.register_caches[0x33], regs) == "BG0000G033"
     assert _decode_serial(plant.register_caches[0x34], regs) == "BG0000G034"
+
+
+def test_make_device_serials_distinct_disambiguates_ems_managed_inverter_slots():
+    """Colliding EMS managed-inverter slot serials (0x11 sub-slots) are re-tailed by slot index (#288)."""
+    from givenergy_modbus.model.ems import EmsRegisterGetter
+    from givenergy_modbus.model.plant import Plant
+    from givenergy_modbus.testing.mock_plant import (
+        _decode_serial,
+        _encode_serial,
+        _make_device_serials_distinct,
+    )
+
+    def slot_regs(i):
+        return EmsRegisterGetter.registers_of(f"inverter_{i}_serial_number")
+
+    plant = Plant()
+    seed: dict = {}
+    for i in (1, 2):  # slots 1 & 2 share a redacted placeholder
+        seed.update(dict(zip(slot_regs(i), _encode_serial("CE0000G000", 5))))
+    seed.update(dict(zip(slot_regs(3), _encode_serial("CE0000G999", 5))))  # already distinct; slot 4 absent
+    plant.register_caches[0x11] = RegisterCache(seed)
+
+    _make_device_serials_distinct(plant)
+
+    cache = plant.register_caches[0x11]
+    assert _decode_serial(cache, slot_regs(1)) == "CE0000G001"
+    assert _decode_serial(cache, slot_regs(2)) == "CE0000G002"
+    assert _decode_serial(cache, slot_regs(3)) == "CE0000G999"  # already distinct → untouched
+    assert _decode_serial(cache, slot_regs(4)) is None  # absent slot ignored
+
+
+def test_ems_mock_serves_distinct_managed_inverter_serials():
+    """The EMS mock gives each managed-inverter slot its own serial (was both CE…G000) (#288)."""
+    from givenergy_modbus.model.ems import Ems
+
+    mock = MockPlant.from_capture(_CAPTURES / "ems_2_inv_3_bat_a" / "ems_arm1036_60s.log")
+    serials = [inv.serial_number for inv in Ems.from_register_cache(mock.devices[0x11]).managed_inverters]
+    assert len(serials) == 2  # the 2-managed-inverter fixture
+    assert len(set(serials)) == 2, f"managed-inverter serials must be distinct: {serials}"
+    assert all(s.startswith("CE") for s in serials)  # real prefix preserved

--- a/tests/client/test_mock_plant_integration.py
+++ b/tests/client/test_mock_plant_integration.py
@@ -218,8 +218,12 @@ def test_serial_encode_decode_roundtrip():
     assert _decode_serial(cache, regs) == "HX2414G832"
 
 
-def test_make_device_serials_distinct_rewrites_only_collisions():
-    """Collided LV-pack serials become distinct (address-tailed); already-distinct ones are left."""
+def test_make_device_serials_distinct_rewrites_all_in_a_colliding_group():
+    """A re-tail must not recreate a collision with an already-distinct member (#288 review).
+
+    When a group collides, every populated member is re-tailed by its unique suffix — not just the
+    colliders — so the synthesized suffix can't land on a value an untouched member already holds.
+    """
     from givenergy_modbus.model.battery import BatteryRegisterGetter
     from givenergy_modbus.model.plant import Plant
     from givenergy_modbus.testing.mock_plant import (
@@ -230,15 +234,38 @@ def test_make_device_serials_distinct_rewrites_only_collisions():
 
     regs = BatteryRegisterGetter.registers_of("serial_number")  # IR(110-114)
     plant = Plant()
-    for addr in (0x33, 0x34):  # share an identical redacted serial → collision
+    for addr in (0x33, 0x34):  # collide on a redacted placeholder
         plant.register_caches[addr] = RegisterCache(dict(zip(regs, _encode_serial("BG0000G000", len(regs)))))
-    plant.register_caches[0x35] = RegisterCache(dict(zip(regs, _encode_serial("BG0000G999", len(regs)))))
+    # 0x35 is already distinct, but its serial ends in "34": re-tailing only 0x34 would mint
+    # "BG0000G034" and recreate a collision with 0x35. Rewriting all populated members avoids that.
+    plant.register_caches[0x35] = RegisterCache(dict(zip(regs, _encode_serial("BG0000G034", len(regs)))))
 
     _make_device_serials_distinct(plant)
 
-    assert _decode_serial(plant.register_caches[0x33], regs) == "BG0000G033"
-    assert _decode_serial(plant.register_caches[0x34], regs) == "BG0000G034"
-    assert _decode_serial(plant.register_caches[0x35], regs) == "BG0000G999"  # distinct already → untouched
+    serials = [_decode_serial(plant.register_caches[a], regs) for a in (0x33, 0x34, 0x35)]
+    assert serials == ["BG0000G033", "BG0000G034", "BG0000G035"]
+    assert len(set(serials)) == 3  # crucially: no re-created collision
+
+
+def test_make_device_serials_distinct_leaves_a_fully_distinct_group_untouched():
+    """A group with no collision is left exactly as captured (#288)."""
+    from givenergy_modbus.model.battery import BatteryRegisterGetter
+    from givenergy_modbus.model.plant import Plant
+    from givenergy_modbus.testing.mock_plant import (
+        _decode_serial,
+        _encode_serial,
+        _make_device_serials_distinct,
+    )
+
+    regs = BatteryRegisterGetter.registers_of("serial_number")
+    plant = Plant()
+    plant.register_caches[0x33] = RegisterCache(dict(zip(regs, _encode_serial("BG0000G111", len(regs)))))
+    plant.register_caches[0x34] = RegisterCache(dict(zip(regs, _encode_serial("BG0000G222", len(regs)))))
+
+    _make_device_serials_distinct(plant)
+
+    assert _decode_serial(plant.register_caches[0x33], regs) == "BG0000G111"  # untouched
+    assert _decode_serial(plant.register_caches[0x34], regs) == "BG0000G222"
 
 
 def test_aio_mock_serves_distinct_module_serials():
@@ -316,18 +343,23 @@ def test_make_device_serials_distinct_disambiguates_ems_managed_inverter_slots()
 
     plant = Plant()
     seed: dict = {}
-    for i in (1, 2):  # slots 1 & 2 share a redacted placeholder
+    for i in (1, 2):  # slots 1 & 2 collide on a redacted placeholder
         seed.update(dict(zip(slot_regs(i), _encode_serial("CE0000G000", 5))))
-    seed.update(dict(zip(slot_regs(3), _encode_serial("CE0000G999", 5))))  # already distinct; slot 4 absent
+    # slot 3 is distinct but ends in slot 1's index — re-tailing only the colliders would recreate a
+    # collision (slot 1 → CE0000G001 == slot 3); rewriting all slots by index avoids it (#288 review).
+    seed.update(dict(zip(slot_regs(3), _encode_serial("CE0000G001", 5))))
+    # slot 4 is empty but *space-padded* — must NOT be mistaken for a colliding serial / phantom
+    # inverter; decode strips whitespace → None (#288 review).
+    seed.update(dict(zip(slot_regs(4), _encode_serial("          ", 5))))
     plant.register_caches[0x11] = RegisterCache(seed)
 
     _make_device_serials_distinct(plant)
 
     cache = plant.register_caches[0x11]
-    assert _decode_serial(cache, slot_regs(1)) == "CE0000G001"
-    assert _decode_serial(cache, slot_regs(2)) == "CE0000G002"
-    assert _decode_serial(cache, slot_regs(3)) == "CE0000G999"  # already distinct → untouched
-    assert _decode_serial(cache, slot_regs(4)) is None  # absent slot ignored
+    serials = [_decode_serial(cache, slot_regs(i)) for i in (1, 2, 3)]
+    assert serials == ["CE0000G001", "CE0000G002", "CE0000G003"]  # all slots re-tailed by index
+    assert len(set(serials)) == 3  # slot 1 must not re-collide with slot 3
+    assert _decode_serial(cache, slot_regs(4)) is None  # space-padded empty slot → not a phantom
 
 
 def test_ems_mock_serves_distinct_managed_inverter_serials():


### PR DESCRIPTION
Closes #288. Follow-up to #283.

## The gap

#283's `_make_device_serials_distinct` gives replayed multi-instance devices distinct serials by re-tailing with the device's **bus address** — covering LV battery packs (`0x32–0x37`) and AIO modules (`0x50–0x53`). EMS managed inverters fall outside it: they aren't separate addresses but up to **4 sub-slots in the single `0x11` EMS cache** (`EmsRegisterGetter.inverter_1..4_serial_number`, IR2066-2085), surfaced via `Ems.managed_inverters`. Fixtures redact serials by zeroing the suffix, so two managed inverters from a paired install collapse to one serial (`CE…G000`) — and a serial-keyed consumer (givenergy-hass#199's per-managed-inverter HA devices) drops the second. Real hardware (distinct suffixes) is unaffected.

## The fix

A small EMS-slot pass appended to `_make_device_serials_distinct`, reusing the existing `_decode_serial`/`_encode_serial` helpers: where two managed-inverter slots in the `0x11` cache share a non-empty serial, re-tail each by its **slot index** (1..4), preserving the prefix and keeping it obviously synthetic — exactly as #283 does for packs/modules by address.

- **Collision-only + register-presence gated**: a non-EMS `0x11` cache has no IR2066+ managed-inverter serials, so every slot decodes to `None` → no-op. The EMS controller's own serial (and the LV/AIO passes) are untouched.
- Mock caches only; fixture bytes never modified.

## Tests

Unit (two slots collide → re-tailed `…G001`/`…G002`, a distinct third left alone, absent slots ignored) and the reported regression: the `ems_2_inv_3_bat_a` fixture through `MockPlant` now yields two **distinct** `Ems.managed_inverters` serials (was both `CE2231G000`). Full suite green, tox green across py311–py314.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Enhanced test coverage for serial number collision handling in test utilities.

* **Chores**
  * Refactored internal serial collision-detection logic in test fixtures for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->