### PR TITLE
fix(splice): widen cell_mV/v_out thresholds for the near-full-SOC knee (#299)

### DIFF
--- a/givenergy_modbus/model/battery_splice.py
+++ b/givenergy_modbus/model/battery_splice.py
@@ -25,14 +25,17 @@ few minutes). ``num_cells``, ``bms_firmware_version`` and the serial block are c
 ANY transient change is corruption on its own.
 
 The original Gen1-calibrated corpus separated cleanly, but field reports from higher-power
-hardware (hass#186, an AC3 + 2x Giv-Bat 5.2: a ~103 mV cell sag on a load step, a ~10 Ah
-capacity recalibration) showed legitimate per-poll deltas just past the ``cell_mV`` (100) and
-``cap_centiAh`` (1000) thresholds — caught by the singleton escrow but noisy. Both were widened
-(cell_mV->150, cap_centiAh->1500). This is safe because the corpus's *only* corruption signature
-is the temperature-zero cohort (>=2 temp registers -> rejected outright): no corruption has ever
-presented as a lone ``cell_mV`` or ``cap_centiAh`` delta, so widening exactly these two classes
-(temps untouched) cannot weaken detection, and any residual over-threshold singleton still
-escrows.
+hardware showed legitimate per-poll deltas exceeding the voltage/capacity thresholds. hass#186
+(an AC3 + 2x Giv-Bat 5.2) saw a ~103 mV cell sag on a load step and a ~10 Ah capacity
+recalibration just past ``cell_mV`` (100) and ``cap_centiAh`` (1000) — caught by the singleton
+escrow but noisy. #299 saw a worse case: as a pack enters the LiFePO4 charge knee near 100% SOC,
+cells surge ~150-200 mV/poll and the pack terminal voltage ~2.3 V/poll together — three
+simultaneous trips (>=2) hard-rejected the whole bank for the entire ~18 min surge. So ``cell_mV``
+was widened 100->150->300, ``cap_centiAh`` 1000->1500, and ``v_out_mV`` 2000->4000. This is safe
+because the corpus's *only* corruption signature is the temperature-zero cohort (>=2 temp registers
+-> rejected outright): no corruption has ever presented as a lone ``cell_mV``, ``v_out_mV`` or
+``cap_centiAh`` delta, so widening exactly these voltage/capacity classes (temps untouched) cannot
+weaken detection, and any residual over-threshold singleton still escrows.
 
 Indices throughout are **bank-relative** (``i`` == register ``IR(60 + i)``); the trips
 returned carry the **absolute** IR number for logging.
