### PR TITLE
feat: add e_self_consumption_today/total computed fields

### DIFF
--- a/givenergy_modbus/model/inverter.py
+++ b/givenergy_modbus/model/inverter.py
@@ -949,6 +949,51 @@ class SinglePhaseInverter(  # type: ignore[valid-type,misc]
             return None
         return pv + grid_in - grid_out - ac_charge
 
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def e_self_consumption_today(self) -> float | None:
+        """Self-consumption energy today (kWh): PV generation used on-site (GivTCP parity).
+
+        DERIVED: PV generation today − grid export today, clamped at ≥ 0.
+
+        Two limitations to be aware of:
+        - Battery-to-grid export is counted in grid_out, so this slightly under-counts
+          true self-consumption when the battery discharges to grid. GivTCP accepts this
+          approximation; we match it here.
+        - NOT monotonically increasing: when battery exports to grid, grid_out rises
+          without pv_generation rising, causing the difference to dip. Consumers that
+          use state_class TOTAL_INCREASING (e.g. HA energy dashboard) MUST apply their
+          own monotonic clamp rather than consuming the raw value directly.
+
+        Returns None if any input is unavailable.
+        """
+        pv = self.e_pv_generation_today  # type: ignore[attr-defined]
+        grid_out = self.e_grid_out_day  # type: ignore[attr-defined]
+        if None in (pv, grid_out):
+            return None
+        return max(0.0, pv - grid_out)
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def e_self_consumption_total(self) -> float | None:
+        """Lifetime self-consumption energy (kWh): PV generation used on-site (GivTCP parity).
+
+        DERIVED: PV generation total − grid export total, clamped at ≥ 0.
+
+        Same battery-to-grid under-count and non-monotonicity caveats as
+        e_self_consumption_today: the difference of two running counters is not
+        guaranteed to increase monotonically. Consumers using state_class
+        TOTAL_INCREASING MUST apply a monotonic clamp (e.g. HA's monotonic=True
+        sensor path) rather than consuming the raw value directly.
+
+        Returns None if any input is unavailable.
+        """
+        pv = self.e_pv_generation_total  # type: ignore[attr-defined]
+        grid_out = self.e_grid_out_total  # type: ignore[attr-defined]
+        if None in (pv, grid_out):
+            return None
+        return max(0.0, pv - grid_out)
+
     # Plain @property (not @computed_field) so the deprecated alias doesn't
     # appear in model_dump() output. See #84 — renamed to work_time_total_hours
     # to put the unit at the call site.

--- a/tests/model/test_inverter.py
+++ b/tests/model/test_inverter.py
@@ -117,6 +117,8 @@ def test_inverter():
             "e_grid_in_total": None,
             "e_ac_charge_today": None,
             "e_consumption_today": None,
+            "e_self_consumption_today": None,
+            "e_self_consumption_total": None,
             "e_battery_charge_today_alt1": None,
             "e_battery_discharge_today_alt1": None,
             "countdown": None,
@@ -529,6 +531,10 @@ def test_from_registers(register_cache):
         # computed: e_pv_generation_today + e_grid_in_day − e_grid_out_day − e_ac_charge_today
         #         = 8.1 + 20.9 − 0.0 − 9.3
         "e_consumption_today": 19.7,
+        # computed: max(0, e_pv_generation_today − e_grid_out_day) = max(0, 8.1 − 0.0)
+        "e_self_consumption_today": 8.1,
+        # computed: max(0, e_pv_generation_total − e_grid_out_total) = max(0, 93.0 − 0.6)
+        "e_self_consumption_total": 92.4,
         "e_battery_charge_today_alt1": 9.0,  # IR(36)
         "e_battery_discharge_today_alt1": 8.9,  # IR(37)
         "countdown": 30,
@@ -877,6 +883,10 @@ def test_from_registers_actual_data(register_cache_inverter_daytime_discharging_
         # computed: e_pv_generation_today + e_grid_in_day − e_grid_out_day − e_ac_charge_today
         #         = 3.8 + 19.8 − 0.0 − 9.3
         "e_consumption_today": 14.3,
+        # computed: max(0, e_pv_generation_today − e_grid_out_day) = max(0, 3.8 − 0.0)
+        "e_self_consumption_today": 3.8,
+        # computed: max(0, e_pv_generation_total − e_grid_out_total) = max(0, 172.5 − 0.9)
+        "e_self_consumption_total": 171.6,
         "e_battery_charge_today_alt1": 9.1,  # IR(36)
         "e_battery_discharge_today_alt1": 3.4,  # IR(37)
         "countdown": 0,
@@ -1385,6 +1395,68 @@ def test_e_consumption_today_computed_formula():
     # Missing any input → None (no partial guess).
     partial = SinglePhaseInverter.from_register_cache(RegisterCache({IR(26): 209, IR(25): 0, IR(35): 93}))
     assert partial.e_consumption_today is None  # type: ignore[attr-defined]
+
+
+@pytest.mark.parametrize(
+    "pv_today, grid_out_day, pv_total, grid_out_total, expected_today, expected_total",
+    [
+        # Normal: PV > export → positive self-consumption
+        (8.1, 0.0, 93.0, 0.6, 8.1, 92.4),
+        # Clamp: export exceeds PV (battery-to-grid) → floor at 0
+        (1.0, 3.0, 10.0, 15.0, 0.0, 0.0),
+        # Exact zero: export equals PV
+        (5.0, 5.0, 50.0, 50.0, 0.0, 0.0),
+    ],
+)
+def test_e_self_consumption_computed_formula(
+    pv_today, grid_out_day, pv_total, grid_out_total, expected_today, expected_total
+):
+    """Self-consumption = max(0, PV − grid_export); battery-to-grid clamps at 0.
+
+    Both fields are @computed_field on SinglePhaseInverter; today uses IR(44) and
+    IR(25), total uses IR(45/46) and IR(21/22).
+    """
+    from givenergy_modbus.model.register import IR
+
+    # uint32 fields span two registers (hi word, lo word); hi=0 for small values.
+    # e_grid_out_total → IR(21)=hi, IR(22)=lo; e_pv_generation_total → IR(45)=hi, IR(46)=lo.
+    inv = SinglePhaseInverter.from_register_cache(
+        RegisterCache(
+            {
+                IR(44): round(pv_today * 10),  # e_pv_generation_today (deci)
+                IR(25): round(grid_out_day * 10),  # e_grid_out_day (deci)
+                IR(45): 0,
+                IR(46): round(pv_total * 10),  # e_pv_generation_total lo word
+                IR(21): 0,
+                IR(22): round(grid_out_total * 10),  # e_grid_out_total lo word
+            }
+        )
+    )
+    assert inv.e_self_consumption_today == pytest.approx(expected_today)  # type: ignore[attr-defined]
+    assert inv.e_self_consumption_total == pytest.approx(expected_total)  # type: ignore[attr-defined]
+    assert "e_self_consumption_today" in inv.model_dump()
+    assert "e_self_consumption_total" in inv.model_dump()
+
+
+def test_e_self_consumption_none_when_any_input_missing():
+    """Returns None when any input register is absent — no partial guessing."""
+    from givenergy_modbus.model.register import IR
+
+    # today: missing pv → None
+    inv = SinglePhaseInverter.from_register_cache(RegisterCache({IR(25): 0}))
+    assert inv.e_self_consumption_today is None  # type: ignore[attr-defined]
+
+    # today: missing grid_out → None
+    inv = SinglePhaseInverter.from_register_cache(RegisterCache({IR(44): 81}))
+    assert inv.e_self_consumption_today is None  # type: ignore[attr-defined]
+
+    # total: missing pv → None
+    inv = SinglePhaseInverter.from_register_cache(RegisterCache({IR(21): 0, IR(22): 6}))
+    assert inv.e_self_consumption_total is None  # type: ignore[attr-defined]
+
+    # total: missing grid_out → None
+    inv = SinglePhaseInverter.from_register_cache(RegisterCache({IR(45): 0, IR(46): 930}))
+    assert inv.e_self_consumption_total is None  # type: ignore[attr-defined]
 
 
 def test_three_phase_has_no_computed_consumption_and_native_ac_charge():

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -1240,6 +1240,10 @@ def test_from_actual():
         # computed: e_pv_generation_today + e_grid_in_day − e_grid_out_day − e_ac_charge_today
         #         = 38.0 + 12.3 − 2.4 − 4.3
         "e_consumption_today": 43.6,
+        # computed: max(0, e_pv_generation_today − e_grid_out_day) = max(0, 38.0 − 2.4)
+        "e_self_consumption_today": 35.6,
+        # computed: max(0, e_pv_generation_total − e_grid_out_total) = max(0, 1698.7 − 163.9)
+        "e_self_consumption_total": 1534.8,
         "e_battery_charge_today_alt1": 5.7,  # IR(36)
         "e_battery_discharge_today_alt1": 5.9,  # IR(37)
         "countdown": 0,


### PR DESCRIPTION
## Summary

- Adds `e_self_consumption_today` and `e_self_consumption_total` as `@computed_field` properties on `SinglePhaseInverter`, following the existing `e_consumption_today` pattern
- Definition (GivTCP parity): `max(0, PV generation − grid export)` — clamped at zero to handle battery-to-grid export where `grid_out` can temporarily exceed `pv_generation`
- Docstrings explicitly document both caveats: the battery-to-grid under-count approximation, and that the raw difference is NOT monotonically increasing. Consumers using `state_class: TOTAL_INCREASING` (e.g. HA energy dashboard) MUST apply a monotonic clamp (e.g. `monotonic=True` sensor path) rather than consuming the raw value directly
- Placement on `SinglePhaseInverter` only — same as `e_consumption_today`; three-phase units are not verified to have all four input registers decoded

Closes #223 (hass-side wiring tracked in givenergy-hass#223)

## Test plan

- [ ] New `test_e_self_consumption_computed_formula` — parametrized: normal positive case, clamp-to-zero (battery-to-grid), and exact-zero (export = PV)
- [ ] New `test_e_self_consumption_none_when_any_input_missing` — any absent input register → `None`
- [ ] Existing snapshot dicts (null inverter, Hybrid fixture, AC fixture, `test_from_actual`) updated with the new fields
- [ ] `uv run pytest tests/model/test_inverter.py` → 73 passed
- [ ] `uv run tox` → py311–py314 + format + lint + build all OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)