### PR TITLE
fix(model): correct ExportPriority HR311 mapping (#303); note HR50 EMS no-op (#304)

### DIFF
--- a/givenergy_modbus/client/commands.py
+++ b/givenergy_modbus/client/commands.py
@@ -393,7 +393,7 @@ def set_export_priority(priority: ExportPriority) -> list[TransparentRequest]:
     Determines where surplus energy goes: battery first, grid first, or load first.
     Confirmed writable on Model.AC via direct portal observations (hass#52).
     """
-    # bool subclasses int, so ExportPriority(True) would resolve to GRID_FIRST and pass as an
+    # bool subclasses int, so ExportPriority(True) would resolve to BATTERY_FIRST (1) and pass as an
     # IntEnum — silently selecting a write mode. Reject it before the enum conversion (audit L1).
     if isinstance(priority, bool):
         raise ValueError(f"Export priority must be an ExportPriority, not bool (got {priority!r})")

--- a/givenergy_modbus/client/commands.py
+++ b/givenergy_modbus/client/commands.py
@@ -369,7 +369,13 @@ def set_battery_power_reserve(val: int) -> list[TransparentRequest]:
 
 
 def set_active_power_rate(target: int) -> list[TransparentRequest]:
-    """Set the inverter's active power output as a percentage of its rated capacity."""
+    """Set the inverter's active power output as a percentage of its rated capacity.
+
+    On an EMS-managed inverter this per-inverter write (HR50) is a silent no-op: it is accepted at
+    the modbus layer (no error, unlike the AC-limit registers) but the EMS controller re-asserts its
+    own value, so the change does not stick. There is no EMS-controller active-power-rate command to
+    target instead (the EMS register block has none). See #304.
+    """
     target = _as_int(target, "target")
     if not 0 <= target <= 100:
         raise ValueError(f"Active power rate ({target}) must be in [0-100]%")

--- a/givenergy_modbus/model/battery.py
+++ b/givenergy_modbus/model/battery.py
@@ -132,16 +132,16 @@ class State(IntEnum):
 class ExportPriority(IntEnum):
     """Dispatch priority for surplus power on AC-coupled inverters.
 
-    The *register* HR(311) was identified as Export Priority via hass#52 wire
-    captures (portal writes of values 0/1/2 round-tripped to HR(311)), but the
-    integer↔label mapping below is provisional and has not been ground-truthed
-    against the portal. A field reporter has flagged a likely 2↔0 swap between
-    ``BATTERY_FIRST`` and ``LOAD_FIRST``; see #303 for the verification task.
+    HR(311) was identified as Export Priority via hass#52 wire captures. The integer↔label mapping
+    is tester-confirmed (hass#218, #303): cycling the GE portal and reading the round-tripped raw
+    value gave ``0 = Load First``, ``1 = Battery First``, ``2 = Grid First``. (The earlier
+    provisional mapping had all three rotated — it guessed a 2↔0 swap, but the field data showed a
+    full rotation.)
     """
 
-    BATTERY_FIRST = 0
-    GRID_FIRST = 1
-    LOAD_FIRST = 2
+    LOAD_FIRST = 0
+    BATTERY_FIRST = 1
+    GRID_FIRST = 2
 
 
 class BatteryPauseMode(IntEnum):

--- a/tests/client/test_commands.py
+++ b/tests/client/test_commands.py
@@ -418,14 +418,26 @@ async def test_set_export_priority():
     assert commands.set_export_priority(ExportPriority.GRID_FIRST) == [
         WriteHoldingRegisterRequest(RegisterMap.EXPORT_PRIORITY, ExportPriority.GRID_FIRST)
     ]
-    # Raw int that maps to a valid member is coerced.
+    # Raw int that maps to a valid member is coerced (2 = Grid First, tester-confirmed #303).
     assert commands.set_export_priority(2) == [
-        WriteHoldingRegisterRequest(RegisterMap.EXPORT_PRIORITY, ExportPriority.LOAD_FIRST)
+        WriteHoldingRegisterRequest(RegisterMap.EXPORT_PRIORITY, ExportPriority.GRID_FIRST)
     ]
     with pytest.raises(ValueError, match="Invalid export priority"):
         commands.set_export_priority(99)
     # HR311 must be in the lower-level PDU allowlist, or encode() raises InvalidPduState.
     commands.set_export_priority(ExportPriority.BATTERY_FIRST)[0].encode()
+
+
+def test_export_priority_raw_int_mapping():
+    """Pin the tester-confirmed HR(311) raw->label mapping (hass#218, #303).
+
+    The enum value IS the raw register value (set_export_priority writes it directly; decode reads
+    ExportPriority(raw)), so a rotation here silently mislabels every consumer. 0/1/2 must stay
+    Load/Battery/Grid First.
+    """
+    assert ExportPriority.LOAD_FIRST == 0
+    assert ExportPriority.BATTERY_FIRST == 1
+    assert ExportPriority.GRID_FIRST == 2
 
 
 async def test_set_enable_eps():
@@ -904,7 +916,7 @@ def test_numeric_arguments_reject_non_integral_and_str():
 def test_set_export_priority_rejects_bool():
     """set_export_priority rejects bool before the enum conversion (audit L1 follow-up).
 
-    ExportPriority(True) resolves to GRID_FIRST (1) and would pass as an IntEnum — silently
+    ExportPriority(True) resolves to BATTERY_FIRST (1) and would pass as an IntEnum — silently
     selecting a write mode. A bool here is a caller error and must fail loudly. Valid enum
     members (and their int values) still work.
     """


### PR DESCRIPTION
Two field-feedback items from givenergy-hass (single-phase AC EMS tester) — closing #303 and answering #304.

## #303 — ExportPriority HR(311) mapping (tester-confirmed)

The tester cycled the GE portal's Export Priority and read back the integration's decoded label:
- Portal "Load First" → "Battery First"
- Portal "Battery First" → "Grid First"
- Portal "Grid First" → "Load First"

Back-solving through the provisional enum gives the true raw→label mapping: **0 = Load First, 1 = Battery First, 2 = Grid First**. The earlier guess (a 2↔0 swap) was incomplete — it's a full rotation.

`set_export_priority` writes the enum's int value directly to HR311 and decode reads `ExportPriority(raw)`, so the enum value *is* the raw register value — correcting it fixes **both** the decoded labels and the writes at once. Added a regression test pinning the raw-int mapping. Register-safety reviewed (mode selector; register + value-range unchanged; net safety improvement).

Closes #303.

## #304 — HR(50) active_power_rate is a no-op under EMS (answer + doc)

A tester wrote HR50 on an EMS-managed inverter (100→5→100) with **no write error** (unlike the AC-limit registers, which error loudly) — but the value didn't stick: the EMS controller re-asserts its own. The EMS register block exposes no active-power-rate command to target instead (`_EmsCommands` / `ems.py` have slots, target SOCs, and `export_power_limit` HR2071, but nothing for active power rate).

Documented the EMS no-op on `set_active_power_rate` so consumers don't chase a write that can't stick. This is the answer to #304 — an EMS hardware/controller limitation, not a library bug (hass will document it consumer-side too). #304 can close as "documented limitation".

## Tests

Full suite (1162) + tox (py311–py314) green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the displayed and accepted export-priority values so device settings now map consistently to Load First, Battery First, and Grid First.
  * Improved handling of active power rate updates on EMS-managed inverters by clarifying that changes may not persist when the controller re-applies its own setting.

* **Documentation**
  * Updated guidance to reflect the verified behaviour and value order for export-priority settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->