### PR TITLE
fix(commands): restore the 1-floor on AC battery-limit setters (HR313/314)

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -266,7 +266,7 @@ An unmarked row means the method is available on both inverter types. On `ThreeP
 | `disable_charge_target()` | Remove SOC limit, target 100% | |
 | `set_enable_charge(enabled)` | Enable or disable charging | |
 | `set_battery_charge_limit(val)` | Charge power limit (0–100%; firmware expected to clamp per-model) | |
-| `set_battery_charge_limit_ac(val)` | AC charge power limit (0–100%) | ⛔ commands-only |
+| `set_battery_charge_limit_ac(val)` | AC charge power limit (1–100%; 0 errors on hardware) | ⛔ commands-only |
 | `set_shallow_charge(val)` | Set shallow charge threshold (deprecated — use `set_battery_soc_reserve`) | ⛔ commands-only |
 
 ### Discharging
@@ -275,7 +275,7 @@ An unmarked row means the method is available on both inverter types. On `ThreeP
 |---|---|---|
 | `set_enable_discharge(enabled)` | Enable or disable discharging | |
 | `set_battery_discharge_limit(val)` | Discharge power limit (0–100%; firmware expected to clamp per-model) | |
-| `set_battery_discharge_limit_ac(val)` | AC discharge power limit (0–100%) | ⛔ commands-only |
+| `set_battery_discharge_limit_ac(val)` | AC discharge power limit (1–100%; 0 errors on hardware) | ⛔ commands-only |
 | `set_battery_soc_reserve(val)` | Minimum SOC to maintain (4–100%) | |
 | `set_battery_power_reserve(val)` | Battery power reserve (4–100%) | |
 

--- a/givenergy_modbus/client/commands.py
+++ b/givenergy_modbus/client/commands.py
@@ -407,28 +407,32 @@ def set_enable_eps(enabled: bool) -> list[TransparentRequest]:
 
 
 def set_battery_charge_limit_ac(val: int) -> list[TransparentRequest]:
-    """Set the battery AC charge power limit as a percentage (0-100).
+    """Set the battery AC charge power limit as a percentage (1-100).
 
-    The GE app exposes 0-100 for this control; 0 is expected to disable AC charge but is not yet
-    field-confirmed on AC hardware. (The v4.1.6 register doc lists 1-100, but it is hybrid-scoped and
-    HR313/314 are AC-coupled registers absent on hybrids, so its bound is of questionable authority.)
+    The floor is 1: writing 0 to HR313/314 ERRORs on an AC inverter (hardware-confirmed via a
+    single-phase AC tester — WriteHoldingRegisterResponse(ERROR) then a write timeout), so the 2.5.8
+    "0 disables" widening was wrong and is reverted here. The 0-floor is DC-specific — the DC pair
+    :func:`set_battery_charge_limit` legitimately accepts 0; writing 1 here drives the battery to
+    near-zero.
     """
     val = _as_int(val, "val")
-    if not 0 <= val <= 100:
-        raise ValueError(f"Specified AC Charge Limit ({val}%) is not in [0-100]%")
+    if not 1 <= val <= 100:
+        raise ValueError(f"Specified AC Charge Limit ({val}%) is not in [1-100]%")
     return [WriteHoldingRegisterRequest(RegisterMap.BATTERY_CHARGE_LIMIT_AC, val)]
 
 
 def set_battery_discharge_limit_ac(val: int) -> list[TransparentRequest]:
-    """Set the battery AC discharge power limit as a percentage (0-100).
+    """Set the battery AC discharge power limit as a percentage (1-100).
 
-    The GE app exposes 0-100 for this control; 0 is expected to disable AC discharge but is not yet
-    field-confirmed on AC hardware. (The v4.1.6 register doc lists 1-100, but it is hybrid-scoped and
-    HR313/314 are AC-coupled registers absent on hybrids, so its bound is of questionable authority.)
+    The floor is 1: writing 0 to HR313/314 ERRORs on an AC inverter (hardware-confirmed via a
+    single-phase AC tester — WriteHoldingRegisterResponse(ERROR) then a write timeout), so the 2.5.8
+    "0 disables" widening was wrong and is reverted here. The 0-floor is DC-specific — the DC pair
+    :func:`set_battery_discharge_limit` legitimately accepts 0; writing 1 here drives the battery to
+    near-zero.
     """
     val = _as_int(val, "val")
