### PR TITLE
feat(plant): confirm cold-start battery baseline before adopting (#289)

### DIFF
--- a/givenergy_modbus/model/battery_splice.py
+++ b/givenergy_modbus/model/battery_splice.py
@@ -158,3 +158,23 @@ def classify_transition(
         if new[i] != prev[i]:
             immut.append((i + BANK_BASE, "IMMUTABLE", prev[i], new[i]))
     return phys, immut
+
+
+#: Cell-mass temperature indices IR(76-79). Their simultaneous zeroing is the corpus's only
+#: corruption *cohort* signature (#256) — a live, reporting pack never does this.
+CELL_TEMP_IDXS: tuple[int, ...] = (16, 17, 18, 19)
+
+
+def is_corruption_cohort(frame: list[int], present: set[int] | None = None) -> bool:
+    """True if a bank exhibits the temp-zero corruption cohort *absolutely* (no baseline needed).
+
+    :func:`classify_transition` catches a *transition* into the temp-zero shape against a last-good
+    baseline; this catches the shape on its own. The cold-start confirmation uses it to refuse to
+    *baseline* such a frame even when two reads corroborate it (#289). Adopting it would be
+    unrecoverable: every subsequent healthy frame would then trip >=2 physics deltas and be
+    hard-rejected forever, and the #286 heal only recovers scalar-immutable poison. Only the
+    cell-mass temps are gated (the corpus signature); a near-zero singleton or a genuinely cold pack
+    on a single sensor is unaffected (``present`` skips never-read registers).
+    """
+    zeros = sum(1 for i in CELL_TEMP_IDXS if (present is None or i in present) and frame[i] == 0)
+    return zeros >= 2

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -16,6 +16,7 @@ from givenergy_modbus.model.battery_splice import (
     STALE_BYPASS_SECONDS,
     THRESHOLD_BY_CLASS,
     classify_transition,
+    is_corruption_cohort,
 )
 from givenergy_modbus.model.devices import DeviceType, PlantDevice
 from givenergy_modbus.model.devices import Inverter as UnifiedInverter
@@ -575,8 +576,9 @@ class Plant(GivEnergyBaseModel):
     # ingestion time). A cold-start frame is not adopted until the next poll reads it the same (no
     # physics/immutable trip between the two), so a transient sub-bus splice (#256) — different
     # garbage each poll — never corroborates and never poisons the baseline. Most-recent-wins on a
-    # disagreement. A persistently-identical wrong value DOES corroborate; that is left to the #286
-    # heal, by design. Ephemeral; rebuilt with a fresh Plant on reconnect; not serialised.
+    # disagreement. A persistently-identical scalar-immutable poison corroborates and is left to the
+    # #286 heal; a corroborated temp-zero corruption cohort is refused outright (it would hard-reject
+    # all healthy data, which the scalar heal can't recover). Ephemeral; rebuilt on reconnect.
     _splice_pending_baseline: dict[int, tuple[list[int], datetime]] = PrivateAttr(default_factory=dict)
 
     # Splice-guard observation clock (#256): per battery device address, the ingestion time of the
@@ -1004,8 +1006,13 @@ class Plant(GivEnergyBaseModel):
         and adopted only once the next poll reads it the same — ``classify_transition`` finds no physics
         or immutable trip between the two. A transient splice reads different garbage each poll, so it
         never corroborates; on a disagreement the most-recent frame becomes the new candidate (so a
-        splice in the *first* frame is recovered from). A persistently-identical wrong value does
-        corroborate and is adopted — by design: recovering that is the #286 heal's job, not this guard's.
+        splice in the *first* frame is recovered from).
+
+        Two exceptions to "corroboration adopts": a frame in the temp-zero corruption cohort
+        (:func:`is_corruption_cohort`) is refused even when corroborated — adopting it would
+        hard-reject every healthy frame forever, an unrecoverable physics-only poison. A
+        persistently-identical *scalar*-immutable poison (IR97/IR98) does corroborate and is adopted,
+        because recovering that one is the #286 heal's job, not this guard's.
 
         Returns True to adopt (corroborated), False to keep holding last-good ("unknown").
         """
@@ -1016,6 +1023,18 @@ class Plant(GivEnergyBaseModel):
             pending = None
         if pending is not None:
             phys, immut = classify_transition(pending[0], frame, incoming_present)
+            if not phys and not immut and is_corruption_cohort(frame, incoming_present):
+                # Corroborated, but the frame IS the temp-zero corruption signature (#256/#289 review).
+                # Baselining it would be unrecoverable: every later healthy frame then trips >=2 physics
+                # and is hard-rejected forever, and the #286 heal only recovers scalar-immutable poison.
+                # Keep holding (cache untouched) — a healthy corroborated pair will baseline instead.
+                self._bump(self.cold_start_held_count, device_address)
+                _logger.warning(
+                    "Battery bank for device 0x%02x: cold-start frame corroborated but is the temp-zero "
+                    "corruption cohort; refusing to baseline it, holding for a healthy read. Please report if seen.",
+                    device_address,
+                )
+                return False
             if not phys and not immut:
                 self._splice_pending_baseline.pop(device_address, None)
                 _logger.info(

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -540,6 +540,10 @@ class Plant(GivEnergyBaseModel):
     splice_reject_count: dict[int, int] = Field(default_factory=dict, exclude=True)
     splice_held_count: dict[int, int] = Field(default_factory=dict, exclude=True)
     retry_count: dict[int, int] = Field(default_factory=dict, exclude=True)
+    # Cold-start baseline holds (#289): a battery bank held back while the first frame after an
+    # empty cache awaits a corroborating read (vs splice_held_count, which is corruption). A benign
+    # "battery initialising / confirming baseline" signal — expected once per device at startup.
+    cold_start_held_count: dict[int, int] = Field(default_factory=dict, exclude=True)
 
     # How long (seconds) to hold last-good for a disputed *constant* battery register (num_cells,
     # bms_firmware_version) before healing to a sustained new value (#286). Splice corruption that
@@ -565,6 +569,15 @@ class Plant(GivEnergyBaseModel):
     # threshold (genuine step persists) rather than snapping back (transient splice reverts).
     # Ephemeral runtime state, rebuilt with a fresh Plant on reconnect; not serialised.
     _splice_escrow: dict[int, tuple[int, int]] = PrivateAttr(default_factory=dict)
+
+    # Cold-start baseline confirmation (#289): per battery device address, the first full bank seen
+    # against an empty cache, held pending a corroborating read — (the 60-value bank-relative frame,
+    # ingestion time). A cold-start frame is not adopted until the next poll reads it the same (no
+    # physics/immutable trip between the two), so a transient sub-bus splice (#256) — different
+    # garbage each poll — never corroborates and never poisons the baseline. Most-recent-wins on a
+    # disagreement. A persistently-identical wrong value DOES corroborate; that is left to the #286
+    # heal, by design. Ephemeral; rebuilt with a fresh Plant on reconnect; not serialised.
+    _splice_pending_baseline: dict[int, tuple[list[int], datetime]] = PrivateAttr(default_factory=dict)
 
     # Splice-guard observation clock (#256): per battery device address, the ingestion time of the
     # last full IR(60,60) bank the guard examined — accepted OR rejected. The stale-baseline bypass
@@ -868,16 +881,25 @@ class Plant(GivEnergyBaseModel):
         prev = [0] * 60
         new = [0] * 60
         present: set[int] = set()
+        incoming_present: set[int] = set()
         for i in range(60):
             reg = IR(BANK_BASE + i)
             cached = cache.get(reg)
             incoming_val = incoming.get(reg)
             prev[i] = cached if cached is not None else 0
             new[i] = incoming_val if incoming_val is not None else prev[i]
-            if incoming_val is not None and cached is not None:
-                present.add(i)
+            if incoming_val is not None:
+                incoming_present.add(i)
+                if cached is not None:
+                    present.add(i)
         if not present:
-            return True  # cold start: no last-good to compare against
+            # Cold start: no last-good to compare against. Don't adopt the first frame blindly — a
+            # transient splice would poison the baseline (#289). Hold it until a second poll
+            # corroborates it (incoming_present, not present, since the cache is empty here).
+            return self._confirm_cold_start_baseline(device_address, list(new), incoming_present, now_ts)
+        # Past cold start — a real baseline exists, so any pending first frame is moot. Clear it so a
+        # short read that seeded the cache mid-confirmation can't leave an orphan around.
+        self._splice_pending_baseline.pop(device_address, None)
 
         # Stale-observation bypass: after a genuine polling gap the per-poll thresholds don't hold
         # (legitimate SOC/temp/cap drift over the gap would exceed them), and rejected banks never
@@ -970,6 +992,49 @@ class Plant(GivEnergyBaseModel):
                 reverted[0],
             )
         return True
+
+    def _confirm_cold_start_baseline(
+        self, device_address: int, frame: list[int], incoming_present: set[int], now_ts: datetime
+    ) -> bool:
+        """Hold a device's first post-empty-cache battery bank until a second poll corroborates it (#289).
+
+        With no last-good to compare against, adopting the first frame blindly lets a transient sub-bus
+        splice (#256) poison the baseline — the very state #281/#286 then spend the heal window
+        recovering from. Instead the first frame is held (cache untouched, the device serves "unknown")
+        and adopted only once the next poll reads it the same — ``classify_transition`` finds no physics
+        or immutable trip between the two. A transient splice reads different garbage each poll, so it
+        never corroborates; on a disagreement the most-recent frame becomes the new candidate (so a
+        splice in the *first* frame is recovered from). A persistently-identical wrong value does
+        corroborate and is adopted — by design: recovering that is the #286 heal's job, not this guard's.
+
+        Returns True to adopt (corroborated), False to keep holding last-good ("unknown").
+        """
+        pending = self._splice_pending_baseline.get(device_address)
+        # A pending older than the stale-bypass window straddles a genuine polling gap — don't
+        # corroborate across it; treat the incoming frame as a fresh first read.
+        if pending is not None and (now_ts - pending[1]).total_seconds() > STALE_BYPASS_SECONDS:
+            pending = None
+        if pending is not None:
+            phys, immut = classify_transition(pending[0], frame, incoming_present)
+            if not phys and not immut:
+                self._splice_pending_baseline.pop(device_address, None)
+                _logger.info(
+                    "Battery bank for device 0x%02x: cold-start baseline corroborated on re-read; committing.",
+                    device_address,
+                )
+                return True
+            reason = f"cold-start reads disagree ({self._format_splice_trips(phys + immut)})"
+        else:
+            reason = "first cold-start frame"
+        # Hold (or re-hold) the most-recent frame as the pending baseline and wait for corroboration.
+        self._splice_pending_baseline[device_address] = (frame, now_ts)
+        self._bump(self.cold_start_held_count, device_address)
+        _logger.info(
+            "Battery bank for device 0x%02x: %s — holding pending a corroborating read; serving unknown meanwhile.",
+            device_address,
+            reason,
+        )
+        return False
 
     def _handle_scalar_immutable(
         self,

--- a/tests/model/test_battery_splice.py
+++ b/tests/model/test_battery_splice.py
@@ -148,3 +148,27 @@ def test_threshold_table_covers_every_rule_class():
         assert THRESHOLD_BY_CLASS[name] == thr
     for name, _pair, thr in PAIR_RULES:
         assert THRESHOLD_BY_CLASS[name] == thr
+
+
+def test_is_corruption_cohort_detects_temp_zero_shape():
+    """>=2 cell-mass temps (IR76-79) at zero is the corruption cohort; a clean bank is not (#289)."""
+    from givenergy_modbus.model.battery_splice import is_corruption_cohort
+
+    assert not is_corruption_cohort(_baseline())  # temps 250 — plausible
+    one_zero = _baseline()
+    one_zero[16] = 0
+    assert not is_corruption_cohort(one_zero)  # a lone zero temp is not the cohort
+    two_zero = _baseline()
+    two_zero[16] = two_zero[17] = 0
+    assert is_corruption_cohort(two_zero)  # >=2 zero temps → cohort
+
+
+def test_is_corruption_cohort_skips_absent_temps():
+    """A never-read temp register (absent from ``present``) is not counted as a zero (#289)."""
+    from givenergy_modbus.model.battery_splice import is_corruption_cohort
+
+    frame = _baseline()  # temps populated and non-zero
+    # Two temps absent from the read: their 0-fill must not be mistaken for the corruption cohort.
+    present = set(range(60)) - {16, 17}
+    frame[16] = frame[17] = 0
+    assert not is_corruption_cohort(frame, present)

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -1604,14 +1604,12 @@ def test_commit_bank_incoherent_serial_discards_bank(plant: Plant, caplog):
 
 
 def test_commit_bank_valid_serial_allows_bank(plant: Plant):
-    """A battery bank with a valid serial number must be committed."""
+    """A battery bank with a valid serial number must be committed (after #289 cold-start corroboration)."""
     # "BG1234G567" encoded across IR(110-114): each register holds two ASCII chars
     # 'B'=0x42, 'G'=0x47 → 0x4247; '1'=0x31, '2'=0x32 → 0x3132; etc.
-    pdu = _make_ir_pdu(
-        {110: 0x4247, 111: 0x3132, 112: 0x3334, 113: 0x3536, 114: 0x3738, 60: 3221},
-        device_address=0x33,
-    )
-    plant.update(pdu)
+    bank = {110: 0x4247, 111: 0x3132, 112: 0x3334, 113: 0x3536, 114: 0x3738, 60: 3221}
+    plant.update(_make_ir_pdu(bank, device_address=0x33))  # held (cold-start, #289)
+    plant.update(_make_ir_pdu(bank, device_address=0x33))  # corroborates → committed
     assert plant.register_caches[0x33].get(IR(60)) == 3221
 
 
@@ -1795,7 +1793,8 @@ def test_commit_rejects_allzero_over_nonzero_battery_bank(plant: Plant):
     """#147: an all-zero battery page over previously-good data is rejected (kept last-good)."""
     # Valid serial ("BG1234G567" across IR110-114) + data, so the seed is coherent and commits.
     seed = {110: 0x4247, 111: 0x3132, 112: 0x3334, 113: 0x3536, 114: 0x3738, 60: 3221}
-    plant.update(_make_ir_pdu(seed, device_address=0x33, base_register=60))
+    plant.update(_make_ir_pdu(seed, device_address=0x33, base_register=60))  # held (cold-start, #289)
+    plant.update(_make_ir_pdu(seed, device_address=0x33, base_register=60))  # corroborates → commits
     assert plant.register_caches[0x33][IR(60)] == 3221
     plant.update(_make_ir_pdu(dict.fromkeys(seed, 0), device_address=0x33, base_register=60))
     assert plant.register_caches[0x33][IR(60)] == 3221  # retained
@@ -2143,6 +2142,7 @@ def test_comms_quality_counters_initialised_empty():
     assert plant.splice_reject_count == {}
     assert plant.splice_held_count == {}
     assert plant.retry_count == {}
+    assert plant.cold_start_held_count == {}
 
 
 def test_crc_failure_count_increments_per_device(plant: Plant):
@@ -2157,7 +2157,7 @@ def test_crc_failure_count_increments_per_device(plant: Plant):
 
 def test_splice_reject_count_increments_on_hard_reject(plant: Plant):
     """A hard-rejected battery bank bumps splice_reject_count, not splice_held_count."""
-    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)
+    _establish_baseline(plant, device_address=_BATT, received_at=_T0)
     corrupt = _coherent_battery_bank({76 + i: 0 for i in range(4)})  # 4 temp-zeros → >=2 physics
     _feed_bank(plant, corrupt, device_address=_BATT, received_at=_T0 + timedelta(seconds=30))
     assert plant.splice_reject_count == {_BATT: 1}
@@ -2166,7 +2166,7 @@ def test_splice_reject_count_increments_on_hard_reject(plant: Plant):
 
 def test_splice_held_count_increments_on_escrow(plant: Plant):
     """A single-delta escrow hold bumps splice_held_count, not splice_reject_count."""
-    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)
+    _establish_baseline(plant, device_address=_BATT, received_at=_T0)
     wild = _coherent_battery_bank({60: 3600})  # one out-of-threshold delta → hold one poll
     _feed_bank(plant, wild, device_address=_BATT, received_at=_T0 + timedelta(seconds=30))
     assert plant.splice_held_count == {_BATT: 1}
@@ -2176,7 +2176,7 @@ def test_splice_held_count_increments_on_escrow(plant: Plant):
 def test_splice_held_count_tracks_scalar_immutable_coherent_hold(plant: Plant):
     """The #281 coherent scalar-immutable hold counts as a held event."""
     poisoned = _coherent_battery_bank({98: 9999})
-    _feed_bank(plant, poisoned, device_address=_BATT, received_at=_T0)  # cold-start adopts (no count)
+    _establish_baseline(plant, poisoned, device_address=_BATT, received_at=_T0)  # corroborate poison in (#289)
     _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0 + timedelta(seconds=10))
     assert plant.splice_held_count == {_BATT: 1}
     assert plant.splice_reject_count == {}
