### PR TITLE
feat(commands): widen battery power-limit bounds to 0–100% (HR111/112, HR313/314)

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -265,8 +265,8 @@ An unmarked row means the method is available on both inverter types. On `ThreeP
 | `set_charge_target_soc(soc)` | Set just the charge-target SOC (4–100), leaving the enable bits untouched | |
 | `disable_charge_target()` | Remove SOC limit, target 100% | |
 | `set_enable_charge(enabled)` | Enable or disable charging | |
-| `set_battery_charge_limit(val)` | Charge power limit (0–50%) | |
-| `set_battery_charge_limit_ac(val)` | AC charge power limit (1–100%) | ⛔ commands-only |
+| `set_battery_charge_limit(val)` | Charge power limit (0–100%; firmware clamps per-model) | |
+| `set_battery_charge_limit_ac(val)` | AC charge power limit (0–100%) | ⛔ commands-only |
 | `set_shallow_charge(val)` | Set shallow charge threshold (deprecated — use `set_battery_soc_reserve`) | ⛔ commands-only |
 
 ### Discharging
@@ -274,8 +274,8 @@ An unmarked row means the method is available on both inverter types. On `ThreeP
 | Function | Description | Surface |
 |---|---|---|
 | `set_enable_discharge(enabled)` | Enable or disable discharging | |
-| `set_battery_discharge_limit(val)` | Discharge power limit (0–50%) | |
-| `set_battery_discharge_limit_ac(val)` | AC discharge power limit (1–100%) | ⛔ commands-only |
+| `set_battery_discharge_limit(val)` | Discharge power limit (0–100%; firmware clamps per-model) | |
+| `set_battery_discharge_limit_ac(val)` | AC discharge power limit (0–100%) | ⛔ commands-only |
 | `set_battery_soc_reserve(val)` | Minimum SOC to maintain (4–100%) | |
 | `set_battery_power_reserve(val)` | Battery power reserve (4–100%) | |
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -265,7 +265,7 @@ An unmarked row means the method is available on both inverter types. On `ThreeP
 | `set_charge_target_soc(soc)` | Set just the charge-target SOC (4–100), leaving the enable bits untouched | |
 | `disable_charge_target()` | Remove SOC limit, target 100% | |
 | `set_enable_charge(enabled)` | Enable or disable charging | |
-| `set_battery_charge_limit(val)` | Charge power limit (0–100%; firmware clamps per-model) | |
+| `set_battery_charge_limit(val)` | Charge power limit (0–100%; firmware expected to clamp per-model) | |
 | `set_battery_charge_limit_ac(val)` | AC charge power limit (0–100%) | ⛔ commands-only |
 | `set_shallow_charge(val)` | Set shallow charge threshold (deprecated — use `set_battery_soc_reserve`) | ⛔ commands-only |
 
@@ -274,7 +274,7 @@ An unmarked row means the method is available on both inverter types. On `ThreeP
 | Function | Description | Surface |
 |---|---|---|
 | `set_enable_discharge(enabled)` | Enable or disable discharging | |
-| `set_battery_discharge_limit(val)` | Discharge power limit (0–100%; firmware clamps per-model) | |
+| `set_battery_discharge_limit(val)` | Discharge power limit (0–100%; firmware expected to clamp per-model) | |
 | `set_battery_discharge_limit_ac(val)` | AC discharge power limit (0–100%) | ⛔ commands-only |
 | `set_battery_soc_reserve(val)` | Minimum SOC to maintain (4–100%) | |
 | `set_battery_power_reserve(val)` | Battery power reserve (4–100%) | |