-    if not 0 <= val <= 100:
-        raise ValueError(f"Specified AC Discharge Limit ({val}%) is not in [0-100]%")
+    if not 1 <= val <= 100:
+        raise ValueError(f"Specified AC Discharge Limit ({val}%) is not in [1-100]%")
     return [WriteHoldingRegisterRequest(RegisterMap.BATTERY_DISCHARGE_LIMIT_AC, val)]
 
 

--- a/givenergy_modbus/client/commands.py
+++ b/givenergy_modbus/client/commands.py
@@ -409,11 +409,12 @@ def set_enable_eps(enabled: bool) -> list[TransparentRequest]:
 def set_battery_charge_limit_ac(val: int) -> list[TransparentRequest]:
     """Set the battery AC charge power limit as a percentage (1-100).
 
-    The floor is 1: writing 0 to HR313/314 ERRORs on an AC inverter (hardware-confirmed via a
-    single-phase AC tester — WriteHoldingRegisterResponse(ERROR) then a write timeout), so the 2.5.8
-    "0 disables" widening was wrong and is reverted here. The 0-floor is DC-specific — the DC pair
-    :func:`set_battery_charge_limit` legitimately accepts 0; writing 1 here drives the battery to
-    near-zero.
+    The GE app exposes 0-100 for this control, but writing 0 to HR313/314 does NOT work in practice on
+    (at least) the AC models tested — it ERRORs (hardware-confirmed via a single-phase AC tester:
+    WriteHoldingRegisterResponse(ERROR) then a write timeout). So the floor is 1 and a 0 raises a clean
+    ValueError rather than a doomed write; the 2.5.8 "0 disables" widening trusted the app range and was
+    wrong. The 0-floor is AC-specific — the DC pair :func:`set_battery_charge_limit` legitimately
+    accepts 0; writing 1 here drives the battery to near-zero.
     """
     val = _as_int(val, "val")
     if not 1 <= val <= 100:
@@ -424,11 +425,12 @@ def set_battery_charge_limit_ac(val: int) -> list[TransparentRequest]:
 def set_battery_discharge_limit_ac(val: int) -> list[TransparentRequest]:
     """Set the battery AC discharge power limit as a percentage (1-100).
 
-    The floor is 1: writing 0 to HR313/314 ERRORs on an AC inverter (hardware-confirmed via a
-    single-phase AC tester — WriteHoldingRegisterResponse(ERROR) then a write timeout), so the 2.5.8
-    "0 disables" widening was wrong and is reverted here. The 0-floor is DC-specific — the DC pair
-    :func:`set_battery_discharge_limit` legitimately accepts 0; writing 1 here drives the battery to
-    near-zero.
+    The GE app exposes 0-100 for this control, but writing 0 to HR313/314 does NOT work in practice on
+    (at least) the AC models tested — it ERRORs (hardware-confirmed via a single-phase AC tester:
+    WriteHoldingRegisterResponse(ERROR) then a write timeout). So the floor is 1 and a 0 raises a clean
+    ValueError rather than a doomed write; the 2.5.8 "0 disables" widening trusted the app range and was
+    wrong. The 0-floor is AC-specific — the DC pair :func:`set_battery_discharge_limit` legitimately
+    accepts 0; writing 1 here drives the battery to near-zero.
     """
     val = _as_int(val, "val")
     if not 1 <= val <= 100:

--- a/tests/client/test_commands.py
+++ b/tests/client/test_commands.py
@@ -436,32 +436,32 @@ async def test_set_enable_eps():
 
 
 async def test_set_battery_charge_limit_ac():