@@ -2530,6 +2530,28 @@ def _coherent_battery_bank(overrides: dict[int, int] | None = None) -> dict[int,
 _BATT = 0x33  # battery pack #1 on bare Plant; 0x32 → inverter getter on bare Plant
 
 
+def _establish_baseline(
+    plant: "Plant",
+    bank: dict[int, int] | None = None,
+    *,
+    device_address: int = _BATT,
+    received_at: datetime | None = _T0,
+) -> None:
+    """Commit a corroborated last-good battery baseline (two agreeing cold-start reads, #289).
+
+    Under #289 the first bank seen against an empty cache is *held* pending a corroborating read, so
+    a single feed no longer seeds the cache. Splice scenarios that need an established baseline feed
+    the same bank twice: the second read (at ``received_at``) corroborates and commits, leaving the
+    cache, ingestion stamp and observation clock exactly where a pre-#289 single feed at
+    ``received_at`` would — the held first read lands one nominal poll (30 s) earlier. A persistently
+    identical value corroborates, so this also primes a poisoned baseline (pass the poison as ``bank``).
+    """
+    bank = bank if bank is not None else _coherent_battery_bank()
+    first_at = received_at - timedelta(seconds=30) if received_at is not None else None
+    _feed_bank(plant, bank, device_address=device_address, received_at=first_at)
+    _feed_bank(plant, bank, device_address=device_address, received_at=received_at)
+
+
 def test_splice_scalar_immut_with_physics_held_not_rejected(plant: Plant, caplog):
     """A cap-pair physics step + scalar-immutable mutation is HELD as last-good, not rejected (#286).
 
@@ -2538,7 +2560,7 @@ def test_splice_scalar_immut_with_physics_held_not_rejected(plant: Plant, caplog
     """
     import logging
 
-    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)
+    _establish_baseline(plant, device_address=_BATT, received_at=_T0)
     corrupted = _coherent_battery_bank({89: 36000, 98: 3006})  # cap-pair physics + IR98 immutable
     with caplog.at_level(logging.INFO, logger="givenergy_modbus.model.plant"):
         _feed_bank(plant, corrupted, device_address=_BATT, received_at=_T0 + timedelta(seconds=30))