@@ -45,9 +48,12 @@ BANK_BASE = 60
 
 # (class name, bank-relative indices, threshold on |delta| in raw units).
 SCALAR_RULES: list[tuple[str, list[int], int]] = [
-    # IR(60-75) cells: ~10 mV/poll at idle, but a higher-power inverter (e.g. AC3) sags a cell
-    # ~100+ mV on a charge<->discharge load step (I×R) — see hass#186; 150 clears that with margin.
-    ("cell_mV", list(range(0, 16)), 150),
+    # IR(60-75) cells: ~10 mV/poll at idle, but an AC3 load step sags a cell ~100+ mV (I×R, hass#186)
+    # AND the LiFePO4 voltage knee near 100% SOC steps cells ~150-200+ mV/poll as the pack tops out
+    # (#299, field-observed at 154-198 mV). 300 clears both with margin. Safe to widen: cell_mV has
+    # never been a corruption signature — corruption always trips the temp-zero cohort (>=2 cell-mass
+    # temps -> 0), so widening cell_mV cannot weaken detection (re-validated against the corpus).
+    ("cell_mV", list(range(0, 16)), 300),
     ("cell_temp_deci", [16, 17, 18, 19, 43, 44], 50),  # IR(76-79,103,104): thermal mass
     ("mosfet_temp_deci", [21], 200),  # IR(81): junction-adjacent, steps with load
     ("v_cells_sum_mV", [20], 1600),  # IR(80)
@@ -58,7 +64,10 @@ SCALAR_RULES: list[tuple[str, list[int], int]] = [
 # cap_centiAh 1500: capacity recalibration (coulomb-count correction) can step ~10 Ah in one poll
 # on a larger pack — see hass#186.
 PAIR_RULES: list[tuple[str, tuple[int, int], int]] = [
-    ("v_out_mV", (22, 23), 2000),  # IR(82-83)
+    # IR(82-83): the pack output ~ sum of cells, so the near-full-SOC knee steps it ~2.3 V/poll as all
+    # cells surge together (#299, field-observed 2263 mV); 4000 clears that. Like cell_mV, never a
+    # corruption signature, so widening can't weaken detection (corpus-re-validated).
+    ("v_out_mV", (22, 23), 4000),
     ("cap_centiAh", (24, 25), 1500),  # IR(84-85) cap_calibrated
     ("cap_centiAh", (26, 27), 1500),  # IR(86-87) cap_design
     ("cap_centiAh", (28, 29), 1500),  # IR(88-89) cap_remaining

--- a/tests/model/test_battery_splice.py
+++ b/tests/model/test_battery_splice.py
@@ -62,10 +62,10 @@ def test_immutable_scalar_serial_partition_covers_immutable():
 def test_single_cell_voltage_step_is_one_physics_trip():
     base = _baseline()
     new = list(base)
-    new[5] = 3600  # +300 mV > 150 mV threshold
+    new[5] = 3700  # +400 mV > 300 mV threshold (#299)
     phys, immut = classify_transition(base, new)
     assert immut == []
-    assert phys == [(BANK_BASE + 5, "cell_mV", 3300, 3600)]
+    assert phys == [(BANK_BASE + 5, "cell_mV", 3300, 3700)]
 
 
 def test_within_threshold_jitter_does_not_trip():
@@ -106,7 +106,7 @@ def test_pair_rule_uses_assembled_uint32_value():
 def test_two_independent_physics_deltas_both_reported():
     base = _baseline()
     new = list(base)
-    new[14] = 3600  # a cell
+    new[14] = 3700  # a cell, +400 mV > 300 mV threshold (#299)
     new[43] = 0  # t_max to zero
     phys, immut = classify_transition(base, new)
     assert immut == []

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -2167,7 +2167,7 @@ def test_splice_reject_count_increments_on_hard_reject(plant: Plant):
 def test_splice_held_count_increments_on_escrow(plant: Plant):
     """A single-delta escrow hold bumps splice_held_count, not splice_reject_count."""
     _establish_baseline(plant, device_address=_BATT, received_at=_T0)
-    wild = _coherent_battery_bank({60: 3600})  # one out-of-threshold delta → hold one poll
+    wild = _coherent_battery_bank({60: 3700})  # one out-of-threshold delta (+400 > 300) → hold one poll
     _feed_bank(plant, wild, device_address=_BATT, received_at=_T0 + timedelta(seconds=30))
     assert plant.splice_held_count == {_BATT: 1}
     assert plant.splice_reject_count == {}
@@ -2763,7 +2763,7 @@ def test_splice_single_step_escrow_then_confirm(plant: Plant, caplog):
     _establish_baseline(plant, device_address=_BATT, received_at=_T0)
     t1 = _T0 + timedelta(seconds=30)
     t2 = _T0 + timedelta(seconds=60)
-    wild = _coherent_battery_bank({60: 3500})  # IR60: +200 mV > 150 threshold — one trip
+    wild = _coherent_battery_bank({60: 3700})  # IR60: +400 mV > 300 threshold — one trip
 
     # The singleton self-healing path is INFO, never WARNING (#256/hass#186).
     with caplog.at_level(logging.INFO, logger="givenergy_modbus.model.plant"):
@@ -2774,12 +2774,12 @@ def test_splice_single_step_escrow_then_confirm(plant: Plant, caplog):
     assert plant.register_caches[_BATT][IR(60)] == 3300, "escrowed bank must not commit"
 
     caplog.clear()
-    # Re-read the same value: |3500 − 3500| = 0 ≤ 150 → value-consistent → confirm.
+    # Re-read the same value: |3700 − 3700| = 0 ≤ 300 → value-consistent → confirm.
     with caplog.at_level(logging.INFO, logger="givenergy_modbus.model.plant"):
         _feed_bank(plant, wild, device_address=_BATT, received_at=t2)
     confirms = [r for r in caplog.records if "confirmed on re-read" in r.message and "0x33" in r.message]
     assert len(confirms) == 1, "confirmed step must emit one INFO log"
-    assert plant.register_caches[_BATT][IR(60)] == 3500, "confirmed step must commit"
+    assert plant.register_caches[_BATT][IR(60)] == 3700, "confirmed step must commit"
 
 
 def test_splice_single_step_escrow_then_snapback(plant: Plant, caplog):
@@ -2789,7 +2789,7 @@ def test_splice_single_step_escrow_then_snapback(plant: Plant, caplog):
     _establish_baseline(plant, device_address=_BATT, received_at=_T0)
     t1 = _T0 + timedelta(seconds=30)
     t2 = _T0 + timedelta(seconds=60)
-    wild = _coherent_battery_bank({60: 3500})
+    wild = _coherent_battery_bank({60: 3700})
     with caplog.at_level(logging.INFO, logger="givenergy_modbus.model.plant"):
         _feed_bank(plant, wild, device_address=_BATT, received_at=t1)
     assert plant.register_caches[_BATT][IR(60)] == 3300
@@ -2814,16 +2814,39 @@ def test_splice_two_wild_values_in_a_row_held(plant: Plant, caplog):
     _establish_baseline(plant, device_address=_BATT, received_at=_T0)
     t1 = _T0 + timedelta(seconds=30)
     t2 = _T0 + timedelta(seconds=60)
-    # v1: IR60 → 3500 (|3500 − 3300| = 200 > 150) → escrow (IR60, 3500).
-    # v2: IR60 → 3700 (|3700 − 3500| = 200 > 150) → does NOT confirm → re-escrow (IR60, 3700).
-    v1 = _coherent_battery_bank({60: 3500})
-    v2 = _coherent_battery_bank({60: 3700})
+    # v1: IR60 → 3700 (|3700 − 3300| = 400 > 300) → escrow (IR60, 3700).
+    # v2: IR60 → 4200 (|4200 − 3700| = 500 > 300) → does NOT confirm → re-escrow (IR60, 4200).
+    v1 = _coherent_battery_bank({60: 3700})
+    v2 = _coherent_battery_bank({60: 4200})
     with caplog.at_level(logging.INFO, logger="givenergy_modbus.model.plant"):
         _feed_bank(plant, v1, device_address=_BATT, received_at=t1)
         _feed_bank(plant, v2, device_address=_BATT, received_at=t2)
     holds = [r for r in caplog.records if "held one poll pending confirmation" in r.message and "0x33" in r.message]
     assert len(holds) == 2, "each wild read must emit its own 'held' INFO log"
     assert plant.register_caches[_BATT][IR(60)] == 3300, "neither wild value must have committed"
+
+
+def test_near_full_soc_knee_surge_commits(plant: Plant, caplog):
+    """A near-100%-SOC LiFePO4 knee surge commits in one poll, not hard-rejected (#299).
+
+    Field signature (device 0x33 topping out — ~18.5 min of rejections): two cells (IR65/IR68)
+    stepped ~198 mV and the pack terminal voltage IR(82–83) ~2.3 V in a single poll as the pack
+    entered the LiFePO4 charge knee. Pre-#299 thresholds (cell_mV 150, v_out 2000) counted three
+    physics trips (>=2) and hard-rejected the whole bank for the entire surge. Widened to 300 / 4000
+    the surge sits within threshold: zero trips → commits directly (no escrow, no rejection).
+    """
+    import logging
+
+    _establish_baseline(plant, device_address=_BATT, received_at=_T0)
+    # IR65/IR68 +198 mV (150 < 198 < 300); v_out IR(82–83) +2263 mV (2000 < 2263 < 4000);
+    # v_cells_sum a coherent sub-threshold step. Pre-#299 this was 3 trips → reject.
+    knee = _coherent_battery_bank({65: 3498, 68: 3498, 80: 53200, 82: 0, 83: 55063})
+    with caplog.at_level(logging.INFO, logger="givenergy_modbus.model.plant"):
+        _feed_bank(plant, knee, device_address=_BATT, received_at=_T0 + timedelta(seconds=30))
+    assert plant.register_caches[_BATT][IR(65)] == 3498, "knee surge must commit (cell)"
+    assert plant.register_caches[_BATT][IR(83)] == 55063, "knee surge must commit (v_out)"
+    assert plant.splice_reject_count == {}, "knee surge must not be rejected"
+    assert plant.splice_held_count == {}, "zero trips → committed directly, not escrowed"
 
 
 def test_cold_start_first_frame_held_pending(plant: Plant, caplog):
@@ -3002,11 +3025,11 @@ def test_splice_escrow_isolated_per_device(plant: Plant):
     t1 = _T0 + timedelta(seconds=30)
     t2 = _T0 + timedelta(seconds=60)
     # Hold 0x33 on IR60; hold 0x34 on IR61.
-    _feed_bank(plant, _coherent_battery_bank({60: 3500}), device_address=0x33, received_at=t1)
-    _feed_bank(plant, _coherent_battery_bank({61: 3500}), device_address=0x34, received_at=t1)
-    # Confirm 0x33 by re-reading IR60=3500.
-    _feed_bank(plant, _coherent_battery_bank({60: 3500}), device_address=0x33, received_at=t2)
-    assert plant.register_caches[0x33][IR(60)] == 3500, "0x33 confirmed and committed"
+    _feed_bank(plant, _coherent_battery_bank({60: 3700}), device_address=0x33, received_at=t1)
+    _feed_bank(plant, _coherent_battery_bank({61: 3700}), device_address=0x34, received_at=t1)
+    # Confirm 0x33 by re-reading IR60=3700.
+    _feed_bank(plant, _coherent_battery_bank({60: 3700}), device_address=0x33, received_at=t2)
+    assert plant.register_caches[0x33][IR(60)] == 3700, "0x33 confirmed and committed"
     assert plant.register_caches[0x34][IR(61)] == 3300, "0x34 still held; 0x33 confirm must not clear it"
 
 


### PR DESCRIPTION
Refs #299 — this is the threshold-widening step. The deeper sustained-step recovery fix stays tracked on #299 as follow-up (per review), so this PR deliberately does **not** auto-close it.

As a LiFePO4 pack enters the charge knee near 100% SOC, all cells surge together and the pack terminal voltage steps with them. On my loft Gen1 this tripped the splice guard's physics-delta thresholds (`cell_mV` 150, `v_out` 2000) on ≥2 registers at once, so the whole bank hit the **hard-reject** path and stayed rejected for the entire ~18.5 min surge (device 0x33), freezing the battery telemetry at the last-good baseline. The rejected data was legitimate — plausible 3.6 V cells / 56 V v_out, drifting smoothly as the pack settled — not corruption.

## Change

- `cell_mV` 150 → 300, `v_out_mV` 2000 → 4000 in `battery_splice.py` (`SCALAR_RULES` / `PAIR_RULES`), clearing the observed knee (cells 154–198 mV/poll, v_out 2263 mV/poll) with margin.
- Module docstring + rule comments updated to fold the #299 knee rationale in alongside the hass#186 cell_mV widening.

## Why it's safe

The corpus's only corruption signature is the temperature-zero cohort (≥2 cell-mass temps → 0), which is untouched. No corruption has ever presented as a lone `cell_mV` or `v_out` delta, so widening exactly these voltage classes can't weaken detection — the same argument as the earlier hass#186 `cell_mV` 100→150 widening. Re-validated against the capture corpus: separation **unchanged** at 1086 clean / 1 genuine singleton / 16 corruption events (all ≥2 trips). Codex independently re-ran the classifier and confirmed the same.

## Tests

- New `test_near_full_soc_knee_surge_commits` reproduces the field signature (two cells +198 mV, v_out +2263 mV in one poll) and asserts it commits rather than rejecting.
- The existing escrow/classifier tests that used ~200 mV cell deltas (chosen to be "just over 150") are bumped to clearly exceed 300 — a mechanical consequence of the threshold move, behaviour intent unchanged.
- Full suite green; `tox` py311–py314 + format + lint green.

## Not in this PR

The deeper fragility #299 notes: a ≥2-physics hard-reject still has no recovery for a *sustained legitimate* step, so a larger future spike could stick again. The heal-adopt / plausibility-gate follow-up (extending #286's time-discriminator, or the #289-deferred plausibility gate) is left as the proper fix and stays open on #299; this widening is the pragmatic first step. Related: #298 (sub-bank salvage / telemetry-lag).