--- a/givenergy_modbus/client/commands.py
+++ b/givenergy_modbus/client/commands.py
@@ -329,12 +329,13 @@ def set_charge_target_soc_3ph(target_soc: int) -> list[TransparentRequest]:
 def set_battery_charge_limit(val: int) -> list[TransparentRequest]:
     """Set the battery charge power limit as a percentage of rated charge power (0-100).
 
-    This is a %-of-rated ceiling, not a current command: the BMS/firmware clamp it to the battery
-    subsystem's actual rating. On DC-coupled hybrids that subsystem is often ~50% of inverter rating
-    (Gen1: 2600 W of 5000 W), which is why GivTCP and older versions capped at 50. But the GE app
-    itself writes >50 (field-tested writing 62% to HR(111) / 59% to HR(112) on a Gen1, both accepted)
-    and the ~50% is model-specific, so we accept 0-100 and let the firmware clamp per-model rather
-    than hard-cap and wrongly reject valid values on hybrids with a larger battery subsystem.
+    This is a %-of-rated ceiling, not a current command. On DC-coupled hybrids the battery subsystem
+    is often ~50% of inverter rating (Gen1: 2600 W of 5000 W), which is why GivTCP and older versions
+    capped at 50. But the GE app itself writes >50 — field-tested writing 62% to HR(111) / 59% to
+    HR(112) on a Gen1, both accepted — so the register tolerates it and the ~50% is model-specific.
+    We accept 0-100 rather than hard-cap and wrongly reject valid values on hybrids with a larger
+    battery subsystem. What the firmware does with a ceiling above the battery's capability (clamp to
+    the real rating is the expectation) is not yet field-verified.
     """
     val = _as_int(val, "val")
     if not 0 <= val <= 100:
@@ -406,7 +407,12 @@ def set_enable_eps(enabled: bool) -> list[TransparentRequest]:
 
 
 def set_battery_charge_limit_ac(val: int) -> list[TransparentRequest]:
-    """Set the battery AC charge power limit as a percentage (0-100; 0 disables AC charge)."""
+    """Set the battery AC charge power limit as a percentage (0-100).
+
+    The GE app exposes 0-100 for this control; 0 is expected to disable AC charge but is not yet
+    field-confirmed on AC hardware. (The v4.1.6 register doc lists 1-100, but it is hybrid-scoped and
+    HR313/314 are AC-coupled registers absent on hybrids, so its bound is of questionable authority.)
+    """
     val = _as_int(val, "val")
     if not 0 <= val <= 100:
         raise ValueError(f"Specified AC Charge Limit ({val}%) is not in [0-100]%")
@@ -414,7 +420,12 @@ def set_battery_charge_limit_ac(val: int) -> list[TransparentRequest]:
 
 
 def set_battery_discharge_limit_ac(val: int) -> list[TransparentRequest]:
-    """Set the battery AC discharge power limit as a percentage (0-100; 0 disables AC discharge)."""
+    """Set the battery AC discharge power limit as a percentage (0-100).
+
+    The GE app exposes 0-100 for this control; 0 is expected to disable AC discharge but is not yet
+    field-confirmed on AC hardware. (The v4.1.6 register doc lists 1-100, but it is hybrid-scoped and
+    HR313/314 are AC-coupled registers absent on hybrids, so its bound is of questionable authority.)
+    """
     val = _as_int(val, "val")
     if not 0 <= val <= 100:
         raise ValueError(f"Specified AC Discharge Limit ({val}%) is not in [0-100]%")

--- a/givenergy_modbus/client/commands.py
+++ b/givenergy_modbus/client/commands.py
@@ -327,18 +327,30 @@ def set_charge_target_soc_3ph(target_soc: int) -> list[TransparentRequest]:
 
 
 def set_battery_charge_limit(val: int) -> list[TransparentRequest]:
-    """Set the battery charge power limit as a percentage of rated charge power (0–50)."""
+    """Set the battery charge power limit as a percentage of rated charge power (0-100).
+
+    This is a %-of-rated ceiling, not a current command: the BMS/firmware clamp it to the battery
+    subsystem's actual rating. On DC-coupled hybrids that subsystem is often ~50% of inverter rating
+    (Gen1: 2600 W of 5000 W), which is why GivTCP and older versions capped at 50. But the GE app
+    itself writes >50 (field-tested writing 62% to HR(111) / 59% to HR(112) on a Gen1, both accepted)
+    and the ~50% is model-specific, so we accept 0-100 and let the firmware clamp per-model rather
+    than hard-cap and wrongly reject valid values on hybrids with a larger battery subsystem.
+    """
     val = _as_int(val, "val")