@@ -2558,7 +2580,7 @@ def test_splice_poisoned_scalar_immut_heals_after_long_insistence(plant: Plant, 
     import logging
 
     poisoned = _coherent_battery_bank({98: 9999})  # corrupt first frame adopted at cold start
-    _feed_bank(plant, poisoned, device_address=_BATT, received_at=_T0)
+    _establish_baseline(plant, poisoned, device_address=_BATT, received_at=_T0)
     healthy = _coherent_battery_bank()  # true IR98 == 3005, coherent
     with caplog.at_level(logging.INFO, logger="givenergy_modbus.model.plant"):
         for n in range(1, 10):  # polls 1-9 @ 100 s: streak started at poll 1, elapsed <= 800 s < 900
@@ -2577,7 +2599,7 @@ def test_splice_poisoned_baseline_with_drift_heals_whole_bank(plant: Plant, capl
     import logging
 
     poisoned = _coherent_battery_bank({98: 9999})
-    _feed_bank(plant, poisoned, device_address=_BATT, received_at=_T0)
+    _establish_baseline(plant, poisoned, device_address=_BATT, received_at=_T0)
     healthy = _coherent_battery_bank({98: 3005, 60: 3600})  # true fw + a sustained real cell delta
     with caplog.at_level(logging.INFO, logger="givenergy_modbus.model.plant"):
         for n in range(1, 11):  # 10 polls @ 100 s → poll 10: count 10, elapsed 900 → heal
@@ -2595,7 +2617,7 @@ def test_splice_transient_corruption_held_not_adopted_soc_protected(plant: Plant
     """
     import logging
 
-    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)  # baseline: fw 3005, soc 55
+    _establish_baseline(plant, device_address=_BATT, received_at=_T0)  # baseline: fw 3005, soc 55
     corrupt = _coherent_battery_bank({98: 2241, 100: 13})  # IR98 immutable + IR100 soc 55->13 (>10 thresh)
     with caplog.at_level(logging.INFO, logger="givenergy_modbus.model.plant"):
         for n in range(1, 7):  # 6 polls @ 30 s = 180 s, far inside the 900 s heal window
@@ -2615,7 +2637,7 @@ def test_splice_heal_seconds_knob_tunes_hold_duration(plant: Plant):
     """splice_heal_seconds tunes how long a scalar-immutable disagreement is held before healing (#286)."""
     plant.splice_heal_seconds = 60.0  # much shorter than the 900 s default
     poisoned = _coherent_battery_bank({98: 9999})
-    _feed_bank(plant, poisoned, device_address=_BATT, received_at=_T0)
+    _establish_baseline(plant, poisoned, device_address=_BATT, received_at=_T0)
     healthy = _coherent_battery_bank()
     for n in range(1, 11):  # 10 polls @ 10 s → poll 10: count 10, elapsed 90 >= 60 → heal
         _feed_bank(plant, healthy, device_address=_BATT, received_at=_T0 + timedelta(seconds=10 * n))
@@ -2627,7 +2649,7 @@ def test_splice_block_age_grows_during_scalar_immut_hold(plant: Plant):
 
     A consumer can therefore see the data is cached/stale (#65).
     """
-    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)  # commits at t0
+    _establish_baseline(plant, device_address=_BATT, received_at=_T0)  # commits at t0
     corrupt = _coherent_battery_bank({98: 2241, 100: 13})  # held (not re-stamped)
     for n in range(1, 4):
         _feed_bank(plant, corrupt, device_address=_BATT, received_at=_T0 + timedelta(seconds=30 * n))
@@ -2639,7 +2661,7 @@ def test_splice_oscillating_scalar_immut_never_adopts(plant: Plant, caplog):
     """Oscillating IR98 garbage never self-adopts — a changing signature resets the streak (#281)."""
     import logging
 
-    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)  # clean seed: IR98 3005
+    _establish_baseline(plant, device_address=_BATT, received_at=_T0)  # clean seed: IR98 3005
     with caplog.at_level(logging.INFO, logger="givenergy_modbus.model.plant"):
         for n in range(1, 13):  # 12 polls @ 15 s = 180 s, still < 300 s (no stale bypass)
             garbage = _coherent_battery_bank({98: 9000 + (n % 2) * 500, 60: 3600})  # IR98 flips each poll
@@ -2652,7 +2674,7 @@ def test_splice_serial_block_change_always_rejected(plant: Plant, caplog):
     """A serial-block change is hard-rejected forever — wrong-pack / re-address protection (#281)."""
     import logging
 
-    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)
+    _establish_baseline(plant, device_address=_BATT, received_at=_T0)
     swapped = _coherent_battery_bank({110: 0x4248})  # serial first word BG.. → a different pack
     with caplog.at_level(logging.INFO, logger="givenergy_modbus.model.plant"):
         for n in range(1, 25):  # 24 polls @ 15 s = 360 s; observation clock refreshes so bypass never fires
@@ -2673,7 +2695,7 @@ def test_splice_heal_requires_uninterrupted_signature(plant: Plant, caplog):
 
     plant.splice_heal_seconds = 1.0  # make the 10-poll floor the operative gate
     poisoned = _coherent_battery_bank({98: 9999})
-    _feed_bank(plant, poisoned, device_address=_BATT, received_at=_T0)
+    _establish_baseline(plant, poisoned, device_address=_BATT, received_at=_T0)
     drift = _coherent_battery_bank({98: 3005, 60: 3600})  # scalar trip (IR98) + 1 physics trip (IR60)
     interrupt = _coherent_battery_bank({98: 9999, 60: 3600})  # IR98 == baseline → no scalar trip → resets streak
     with caplog.at_level(logging.INFO, logger="givenergy_modbus.model.plant"):
@@ -2690,7 +2712,7 @@ def test_splice_cell_and_temp_cohort_rejected(plant: Plant, caplog):
     """Two independent physics trips (a cell + a temperature) are rejected outright (≥2-physics rule)."""
     import logging
 
-    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)
+    _establish_baseline(plant, device_address=_BATT, received_at=_T0)
     corrupted = _coherent_battery_bank(
         {
             74: 3700,  # IR74: cell delta 400 mV > 100 threshold
@@ -2710,7 +2732,7 @@ def test_splice_temp_cohort_zeros_rejected(plant: Plant, caplog):
     """All four cell-mass temps dropping to zero (4 physics trips) is rejected outright."""
     import logging
 
-    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)
+    _establish_baseline(plant, device_address=_BATT, received_at=_T0)
     corrupted = _coherent_battery_bank({76 + i: 0 for i in range(4)})  # IR76–79: 250 → 0
     with caplog.at_level(logging.WARNING, logger="givenergy_modbus.model.plant"):
         _feed_bank(plant, corrupted, device_address=_BATT, received_at=_T0 + timedelta(seconds=30))
@@ -2723,7 +2745,7 @@ def test_splice_clean_bank_commits_no_false_trip(plant: Plant, caplog):
     """In-threshold jitter on a clean bank commits normally and emits no splice WARNING."""
     import logging
 
-    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)
+    _establish_baseline(plant, device_address=_BATT, received_at=_T0)
     # +149 mV cell (≤ 150 threshold), +49 deci temp (≤ 50 threshold) — both within limits.
     jitter = _coherent_battery_bank({60: 3449, 76: 299})
     with caplog.at_level(logging.WARNING, logger="givenergy_modbus.model.plant"):
@@ -2738,7 +2760,7 @@ def test_splice_single_step_escrow_then_confirm(plant: Plant, caplog):
     """A lone impossible delta is escrowed; re-reading the same value confirms and commits."""
     import logging
 
-    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)
+    _establish_baseline(plant, device_address=_BATT, received_at=_T0)
     t1 = _T0 + timedelta(seconds=30)
     t2 = _T0 + timedelta(seconds=60)
     wild = _coherent_battery_bank({60: 3500})  # IR60: +200 mV > 150 threshold — one trip
@@ -2764,7 +2786,7 @@ def test_splice_single_step_escrow_then_snapback(plant: Plant, caplog):
     """A transient splice that snaps back clears the escrow, logs the reversion (INFO), commits clean."""
     import logging
 
-    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)
+    _establish_baseline(plant, device_address=_BATT, received_at=_T0)
     t1 = _T0 + timedelta(seconds=30)
     t2 = _T0 + timedelta(seconds=60)
     wild = _coherent_battery_bank({60: 3500})
@@ -2789,7 +2811,7 @@ def test_splice_two_wild_values_in_a_row_held(plant: Plant, caplog):
     """Two consecutive wild values for the same register are both held (value-consistency guard)."""
     import logging
 
-    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)
+    _establish_baseline(plant, device_address=_BATT, received_at=_T0)
     t1 = _T0 + timedelta(seconds=30)
     t2 = _T0 + timedelta(seconds=60)
     # v1: IR60 → 3500 (|3500 − 3300| = 200 > 150) → escrow (IR60, 3500).