-    assert commands.set_battery_charge_limit_ac(50) == [
-        WriteHoldingRegisterRequest(RegisterMap.BATTERY_CHARGE_LIMIT_AC, 50)
-    ]
-    # 0 now commits (disables AC charge; was rejected pre-widen); 100 is max; 101 rejects.
-    assert commands.set_battery_charge_limit_ac(0) == [
-        WriteHoldingRegisterRequest(RegisterMap.BATTERY_CHARGE_LIMIT_AC, 0)
+    assert commands.set_battery_charge_limit_ac(1) == [
+        WriteHoldingRegisterRequest(RegisterMap.BATTERY_CHARGE_LIMIT_AC, 1)
     ]
     assert commands.set_battery_charge_limit_ac(100) == [
         WriteHoldingRegisterRequest(RegisterMap.BATTERY_CHARGE_LIMIT_AC, 100)
     ]
-    with pytest.raises(ValueError, match=r"AC Charge Limit \(101%\) is not in \[0-100\]\%"):
+    # 0 ERRORs on AC hardware (field-confirmed, #302) — reject client-side rather than let a hardware
+    # ERROR + write timeout happen. The 0-floor is DC-specific (the DC pair legitimately accepts 0).
+    with pytest.raises(ValueError, match=r"AC Charge Limit \(0%\) is not in \[1-100\]\%"):
+        commands.set_battery_charge_limit_ac(0)
+    with pytest.raises(ValueError, match=r"AC Charge Limit \(101%\) is not in \[1-100\]\%"):
         commands.set_battery_charge_limit_ac(101)
 
 
 async def test_set_battery_discharge_limit_ac():
-    assert commands.set_battery_discharge_limit_ac(50) == [
-        WriteHoldingRegisterRequest(RegisterMap.BATTERY_DISCHARGE_LIMIT_AC, 50)
-    ]
-    # 0 now commits (disables AC discharge; was rejected pre-widen); 100 is max; 101 rejects.
-    assert commands.set_battery_discharge_limit_ac(0) == [
-        WriteHoldingRegisterRequest(RegisterMap.BATTERY_DISCHARGE_LIMIT_AC, 0)
+    assert commands.set_battery_discharge_limit_ac(1) == [
+        WriteHoldingRegisterRequest(RegisterMap.BATTERY_DISCHARGE_LIMIT_AC, 1)
     ]
     assert commands.set_battery_discharge_limit_ac(100) == [
         WriteHoldingRegisterRequest(RegisterMap.BATTERY_DISCHARGE_LIMIT_AC, 100)
     ]
-    with pytest.raises(ValueError, match=r"AC Discharge Limit \(101%\) is not in \[0-100\]\%"):
+    # 0 ERRORs on AC hardware (field-confirmed, #302) — reject client-side rather than let a hardware
+    # ERROR + write timeout happen. The 0-floor is DC-specific (the DC pair legitimately accepts 0).
+    with pytest.raises(ValueError, match=r"AC Discharge Limit \(0%\) is not in \[1-100\]\%"):
+        commands.set_battery_discharge_limit_ac(0)
+    with pytest.raises(ValueError, match=r"AC Discharge Limit \(101%\) is not in \[1-100\]\%"):
         commands.set_battery_discharge_limit_ac(101)
 
 


### PR DESCRIPTION
Field feedback closing the AC arm of #302.

2.5.8 (#301) widened the AC setters `set_battery_charge_limit_ac` / `set_battery_discharge_limit_ac` (HR313/314) to `[0,100]`, dropping the `1`-floor on a "0 disables AC charge/discharge" assumption that wasn't field-confirmed (Codex flagged exactly this at the time).

**An AC-coupled tester has now confirmed** (via givenergy-hass): writing **0** to HR313/314 **ERRORs** on the hardware — `WriteHoldingRegisterResponse(ERROR 313 -> 0)` then a write timeout. Writing **1** works (drives the battery to near-zero). So `0` is invalid on the AC pair.

## Change

- Restore `1 <= val <= 100` on the two **AC** setters → a `0` now raises a clean `ValueError` instead of dispatching a doomed hardware write.
- The **DC** pair (`set_battery_charge_limit` / `set_battery_discharge_limit`, HR111/112) is **unchanged** at `[0,100]` — `0` is legitimately accepted there (separately confirmed on a DC inverter). The asymmetry is now documented in the docstrings.

## Tests

AC tests revert to `0` raising `[1-100]`; DC tests unchanged. Full suite + tox (py311–py314) green. Register-safety reviewed (strictly safer — a bound tightening that turns a known-erroring write into a clean client-side ValueError).

Closes the AC arm of #302 (the DC clamp was already field-confirmed there).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened validation for AC battery charge and discharge limit settings so only values from 1–100% are accepted.
  * Updated error messages to clearly reflect the supported range and avoid invalid hardware writes.

* **Documentation**
  * Corrected the command reference for AC charge/discharge limits to show the 1–100% range and revised hardware behaviour notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->