### PR TITLE
fix(plant): gate the temp-zero corruption cohort on the stale-bypass + short-read paths (#294)

### DIFF
--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -866,18 +866,13 @@ class Plant(GivEnergyBaseModel):
         a gap of more than ``STALE_BYPASS_SECONDS`` since the last *observed* full bank — a
         genuine polling outage, not a rejection streak — is too stale for per-poll thresholds
         to apply (legitimate multi-field drift over the gap would trip them) — all three fall
-        through as a no-op commit so the cache self-heals without manual recovery.
+        through as a no-op commit so the cache self-heals without manual recovery. The one
+        exception is the temp-zero corruption cohort, which is held (never adopted) on every
+        path, not just cold start (#294).
         """
-        if register_count < 60:
-            return True
         now_ts = now if now is not None else datetime.now(UTC)
         if now_ts.tzinfo is None:
             now_ts = now_ts.replace(tzinfo=UTC)
-        # Record this observation up front — a rejected bank is still an observation, so the gap
-        # computed below measures time since we last *saw* a full bank, not since we last accepted
-        # one. This is what separates a real outage from a sustained corruption run (see below).
-        prev_seen = self._splice_last_seen.get(device_address)
-        self._splice_last_seen[device_address] = now_ts
 
         cache = self.register_caches[device_address]
         prev = [0] * 60
@@ -894,6 +889,29 @@ class Plant(GivEnergyBaseModel):
                 incoming_present.add(i)
                 if cached is not None:
                     present.add(i)
+
+        # Short read: a partial bank can't be physics-classified, so it commits directly — EXCEPT the
+        # temp-zero corruption cohort (>=2 cell-mass temps at 0), which would seed an unrecoverable
+        # poisoned baseline (#294 — the same hole #289 closed for cold start). A short read is not a
+        # full observation, so this returns before the _splice_last_seen update below (it must not
+        # advance the stale-bypass clock).
+        if register_count < 60:
+            if is_corruption_cohort(new, incoming_present):
+                self._bump(self.splice_reject_count, device_address)
+                _logger.warning(
+                    "Rejected short battery bank for device 0x%02x — temp-zero corruption cohort; "
+                    "keeping last-good. Please report if seen.",
+                    device_address,
+                )
+                return False
+            return True
+
+        # Record this observation up front — a rejected bank is still an observation, so the gap
+        # computed below measures time since we last *saw* a full bank, not since we last accepted
+        # one. This is what separates a real outage from a sustained corruption run (see below).
+        prev_seen = self._splice_last_seen.get(device_address)
+        self._splice_last_seen[device_address] = now_ts
+
         if not present:
             # Cold start: no last-good to compare against. Don't adopt the first frame blindly — a
             # transient splice would poison the baseline (#289). Hold it until a second poll
@@ -911,6 +929,19 @@ class Plant(GivEnergyBaseModel):
         # keeps arriving and being rejected each poll, ageing the last *commit* past the window —
         # but prev_seen stays ~one poll old, so this does NOT fire and the corruption stays rejected.
         if prev_seen is not None and (now_ts - prev_seen).total_seconds() > STALE_BYPASS_SECONDS:
+            if is_corruption_cohort(new, incoming_present):
+                # Don't adopt the corruption cohort even post-gap (#294). Hold last-good and keep the
+                # bypass armed for the next healthy frame: restore the observation clock to prev_seen
+                # so the gap is still seen next poll — otherwise a healthy recovery frame would be
+                # rejected against the stale baseline, re-pinning the very thing the bypass avoids.
+                self._splice_last_seen[device_address] = prev_seen
+                self._bump(self.splice_reject_count, device_address)
+                _logger.warning(
+                    "Battery bank for device 0x%02x: stale-baseline bypass blocked — temp-zero "
+                    "corruption cohort post-gap; holding last-good for a healthy read. Please report if seen.",
+                    device_address,
+                )
+                return False
             self._splice_escrow.pop(device_address, None)
             self._splice_immut_streak.pop(device_address, None)
             _logger.info(

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -3003,6 +3003,27 @@ def test_splice_short_read_skips_guard(plant: Plant, caplog):
     assert plant.register_caches[_BATT][IR(76)] == 0  # committed
 
 
+def test_splice_short_read_refuses_temp_zero_cohort(plant: Plant, caplog):
+    """A short read carrying the temp-zero cohort (>=2 cell-mass temps at 0) is held, not committed (#294).
+
+    The short-read fast-path commits a partial bank without a physics comparison, so a spliced
+    short read that zeroes >=2 temps would otherwise seed an unrecoverable poisoned baseline. The
+    cohort is refused (held last-good); a lone temp-zero (<2) still commits as before.
+    """
+    import logging
+
+    _establish_baseline(plant, device_address=_BATT, received_at=_T0)
+    with caplog.at_level(logging.WARNING, logger="givenergy_modbus.model.plant"):
+        _feed_bank(plant, {76: 0, 77: 0}, device_address=_BATT, count=20, received_at=_T0 + timedelta(seconds=30))
+    assert plant.register_caches[_BATT][IR(76)] == 250  # held — baseline temp, not the zeroed cohort
+    assert plant.splice_reject_count == {_BATT: 1}
+    assert [r for r in caplog.records if "corruption cohort" in r.message and "0x33" in r.message]
+
+    # A lone temp-zero is not the cohort — short read still commits (recoverable single trip).
+    _feed_bank(plant, {76: 0}, device_address=_BATT, count=1, received_at=_T0 + timedelta(seconds=60))
+    assert plant.register_caches[_BATT][IR(76)] == 0
+
+
 def test_splice_non_battery_device_skips_guard(plant: Plant, caplog):
     """On a bare Plant, 0x32 → inverter getter; the splice guard is not applied there."""
     import logging
@@ -3069,6 +3090,30 @@ def test_splice_stale_baseline_bypass(plant: Plant, caplog):
     assert len(infos) == 1 and infos[0].levelno == logging.INFO
     warns = [r for r in caplog.records if "Rejected battery bank" in r.message]
     assert not warns
+
+
+def test_splice_stale_bypass_refuses_temp_zero_cohort(plant: Plant, caplog):
+    """The stale-baseline bypass must not adopt the temp-zero corruption cohort post-gap (#294).
+
+    A gap > STALE_BYPASS_SECONDS normally adopts the next bank unconditionally, but the temp-zero
+    cohort would seed an unrecoverable poisoned baseline. It's held instead; crucially the bypass
+    stays armed (the observation clock is not consumed) so the next healthy frame still recovers.
+    """
+    import logging
+
+    _establish_baseline(plant, device_address=_BATT, received_at=_T0)
+    cohort = _coherent_battery_bank({76: 0, 77: 0, 78: 0, 79: 0})  # temp-zero cohort
+    with caplog.at_level(logging.WARNING, logger="givenergy_modbus.model.plant"):
+        _feed_bank(plant, cohort, device_address=_BATT, received_at=_T0 + timedelta(seconds=400))
+    assert plant.register_caches[_BATT][IR(76)] == 250  # held — not adopted
+    assert plant.splice_reject_count == {_BATT: 1}
+    assert [r for r in caplog.records if "corruption cohort post-gap" in r.message and "0x33" in r.message]
+
+    # Bypass stayed armed: a healthy frame one poll later still sees the gap and adopts.
+    healthy = _coherent_battery_bank({60: 3400})
+    _feed_bank(plant, healthy, device_address=_BATT, received_at=_T0 + timedelta(seconds=430))
+    assert plant.register_caches[_BATT][IR(60)] == 3400  # recovered via bypass
+    assert plant.register_caches[_BATT][IR(76)] == 250
 
 
 def test_splice_sustained_corruption_never_bypassed(plant: Plant, caplog):


### PR DESCRIPTION
Closes #294.

#289 added `is_corruption_cohort` — refuse to *baseline* a frame with ≥2 cell-mass temps (IR76-79) at zero (the corpus's only corruption-cohort signature). Adopting it is unrecoverable: every later healthy frame then trips ≥2 physics vs the poisoned baseline and is hard-rejected forever (the #286 heal only recovers scalar-immutables, not physics).

But that gate was wired into only one of the three `_splice_guard` paths that adopt a bank **without** a physics comparison — cold-start. The **stale-bypass** (gap > `STALE_BYPASS_SECONDS`) and **short-read** (`register_count < 60`) paths still adopted a cohort blindly. Field-observed live on a Gen1 (#294): a temp-zero baseline rejecting the real ~30 °C temps.

## Change (`_splice_guard` only)

- **Short-read**: build the incoming frame before the early return, then hold instead of commit if it's the cohort. A lone temp-zero (`<2`) still commits.
- **Stale-bypass**: hold instead of adopt if the post-gap frame is the cohort. **Key subtlety:** a refused cohort restores the observation clock to `prev_seen` so the bypass stays armed — otherwise the cohort would consume the bypass and a healthy recovery frame would be rejected against the stale baseline, re-pinning the exact failure the bypass exists to prevent.

Cold-start was already covered, so the cohort is now held on **every** adopt-without-comparison path.

## Safety

Strictly safer — it only refuses *more* corruption; `classify_transition` (the corpus 1086/1/16 separation) is untouched, confirmed via `tests/debug/physics_delta_classify.py`. Read/commit guard, not a write path.

## Tests

- `test_splice_short_read_refuses_temp_zero_cohort` — ≥2-temp-zero short read held; lone temp-zero commits.
- `test_splice_stale_bypass_refuses_temp_zero_cohort` — post-gap cohort held, then a healthy frame recovers via the still-armed bypass.
- Existing stale-bypass / short-read / sustained-corruption tests unaffected. Full suite (1164) + tox (py311–py314) green.

## Follow-on (separate)

#299 — recovery for a sustained *legitimate* ≥2-physics step (smooth-streak plausibility heal-adopt). This PR's comprehensive cohort gate is its prerequisite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of short battery data reads so invalid temperature patterns are now held back instead of being accepted.
  * Refined stale-data recovery so suspicious readings are no longer adopted after a long gap, helping preserve the last known good state.
  * Prevented recovery logic from being advanced by short reads, making the guard more reliable.

* **Tests**
  * Added regression coverage for short-read rejection and stale-baseline recovery behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->