@@ -2804,22 +2826,107 @@ def test_splice_two_wild_values_in_a_row_held(plant: Plant, caplog):
     assert plant.register_caches[_BATT][IR(60)] == 3300, "neither wild value must have committed"
 
 
-def test_splice_cold_start_no_op_commit(plant: Plant, caplog):
-    """The first bank to a fresh device address has no last-good and commits as a no-op."""
+def test_cold_start_first_frame_held_pending(plant: Plant, caplog):
+    """The first bank against an empty cache is held pending a corroborating read, not adopted (#289).
+
+    A transient sub-bus splice in the very first frame would otherwise poison the baseline. The frame
+    is held (the cache stays empty, the device serves "unknown") at INFO — normal startup, not
+    corruption, so no WARNING.
+    """
     import logging
 
-    with caplog.at_level(logging.WARNING, logger="givenergy_modbus.model.plant"):
+    with caplog.at_level(logging.INFO, logger="givenergy_modbus.model.plant"):
         _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)
-    warns = [r for r in caplog.records if "splice" in r.message.lower() or "Held battery bank" in r.message]
-    assert not warns
+    assert IR(60) not in plant.register_caches[_BATT], "first cold-start frame must be held, not committed"
+    assert plant.cold_start_held_count == {_BATT: 1}
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING and "0x33" in r.message]
+    assert [r for r in caplog.records if "first cold-start frame" in r.message and "0x33" in r.message]
+
+
+def test_cold_start_baseline_adopted_on_corroborating_read(plant: Plant, caplog):
+    """A cold-start baseline is adopted once a second poll reads it the same (#289)."""
+    import logging
+
+    bank = _coherent_battery_bank()
+    with caplog.at_level(logging.INFO, logger="givenergy_modbus.model.plant"):
+        _feed_bank(plant, bank, device_address=_BATT, received_at=_T0)  # held
+        _feed_bank(plant, bank, device_address=_BATT, received_at=_T0 + timedelta(seconds=30))  # corroborates
+    assert plant.register_caches[_BATT][IR(60)] == 3300  # committed after corroboration
+    assert plant.register_caches[_BATT][IR(98)] == 3005
+    assert [r for r in caplog.records if "corroborated on re-read" in r.message and "0x33" in r.message]
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING and "0x33" in r.message]
+
+
+def test_cold_start_transient_splice_first_frame_not_adopted(plant: Plant, caplog):
+    """A transient splice in the first cold-start frame never becomes the baseline (#289 — core anti-poison).
+
+    Frame 1 is a temp-zero cohort splice; frame 2 is clean. They disagree, so the splice is never
+    corroborated; the most-recent (clean) frame becomes the candidate and is adopted once it reads the
+    same again. The corrupt zeros must never reach the cache.
+    """
+    import logging
+
+    splice = _coherent_battery_bank({76 + i: 0 for i in range(4)})  # 4 temp-zeros — a #256 splice shape
+    clean = _coherent_battery_bank()
+    with caplog.at_level(logging.INFO, logger="givenergy_modbus.model.plant"):
+        _feed_bank(plant, splice, device_address=_BATT, received_at=_T0)  # held (frame 1)
+        _feed_bank(plant, clean, device_address=_BATT, received_at=_T0 + timedelta(seconds=30))  # disagree → re-hold
+        assert IR(76) not in plant.register_caches[_BATT], "must not adopt with only one clean read seen"
+        _feed_bank(plant, clean, device_address=_BATT, received_at=_T0 + timedelta(seconds=60))  # corroborates clean
+    assert plant.register_caches[_BATT][IR(76)] == 250, "clean baseline adopted; splice zeros never committed"
     assert plant.register_caches[_BATT][IR(60)] == 3300
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING and "0x33" in r.message]
+
+
+def test_cold_start_most_recent_wins_recovers_from_corrupt_first(plant: Plant):
+    """When cold-start reads disagree, the most-recent frame becomes the candidate (#289).
+
+    corrupt, clean, clean → the corrupt first frame is discarded and the clean value adopted.
+    """
+    corrupt = _coherent_battery_bank({98: 9999, 60: 3600})  # immutable + physics trip vs clean
+    clean = _coherent_battery_bank()
+    _feed_bank(plant, corrupt, device_address=_BATT, received_at=_T0)  # held
+    _feed_bank(plant, clean, device_address=_BATT, received_at=_T0 + timedelta(seconds=30))  # disagree → re-hold clean
+    _feed_bank(plant, clean, device_address=_BATT, received_at=_T0 + timedelta(seconds=60))  # corroborate clean
+    assert plant.register_caches[_BATT][IR(98)] == 3005  # corrupt first frame discarded
+    assert plant.register_caches[_BATT][IR(60)] == 3300
+
+
+def test_cold_start_stale_pending_reset(plant: Plant):
+    """A pending cold-start frame older than the stale-bypass window isn't corroborated across the gap (#289).
+
+    The first frame is held; the next arrives after > STALE_BYPASS_SECONDS (a genuine outage). It is
+    treated as a fresh first read (re-held), not corroborated against the stale pending, so a further
+    matching read is needed to adopt.
+    """
+    bank = _coherent_battery_bank()
+    _feed_bank(plant, bank, device_address=_BATT, received_at=_T0)  # held
+    # 400 s later (> 300 s): the pending is stale → treated as a fresh first, re-held (not adopted).
+    _feed_bank(plant, bank, device_address=_BATT, received_at=_T0 + timedelta(seconds=400))
+    assert IR(60) not in plant.register_caches[_BATT], "stale pending must not corroborate across the gap"
+    assert plant.cold_start_held_count[_BATT] == 2  # both reads held
+    # A further matching read now corroborates the fresh pending and commits.
+    _feed_bank(plant, bank, device_address=_BATT, received_at=_T0 + timedelta(seconds=430))
+    assert plant.register_caches[_BATT][IR(60)] == 3300
+
+
+def test_cold_start_persistent_value_corroborates(plant: Plant):
+    """A persistently-identical value corroborates and is adopted — #289 targets transient splices, not it.
+
+    Two identical poisoned reads read the same, so they corroborate into the baseline; recovering a
+    *persistent* poison is the #286 heal's job, not the cold-start guard's. Documents the boundary.
+    """
+    poisoned = _coherent_battery_bank({98: 9999})
+    _feed_bank(plant, poisoned, device_address=_BATT, received_at=_T0)  # held
+    _feed_bank(plant, poisoned, device_address=_BATT, received_at=_T0 + timedelta(seconds=30))  # corroborates
+    assert plant.register_caches[_BATT][IR(98)] == 9999  # adopted — #286 heal recovers this later
 
 
 def test_splice_ir115_usb_change_alone_commits(plant: Plant, caplog):
     """IR(115) usb_device_inserted is mutable (exempt from IMMUTABLE); a change alone must commit."""
     import logging
 
