### PR TITLE
fix(mock): disambiguate serials in main() + deprecate `python -m` serve path

### DIFF
--- a/givenergy_modbus/testing/mock_plant.py
+++ b/givenergy_modbus/testing/mock_plant.py
@@ -15,9 +15,19 @@ Fidelity choices (Phase 1 — read-serving, static topology):
 
 Mutable writes and dynamic bus/device add-remove are a later phase.
 
-Run it directly to point another client at a capture::
+To serve a mock from a capture, use the CLI (the canonical serve tool)::
 
-    python -m givenergy_modbus.testing.mock_plant --capture path/to/plant.log --port 8899
+    givenergy-cli mock-server --capture path/to/plant.log   # see --help for --bind/--port
+
+In-process (tests, scripting), build one with :meth:`MockPlant.from_capture` — which also
+re-tails multi-instance devices to distinct serials (#283/#288/#290)::
+
+    mock = MockPlant.from_capture("path/to/plant.log")
+    host, port = await mock.start()
+
+Running this module as ``python -m givenergy_modbus.testing.mock_plant`` is **deprecated**: it
+double-imports under the package ``__init__`` (a ``RuntimeWarning``). Prefer the CLI or
+``from_capture`` above.
 """
 
 from __future__ import annotations
@@ -409,6 +419,10 @@ def main(argv: list[str] | None = None) -> int:
     logging.basicConfig(level=logging.DEBUG if args.verbose else logging.INFO)
 
     plant = plant_from_capture(*args.capture)
+    # Match MockPlant.from_capture(): give replayed multi-instance devices distinct serials so the
+    # served mock doesn't collide e.g. EMS managed-inverter serials (#283/#288/#290). Building the
+    # MockPlant by hand below would otherwise skip this and serve colliding serials.
+    _make_device_serials_distinct(plant)
     for reg, val in ((21, args.arm_fw), (19, args.dsp_fw)):  # HR(21)=ARM, HR(19)=DSP firmware version
         if val is not None:
             for cache in plant.register_caches.values():
@@ -434,4 +448,12 @@ def main(argv: list[str] | None = None) -> int:
 
 
 if __name__ == "__main__":
+    # `python -m …mock_plant` double-imports under the package __init__ (RuntimeWarning) and is
+    # deprecated; the CLI is the serve tool. Warn once (lastResort handler shows it before main()
+    # configures logging), then run anyway so existing scripts don't break.
+    _logger.warning(
+        "`python -m givenergy_modbus.testing.mock_plant` is deprecated (it double-imports under the "
+        "package __init__). Use `givenergy-cli mock-server` to serve a mock, or MockPlant.from_capture() "
+        "in-process."
+    )
     raise SystemExit(main())

--- a/tests/client/test_mock_plant_integration.py
+++ b/tests/client/test_mock_plant_integration.py
@@ -371,3 +371,36 @@ def test_ems_mock_serves_distinct_managed_inverter_serials():
     assert len(serials) == 2  # the 2-managed-inverter fixture
     assert len(set(serials)) == 2, f"managed-inverter serials must be distinct: {serials}"
     assert all(s.startswith("CE") for s in serials)  # real prefix preserved
+
+
+def test_main_serve_path_disambiguates_managed_inverter_serials(monkeypatch):
+    """main() (the scripted serve path) disambiguates serials like from_capture, not collide them.
+
+    Regression for the hass-reported gap: main() built MockPlant from plant_from_capture() directly and
+    skipped _make_device_serials_distinct, so the served mock collided both managed inverters at CE…G000.
+    Spy on construction and stub the server so we can inspect the built mock without binding a socket.
+    """
+    from givenergy_modbus.model.ems import Ems
+    from givenergy_modbus.testing.mock_plant import MockPlant, main
+
+    captured: dict = {}
+    orig_init = MockPlant.__init__
+
+    def _spy_init(self, devices, **kwargs):
+        orig_init(self, devices, **kwargs)
+        captured["mock"] = self
+
+    async def _noop_start(self, host="127.0.0.1", port=0):
+        return ("127.0.0.1", 0)
+
+    async def _noop_serve(self):
+        return
+
+    monkeypatch.setattr(MockPlant, "__init__", _spy_init)
+    monkeypatch.setattr(MockPlant, "start", _noop_start)
+    monkeypatch.setattr(MockPlant, "serve_forever", _noop_serve)
+
+    rc = main(["--capture", str(_CAPTURES / "ems_2_inv_3_bat_a" / "ems_arm1036_60s.log"), "--port", "0"])
+    assert rc == 0
+    serials = [inv.serial_number for inv in Ems.from_register_cache(captured["mock"].devices[0x11]).managed_inverters]
+    assert len(serials) == 2 and len(set(serials)) == 2, f"main() must serve distinct serials, got {serials}"


### PR DESCRIPTION
## Problem

The `mock_plant` module docstring advertised `python -m givenergy_modbus.testing.mock_plant --capture …` as the way to serve a mock. That path has two defects:

1. **Double-import** — `testing/__init__.py` imports `mock_plant`, so running it as `-m` loads the module twice (once as `__main__`, once as the package member) and emits a `RuntimeWarning`.
2. **Collided serials (the real bug)** — `main()` built the `MockPlant` from `plant_from_capture()` directly and never called `_make_device_serials_distinct()` (which lives only in `MockPlant.from_capture()`). So the served mock collided multi-instance device serials — e.g. an EMS capture served both managed inverters as `CE…G000`, defeating #283/#288/#290.

Surfaced hass-side (after ~2h of debugging) while validating [givenergy-hass#199](https://github.com/dewet22/givenergy-hass/issues/199) (EMS managed-inverter devices) against the mock.

## Fix

- `main()` now runs `_make_device_serials_distinct()` after loading the capture, exactly like `MockPlant.from_capture()` — the scripted serve path serves distinct serials.
- Docstring points at `givenergy-cli mock-server` (the canonical serve tool) and `MockPlant.from_capture()` for in-process/tests; the `-m` invocation is marked **deprecated**.
- `__main__` emits a one-time deprecation warning, then runs anyway so existing scripts don't break.

## Test

A regression test drives `main()` with the server stubbed (spy on construction, no-op `start`/`serve_forever`) and asserts the built mock serves two **distinct** managed-inverter serials. Verified it fails without the fix.

Full suite (1153) green, tox py311–py314.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
