### PR TITLE
docs(battery): soften ExportPriority mapping claim (#303)

### DIFF
--- a/givenergy_modbus/model/battery.py
+++ b/givenergy_modbus/model/battery.py
@@ -132,9 +132,11 @@ class State(IntEnum):
 class ExportPriority(IntEnum):
     """Dispatch priority for surplus power on AC-coupled inverters.
 
-    Confirmed writable on Model.AC via direct portal observations (hass#52):
-    HR(311) was written with values 0/1/2 while the portal's "Export Priority"
-    control was cycled through its three options.
+    The *register* HR(311) was identified as Export Priority via hass#52 wire
+    captures (portal writes of values 0/1/2 round-tripped to HR(311)), but the
+    integer↔label mapping below is provisional and has not been ground-truthed
+    against the portal. A field reporter has flagged a likely 2↔0 swap between
+    ``BATTERY_FIRST`` and ``LOAD_FIRST``; see #303 for the verification task.
     """
 
     BATTERY_FIRST = 0


### PR DESCRIPTION
## Summary
The `ExportPriority` docstring claimed the `BATTERY_FIRST=0 / GRID_FIRST=1 / LOAD_FIRST=2` mapping was confirmed via hass#52 portal observations, but on a second look only the *register* HR(311) was ground-truthed there — the integer↔label mapping was assumed. A field reporter (via the hass agent) has flagged a likely 2↔0 swap between `BATTERY_FIRST` and `LOAD_FIRST`.

This PR is the docstring-only follow-up: marks the mapping as provisional and points at #303 for the verification task. No behavioural change; the enum values are unchanged until ground truth (raw HR(311) captures at each of the three portal options) lands.

## Test plan
- [x] `uv run tox` — py311/py312/py313/py314 + format/lint/build all green
- [x] `uv run pytest -k ExportPriority` — 3 tests pass
- [ ] Wait for tester captures via hass; correct the mapping and add a raw-int decode regression test in a follow-up PR.

Refs #303.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the guidance for battery export priority values, including a provisional note about how some settings may be mapped.
  * Added a caution that two priority labels may be swapped in certain cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->