-    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)
+    _establish_baseline(plant, device_address=_BATT, received_at=_T0)
     with caplog.at_level(logging.WARNING, logger="givenergy_modbus.model.plant"):
         _feed_bank(
             plant,
@@ -2836,7 +2943,7 @@ def test_splice_short_read_skips_guard(plant: Plant, caplog):
     """A register_count < 60 frame bypasses the splice guard even if values would trip battery physics."""
     import logging
 
-    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)
+    _establish_baseline(plant, device_address=_BATT, received_at=_T0)
     # IR76 dropping to 0 would be a temp-zero physics trip on a full 60-register bank.
     # With count=1 the guard gates off and the value commits normally.
     with caplog.at_level(logging.WARNING, logger="givenergy_modbus.model.plant"):
@@ -2863,8 +2970,8 @@ def test_splice_non_battery_device_skips_guard(plant: Plant, caplog):
 
 def test_splice_escrow_isolated_per_device(plant: Plant):
     """The splice escrow is keyed per device; confirming 0x33 must not affect 0x34's held state."""
-    _feed_bank(plant, _coherent_battery_bank(), device_address=0x33, received_at=_T0)
-    _feed_bank(plant, _coherent_battery_bank(), device_address=0x34, received_at=_T0)
+    _establish_baseline(plant, device_address=0x33, received_at=_T0)
+    _establish_baseline(plant, device_address=0x34, received_at=_T0)
     t1 = _T0 + timedelta(seconds=30)
     t2 = _T0 + timedelta(seconds=60)
     # Hold 0x33 on IR60; hold 0x34 on IR61.