-    if not 0 <= val <= 50:
-        raise ValueError(f"Specified Charge Limit ({val}%) is not in [0-50]%")
+    if not 0 <= val <= 100:
+        raise ValueError(f"Specified Charge Limit ({val}%) is not in [0-100]%")
     return [WriteHoldingRegisterRequest(RegisterMap.BATTERY_CHARGE_LIMIT, val)]
 
 
 def set_battery_discharge_limit(val: int) -> list[TransparentRequest]:
-    """Set the battery discharge power limit as a percentage of rated discharge power (0–50)."""
+    """Set the battery discharge power limit as a percentage of rated discharge power (0-100).
+
+    See :func:`set_battery_charge_limit` for why this accepts 0-100 (firmware clamps per-model)
+    rather than the historical [0-50].
+    """
     val = _as_int(val, "val")
-    if not 0 <= val <= 50:
-        raise ValueError(f"Specified Discharge Limit ({val}%) is not in [0-50]%")
+    if not 0 <= val <= 100:
+        raise ValueError(f"Specified Discharge Limit ({val}%) is not in [0-100]%")
     return [WriteHoldingRegisterRequest(RegisterMap.BATTERY_DISCHARGE_LIMIT, val)]
 
 
@@ -394,18 +406,18 @@ def set_enable_eps(enabled: bool) -> list[TransparentRequest]:
 
 
 def set_battery_charge_limit_ac(val: int) -> list[TransparentRequest]:
-    """Set the battery AC charge power limit as a percentage."""
+    """Set the battery AC charge power limit as a percentage (0-100; 0 disables AC charge)."""
     val = _as_int(val, "val")
-    if not 1 <= val <= 100:
-        raise ValueError(f"Specified AC Charge Limit ({val}%) is not in [1-100]%")
+    if not 0 <= val <= 100:
+        raise ValueError(f"Specified AC Charge Limit ({val}%) is not in [0-100]%")
     return [WriteHoldingRegisterRequest(RegisterMap.BATTERY_CHARGE_LIMIT_AC, val)]
 
 
 def set_battery_discharge_limit_ac(val: int) -> list[TransparentRequest]:
-    """Set the battery AC discharge power limit as a percentage."""
+    """Set the battery AC discharge power limit as a percentage (0-100; 0 disables AC discharge)."""
     val = _as_int(val, "val")
-    if not 1 <= val <= 100:
-        raise ValueError(f"Specified AC Discharge Limit ({val}%) is not in [1-100]%")
+    if not 0 <= val <= 100:
+        raise ValueError(f"Specified AC Discharge Limit ({val}%) is not in [0-100]%")
     return [WriteHoldingRegisterRequest(RegisterMap.BATTERY_DISCHARGE_LIMIT_AC, val)]
 
 
@@ -978,11 +990,11 @@ class _InverterCommands:
         return set_battery_soc_reserve(val)
 
     def set_battery_charge_limit(self, val: int) -> list[TransparentRequest]:
-        """Set the battery charge power limit as a percentage of the rated charge power (0-50)."""
+        """Set the battery charge power limit as a percentage of the rated charge power (0-100)."""
         return set_battery_charge_limit(val)
 
     def set_battery_discharge_limit(self, val: int) -> list[TransparentRequest]:
-        """Set the battery discharge power limit as a percentage of the rated discharge power (0-50)."""
+        """Set the battery discharge power limit as a percentage of the rated discharge power (0-100)."""
         return set_battery_discharge_limit(val)
 
     def set_battery_power_reserve(self, val: int) -> list[TransparentRequest]:

--- a/tests/client/test_commands.py
+++ b/tests/client/test_commands.py
@@ -359,10 +359,17 @@ async def test_set_charge_and_discharge_limits():
         WriteHoldingRegisterRequest(RegisterMap.BATTERY_DISCHARGE_LIMIT, 50, device_address=0x11),
     ]
 
-    with pytest.raises(ValueError, match=r"Specified Charge Limit \(51%\) is not in \[0-50\]\%"):
-        commands.set_battery_charge_limit(51)
-    with pytest.raises(ValueError, match=r"Specified Discharge Limit \(51%\) is not in \[0-50\]\%"):
-        commands.set_battery_discharge_limit(51)
+    # Widened 0-50 -> 0-100: 51 and 100 now commit (firmware clamps per-model); 101 is the new ceiling.
+    assert commands.set_battery_charge_limit(51) == [
+        WriteHoldingRegisterRequest(RegisterMap.BATTERY_CHARGE_LIMIT, 51),
+    ]
+    assert commands.set_battery_discharge_limit(100) == [
+        WriteHoldingRegisterRequest(RegisterMap.BATTERY_DISCHARGE_LIMIT, 100),
+    ]
+    with pytest.raises(ValueError, match=r"Specified Charge Limit \(101%\) is not in \[0-100\]\%"):
+        commands.set_battery_charge_limit(101)
+    with pytest.raises(ValueError, match=r"Specified Discharge Limit \(101%\) is not in \[0-100\]\%"):
+        commands.set_battery_discharge_limit(101)
 
 
 async def test_set_system_time():
@@ -432,9 +439,14 @@ async def test_set_battery_charge_limit_ac():
     assert commands.set_battery_charge_limit_ac(50) == [
         WriteHoldingRegisterRequest(RegisterMap.BATTERY_CHARGE_LIMIT_AC, 50)
     ]
-    with pytest.raises(ValueError, match="AC Charge Limit"):
-        commands.set_battery_charge_limit_ac(0)
-    with pytest.raises(ValueError, match="AC Charge Limit"):
+    # 0 now commits (disables AC charge; was rejected pre-widen); 100 is max; 101 rejects.
+    assert commands.set_battery_charge_limit_ac(0) == [
+        WriteHoldingRegisterRequest(RegisterMap.BATTERY_CHARGE_LIMIT_AC, 0)
+    ]
+    assert commands.set_battery_charge_limit_ac(100) == [
+        WriteHoldingRegisterRequest(RegisterMap.BATTERY_CHARGE_LIMIT_AC, 100)
+    ]
+    with pytest.raises(ValueError, match=r"AC Charge Limit \(101%\) is not in \[0-100\]\%"):
         commands.set_battery_charge_limit_ac(101)
 
 
@@ -442,9 +454,14 @@ async def test_set_battery_discharge_limit_ac():
     assert commands.set_battery_discharge_limit_ac(50) == [
         WriteHoldingRegisterRequest(RegisterMap.BATTERY_DISCHARGE_LIMIT_AC, 50)
     ]
-    with pytest.raises(ValueError, match="AC Discharge Limit"):
-        commands.set_battery_discharge_limit_ac(0)
-    with pytest.raises(ValueError, match="AC Discharge Limit"):
+    # 0 now commits (disables AC discharge; was rejected pre-widen); 100 is max; 101 rejects.
+    assert commands.set_battery_discharge_limit_ac(0) == [
+        WriteHoldingRegisterRequest(RegisterMap.BATTERY_DISCHARGE_LIMIT_AC, 0)
+    ]
+    assert commands.set_battery_discharge_limit_ac(100) == [
+        WriteHoldingRegisterRequest(RegisterMap.BATTERY_DISCHARGE_LIMIT_AC, 100)
+    ]
+    with pytest.raises(ValueError, match=r"AC Discharge Limit \(101%\) is not in \[0-100\]\%"):
         commands.set_battery_discharge_limit_ac(101)
 
 