@@ -2878,7 +2985,7 @@ def test_splice_escrow_isolated_per_device(plant: Plant):
 
 def test_splice_rejected_bank_preserves_staleness(plant: Plant):
     """A splice-rejected bank records no ingestion timestamp; block_age keeps growing (#65/#256)."""
-    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)
+    _establish_baseline(plant, device_address=_BATT, received_at=_T0)
     # ≥2 physics trips → rejected → _stamp_block never called.
     corrupted = _coherent_battery_bank({60: 3700, 76: 0})
     _feed_bank(plant, corrupted, device_address=_BATT, received_at=_T0 + timedelta(seconds=30))
@@ -2897,7 +3004,7 @@ def test_splice_stale_baseline_bypass(plant: Plant, caplog):
     """
     import logging
 
-    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)
+    _establish_baseline(plant, device_address=_BATT, received_at=_T0)
     # Simulate a 400 s gap (> STALE_BYPASS_SECONDS=300): values that would be >=2 physics
     # trips on a fresh baseline must commit unconditionally after a stale one.
     t_reconnect = _T0 + timedelta(seconds=400)
@@ -2925,7 +3032,7 @@ def test_splice_sustained_corruption_never_bypassed(plant: Plant, caplog):
     """
     import logging
 
-    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)
+    _establish_baseline(plant, device_address=_BATT, received_at=_T0)
     corrupt = _coherent_battery_bank({76 + i: 0 for i in range(4)})  # 4 temp-zero physics trips
     with caplog.at_level(logging.INFO, logger="givenergy_modbus.model.plant"):
         # 20 consecutive polls × 30 s = 600 s, well past the 300 s bypass window.
@@ -2949,7 +3056,7 @@ def test_splice_bypass_only_after_genuine_gap_not_rejection_streak(plant: Plant,
     """
     import logging
 
-    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0)
+    _establish_baseline(plant, device_address=_BATT, received_at=_T0)
     # A rejected corruption bank shortly after seed: advances the observation clock to _T0+30.
     _feed_bank(
         plant,
@@ -2979,8 +3086,8 @@ def test_splice_guard_normalises_naive_received_at(plant: Plant, caplog):
     import logging
 
     naive_t0 = datetime(2026, 6, 9, 12, 0, 0)  # no tzinfo
-    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=naive_t0)
-    assert plant.register_caches[_BATT][IR(60)] == 3300  # cold-start commit, no crash on naive
+    _establish_baseline(plant, device_address=_BATT, received_at=naive_t0)
+    assert plant.register_caches[_BATT][IR(60)] == 3300  # corroborated commit, no crash on naive
 
     naive_later = datetime(2026, 6, 9, 12, 6, 40)  # +400 s, still naive (> bypass window)
     with caplog.at_level(logging.INFO, logger="givenergy_modbus.model.plant"):
@@ -3001,8 +3108,8 @@ def test_splice_guard_defaults_now_when_received_at_missing(plant: Plant):
     The `now is None` fallback must produce a tz-aware timestamp so consecutive observations
     still subtract cleanly; a near-instant second poll has a ~0 s gap and commits normally.
     """
-    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT)  # received_at=None
-    assert plant.register_caches[_BATT][IR(60)] == 3300  # cold-start commit, no crash
+    _establish_baseline(plant, device_address=_BATT, received_at=None)  # both reads default now()
+    assert plant.register_caches[_BATT][IR(60)] == 3300  # corroborated commit, no crash
     # Second bank moments later: gap ~0 s (no bypass), single in-threshold change commits.
     _feed_bank(plant, _coherent_battery_bank({60: 3350}), device_address=_BATT)
     assert plant.register_caches[_BATT][IR(60)] == 3350

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -2922,6 +2922,33 @@ def test_cold_start_persistent_value_corroborates(plant: Plant):
     assert plant.register_caches[_BATT][IR(98)] == 9999  # adopted — #286 heal recovers this later
 
 