--- a/tests/debug/probe_discharge_limit_clamp.py
+++ b/tests/debug/probe_discharge_limit_clamp.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Live probe (#301): does HYBRID_GEN1 battery output exceed the 50% discharge limit when set higher?
+
+Run this *while an EV charge (or any sustained load the battery supplies) is active*,
+so the battery is discharging near its ceiling. The probe sweeps the discharge power
+limit (HR112) up through 50 -> 100 % and reports the actual battery power (IR52) at
+each step. If output rises past ~2.5 kW (the Gen1 battery subsystem's ~50%-of-rated
+ceiling) the subsystem has genuine headroom above 50; if it plateaus, the firmware
+clamps it (the widen is still correct, just inert above the real rating).
+
+Safety:
+- Touches exactly one register (BATTERY_DISCHARGE_LIMIT, HR112, WRITE_SAFE), and
+  ALWAYS restores the original value in a finally block.
+- Requires the #301 widen (set_battery_discharge_limit accepting >50); run from the
+  feat/widen-battery-power-limits branch or a release that includes it.
+- Read-only until you confirm at the prompt.
+
+    uv run python tests/debug/probe_discharge_limit_clamp.py <inverter-host>
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+
+from givenergy_modbus.client import commands
+from givenergy_modbus.client.client import Client
+from givenergy_modbus.client.commands import RegisterMap
+from givenergy_modbus.model.inverter import Model
+from givenergy_modbus.model.register import HR, IR
+from givenergy_modbus.model.register_cache import RegisterCache
+
+SWEEP = (50, 60, 70, 85, 100)  # discharge-limit % steps to walk through
+SETTLE_SECONDS = 8.0  # let the inverter apply each write and the battery ramp
+
+
+def _signed16(raw: int | None) -> int | None:
+    """Interpret a raw uint16 cache value as int16 (p_battery is signed: + = discharging)."""
+    if raw is None:
+        return None
+    return raw - 65536 if raw >= 32768 else raw
+
+
+async def _refresh(client: Client) -> RegisterCache:
+    # Patient timeouts: the inverter is contended by other TCP clients (dongle fan-out).
+    await client.refresh_plant(full_refresh=True, timeout=3.0, retries=2)
+    caps = client.plant.capabilities
+    assert caps is not None, "detect() must run before reading"
+    return client.plant.register_caches.get(caps.inverter_address, RegisterCache())
+
+
+async def _read(client: Client) -> tuple[int | None, int | None]:
+    """Return (discharge_limit HR112, p_battery W IR52)."""
+    cache = await _refresh(client)
+    return cache.get(HR(RegisterMap.BATTERY_DISCHARGE_LIMIT)), _signed16(cache.get(IR(52)))
+
+
+async def _set_limit(client: Client, val: int) -> None:
+    await client.one_shot_command(commands.set_battery_discharge_limit(val), timeout=3.0, retries=2)
+
+
+async def main(host: str) -> None:
+    client = Client(host, 8899)
+    await client.connect()
+    try:
+        caps = await client.detect()
+        print(f"detected: {caps.device_type.name}, inverter_address=0x{caps.inverter_address:02x}")
+        if caps.device_type != Model.HYBRID_GEN1:
+            print(f"WARNING: expected HYBRID_GEN1, got {caps.device_type.name} — aborting to be safe.")
+            return
+
+        original, p0 = await _read(client)
+        print(f"baseline: discharge_limit={original}%  p_battery={p0} W (+ = discharging)")
+        if not isinstance(original, int):
+            print("could not read a sane baseline discharge limit — aborting before any write.")
+            return
+
+        print(
+            "\nStart/confirm an EV charge (or another sustained load the battery supplies) so the\n"
+            "battery is discharging near its limit, THEN proceed. The probe sweeps the discharge\n"
+            "limit and logs battery power at each step, restoring the original limit afterwards."
+        )
+        answer = await asyncio.to_thread(input, f"Proceed sweeping discharge limit {SWEEP} %? [y/N] ")
+        if answer.strip().lower() != "y":
+            print("aborted — no writes were sent.")
+            return
+
+        results: list[tuple[int, int | None]] = []
+        try:
+            for limit in SWEEP:
+                print(f"  set discharge_limit={limit}% ...")
+                await _set_limit(client, limit)
+                await asyncio.sleep(SETTLE_SECONDS)
+                _lim, p = await _read(client)
+                print(f"    -> p_battery={p} W")
+                results.append((limit, p))
+        finally:
+            print(f"restoring discharge_limit={original}% ...")
+            try:
+                await _set_limit(client, original)
+            except Exception as e:  # noqa: BLE001 — best-effort cleanup, report and continue
+                print(f"  failed to restore: {e} — please set it back to {original}% manually")
+
+        print("\nlimit% -> battery power (W):")
+        for limit, p in results:
+            print(f"  {limit:3d}%  {p} W")
+        print(
+            "\nReading: if power rises past ~2500 W as the limit goes above 50, the battery subsystem\n"
+            "has headroom above 50%; if it plateaus, the firmware clamps at the rated max."
+        )
+    finally:
+        await client.close()
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("usage: probe_discharge_limit_clamp.py <inverter-host>", file=sys.stderr)
+        raise SystemExit(2)
+    asyncio.run(main(sys.argv[1]))


### PR DESCRIPTION
Reported via givenergy-hass (Nick, EMS tester): `set_battery_charge_limit` / `set_battery_discharge_limit` (HR111/112) reject >50%, while the GivEnergy app exposes "Battery Charge/Discharge Power" as 0–100%.

## Investigation — is the 50% real?

It looked like it might be a genuine hardware limit, not conservatism:
- **GivTCP** (downstream fork, large install base) caps HR111/112 at `[0,50]` with the comment *"50% (2.6 kW) is the maximum for most inverters"*, and routes AC-coupled/3-phase to HR313/314 `[1,100]`.
- **All four capture fixtures** read the DC limit (HR111/112) at exactly 50; my hybrid's battery is rated 2600 W of a 5000 W inverter ≈ 52% — so on a DC-coupled hybrid the battery subsystem is ~half the inverter rating.

## What changed it

I tested on my own Gen1 hybrid: the GivEnergy app wrote **62% to HR111** and **59% to HR112**, both accepted. So the register tolerates >50 — GivTCP's 50 is a software clamp to the *effective* max, and it's model-specific (a hard `[0,50]` would wrongly reject valid higher values on a hybrid with a larger battery subsystem).

These registers are a percentage-of-rated **ceiling**, not a current command — the BMS/firmware clamp to the battery's actual rating — so a too-high value is clamped (ineffective), not unsafe. Register-safety reviewed: the library only ever writes the percentage; nothing downstream turns it into a current/power command; gating and encoding are unchanged.

## Change

Widen all four setters to `[0,100]`:
- HR111/112 (DC): `[0,50]` → `[0,100]`
- HR313/314 (AC): `[1,100]` → `[0,100]` (0 = disable AC charge/discharge, matching the DC pair and GivTCP's own model `valid=(0,100)`)

A thorough docstring records the provenance so the bound isn't re-capped at 50.

## Tests

Updated `tests/client/test_commands.py`: 51/100 now commit on the DC pair, 0/100 on the AC pair, 101 is the new rejection. Full suite + tox (py311–py314) green.

## Pending / notes (not blocking)

- A physical clamp test on my hybrid (set discharge 50%, start an EV charge, bump past 50%, watch whether output rises past ~2.5 kW or clamps) — characterises whether >50% does anything on this unit; result folds back into the tracking issue.
- Pre-existing #75 (three-phase HR313/314 → HR1110/1108 read remap) is untouched.

Durable tracking issue to follow (hass asked us to capture this on the modbus side).