+def test_cold_start_corroborated_temp_zero_cohort_not_adopted(plant: Plant, caplog):
+    """A temp-zero corruption cohort is refused as a baseline even when two reads corroborate it (#289 review).
+
+    Codex's case: two identical IR76-79=0 frames corroborate, but baselining them would hard-reject
+    every healthy frame forever (physics-only poison the #286 scalar heal can't recover). The cohort
+    is refused (held, surfaced at WARNING); sustained healthy reads then corroborate and adopt.
+    """
+    import logging
+
+    splice = _coherent_battery_bank({76 + i: 0 for i in range(4)})  # IR76-79 = 0 — the temp-zero cohort
+    healthy = _coherent_battery_bank()
+    with caplog.at_level(logging.INFO, logger="givenergy_modbus.model.plant"):
+        _feed_bank(plant, splice, device_address=_BATT, received_at=_T0)  # held
+        _feed_bank(
+            plant, splice, device_address=_BATT, received_at=_T0 + timedelta(seconds=30)
+        )  # corroborates → refused
+        assert IR(76) not in plant.register_caches[_BATT], "corroborated temp-zero cohort must not be baselined"
+        # Sustained healthy reads: the first disagrees with the held cohort, the second corroborates → adopt.
+        _feed_bank(plant, healthy, device_address=_BATT, received_at=_T0 + timedelta(seconds=60))
+        _feed_bank(plant, healthy, device_address=_BATT, received_at=_T0 + timedelta(seconds=90))
+    assert plant.register_caches[_BATT][IR(76)] == 250, "healthy baseline finally adopted; cohort never committed"
+    assert plant.register_caches[_BATT][IR(60)] == 3300
+    assert plant.splice_reject_count == {}, "the cohort was held at cold start, never hard-rejected"
+    warns = [r for r in caplog.records if "temp-zero corruption cohort" in r.message and "0x33" in r.message]
+    assert warns and warns[0].levelno == logging.WARNING
+
+
 def test_splice_ir115_usb_change_alone_commits(plant: Plant, caplog):
     """IR(115) usb_device_inserted is mutable (exempt from IMMUTABLE); a change alone must commit."""
     import logging


### PR DESCRIPTION
Closes #289. Follow-up to #286.

## The hole

When a battery device's cache is empty — a genuine cold start — the splice guard had no last-good to compare against, so it adopted the first bank **unconditionally** (`plant.py`, `if not present: return True`). If that first frame was a sub-bus splice (#147/#256), it poisoned the baseline, and everything #281/#286 do afterwards is recovery from that poisoned state (holding last-good for the `splice_heal_seconds` window).

## The fix — confirm-the-first-frame

The first cold-start frame is now **held** pending a corroborating read, reusing the pure `classify_transition` classifier exactly like the existing physics escrow ("held one poll, committed only if the next reads the same"):

- **First frame** → held (cache untouched, device serves "unknown").
- **Next frame** → `classify_transition(pending, incoming)`. Agree (no trip) → corroborated → commit. Disagree → one of them is a splice → keep the **most recent** as the candidate and wait (recovers if the *first* frame was the splice).

A transient splice reads different garbage each poll, so it never corroborates and never becomes the baseline.

### Design boundary (deliberate)

This defends against *transient/windowed* splices — the real #256 signature. A **persistently**-identical wrong value corroborates itself and is still adopted — by design, because recovering that is the #286 heal's job. The two layers compose: #289 stops transient poison forming, #286 heals persistent poison. Closing the hole at the source should let `splice_heal_seconds` be set shorter later, without re-opening the adoption window.

### Scope

Scoped to the genuine cold-start (empty-cache) branch only. The #256 post-outage stale-bypass is left untouched, so the deliberate fast-readopt-after-outage behaviour isn't regressed.

## Cost & observability

~1 extra poll of "unknown" battery data at startup — safer than serving a poisoned SOC/firmware for the heal window. Surfaced via a new per-device `cold_start_held_count` counter (#284-style, a benign "initialising" signal distinct from `splice_held_count`), plus the existing `block_age()` / absent-register signals.

## Tests

6 new cold-start tests (held-pending, corroborate-and-adopt, transient-splice-never-adopted, most-recent-wins, stale-pending-reset, persistent-value-corroborates). A behaviour change ripples through the existing splice suite — a single battery feed no longer seeds the cache — so those tests now establish a baseline with two corroborating feeds via a new `_establish_baseline` helper that is post-condition-identical to the old single feed. The #286 heal tests prime their poisoned baseline the same way, which nicely demonstrates the #289/#286 layering.

Full suite (1149) green, tox py311–py314, ruff/mypy clean, new code fully patch-covered.

## Known limitation (noted, not bounded)

A pathological *alternating* clean/splice every single poll would hold indefinitely. It's corpus-unsupported (splices are ~1.5%, 1086/17/0), and "unknown" is safer than an adopted poison — bounding it would reintroduce a poison window, so I've left it unbounded and documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Update (review)

Codex caught a real hole in the original "persistent poison → #286 recovers it" boundary: it only holds for *scalar-immutable* poison. A persistent **temp-zero corruption cohort** (IR76-79=0) corroborates itself at cold start and, if adopted, hard-rejects every healthy frame forever — physics-only poison the scalar heal can't recover. Making the ≥2-physics hard-reject healable would be symmetric with, and re-open, the #256 sustained-corruption hole, so instead the cold-start confirmation now **refuses to baseline the known corruption signature** (new `battery_splice.is_corruption_cohort`): a corroborated cohort is held (WARNING) until a healthy pair corroborates instead. Scalar-immutable poison still corroborates and is left to #286, by design. Fixed in 4e1c36a with a bad/bad→sustained-healthy regression + predicate unit tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved detection of corrupted battery temperature sensor data to prevent invalid readings from affecting system performance.
  * Enhanced cold-start battery baseline establishment with a confirmation process that requires consistent readings before adoption, reducing false data acceptance.

* **Tests**
  * Added test coverage for data corruption detection and cold-start baseline confirmation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->