### PR TITLE
feat: add e_pv_direct_today computed field

### DIFF
--- a/givenergy_modbus/model/inverter.py
+++ b/givenergy_modbus/model/inverter.py
@@ -999,11 +999,20 @@ class SinglePhaseInverter(  # type: ignore[valid-type,misc]
     def e_pv_direct_today(self) -> float | None:
         """PV energy used directly by load today (kWh): solar bypassing battery and grid.
 
-        DERIVED: pv_generation − grid_export − battery_charge + ac_charge, clamped ≥ 0.
-        The + ac_charge term nets out grid-sourced (AC) battery charging — e_battery_charge
-        lumps PV-sourced and AC-sourced charge into one counter, so without it the figure
-        under-counts by the day's AC-charge energy on time-of-use tariffs (Octopus Go /
-        Predbat). For pure-solar systems ac_charge is 0 and the term is a no-op.
+        DERIVED: (pv_generation − grid_export) − pv_to_battery, clamped to [0, pv − grid_export],
+        where pv_to_battery = max(0, battery_charge − ac_charge).
+
+        e_battery_charge lumps PV-sourced and AC-sourced charge into one counter, so the
+        PV portion that went to the battery is battery_charge − ac_charge — subtracting it
+        leaves the PV that reached load directly. Without the ac_charge term the figure
+        would under-count by the day's AC-charge energy on time-of-use tariffs (Octopus Go
+        / Predbat); for pure-solar systems ac_charge is 0 and it's a no-op.
+
+        Both bounds matter. The lower clamp (≥ 0) handles export exceeding PV. The upper
+        clamp (≤ pv − grid_export, via flooring pv_to_battery at 0) handles AC→DC
+        conversion loss / counter skew making ac_charge momentarily exceed battery_charge:
+        without it, direct PV could exceed total on-site PV self-consumption, which is
+        nonsensical (a subset can't beat its superset) — Codex review on #313.
 
         Restricted to DC-coupled solar hybrids: on AC-coupled and All-in-One units the
         PV-generation registers (IR44/45-46) are mislabelled — they read non-zero on
@@ -1028,10 +1037,12 @@ class SinglePhaseInverter(  # type: ignore[valid-type,misc]
         ac_charge = self.e_ac_charge_today  # type: ignore[attr-defined]
         if None in (pv, grid_out, battery_charge, ac_charge):
             return None
-        # Round to the inputs' native 0.1 kWh resolution: a four-term sum of deci-scaled
-        # floats accumulates representation noise (e.g. 4.000000000000001) that 1dp removes
-        # losslessly, since the true result is always a multiple of 0.1.
-        return round(max(0.0, pv - grid_out - battery_charge + ac_charge), 1)
+        # PV that charged the battery, floored at 0: AC→DC conversion loss / counter skew
+        # can push ac_charge above battery_charge, which would otherwise make this negative
+        # and inflate direct PV beyond total on-site PV. Round to the inputs' native 0.1 kWh
+        # resolution — a deci-scaled difference accrues float noise that 1dp removes losslessly.
+        pv_to_battery = max(0.0, battery_charge - ac_charge)
+        return round(max(0.0, pv - grid_out - pv_to_battery), 1)
 
     # Plain @property (not @computed_field) so the deprecated alias doesn't
     # appear in model_dump() output. See #84 — renamed to work_time_total_hours

--- a/givenergy_modbus/model/inverter.py
+++ b/givenergy_modbus/model/inverter.py
@@ -994,6 +994,45 @@ class SinglePhaseInverter(  # type: ignore[valid-type,misc]
             return None
         return max(0.0, pv - grid_out)
 
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def e_pv_direct_today(self) -> float | None:
+        """PV energy used directly by load today (kWh): solar bypassing battery and grid.
+
+        DERIVED: pv_generation − grid_export − battery_charge + ac_charge, clamped ≥ 0.
+        The + ac_charge term nets out grid-sourced (AC) battery charging — e_battery_charge
+        lumps PV-sourced and AC-sourced charge into one counter, so without it the figure
+        under-counts by the day's AC-charge energy on time-of-use tariffs (Octopus Go /
+        Predbat). For pure-solar systems ac_charge is 0 and the term is a no-op.
+
+        Restricted to DC-coupled solar hybrids: on AC-coupled and All-in-One units the
+        PV-generation registers (IR44/45-46) are mislabelled — they read non-zero on
+        battery-only hardware (#293) — so the field returns None there rather than a
+        confident wrong value. In practice e_battery_charge_today only routes on
+        HYBRID_GEN1 today (see _BATTERY_ENERGY_SOURCE / #184), so the field is currently
+        GEN1-effective and returns None on other DC models until that map widens.
+
+        Only daily is offered: the lifetime equivalent needs e_ac_charge_total, which
+        single-phase firmware does not expose (three-phase only, IR1378/9).
+
+        NOT monotonically increasing intraday — a grid-export burst can dip it — so
+        consumers using state_class TOTAL_INCREASING MUST apply their own monotonic clamp
+        (e.g. HA's monotonic=True path). Returns None if any input is unavailable or the
+        model is ineligible.
+        """
+        if self.is_ac_coupled or self.model is Model.ALL_IN_ONE:  # type: ignore[attr-defined]
+            return None
+        pv = self.e_pv_generation_today  # type: ignore[attr-defined]
+        grid_out = self.e_grid_out_day  # type: ignore[attr-defined]
+        battery_charge = self.e_battery_charge_today
+        ac_charge = self.e_ac_charge_today  # type: ignore[attr-defined]
+        if None in (pv, grid_out, battery_charge, ac_charge):
+            return None
+        # Round to the inputs' native 0.1 kWh resolution: a four-term sum of deci-scaled
+        # floats accumulates representation noise (e.g. 4.000000000000001) that 1dp removes
+        # losslessly, since the true result is always a multiple of 0.1.
+        return round(max(0.0, pv - grid_out - battery_charge + ac_charge), 1)
+
     # Plain @property (not @computed_field) so the deprecated alias doesn't
     # appear in model_dump() output. See #84 — renamed to work_time_total_hours
     # to put the unit at the call site.

--- a/tests/model/test_inverter.py
+++ b/tests/model/test_inverter.py
@@ -119,6 +119,7 @@ def test_inverter():
             "e_consumption_today": None,
             "e_self_consumption_today": None,
             "e_self_consumption_total": None,
+            "e_pv_direct_today": None,
             "e_battery_charge_today_alt1": None,
             "e_battery_discharge_today_alt1": None,
             "countdown": None,
@@ -535,6 +536,8 @@ def test_from_registers(register_cache):
         "e_self_consumption_today": 8.1,
         # computed: max(0, e_pv_generation_total − e_grid_out_total) = max(0, 93.0 − 0.6)
         "e_self_consumption_total": 92.4,
+        # computed: max(0, pv − grid_out − battery_charge + ac_charge) = max(0, 8.1 − 0.0 − 9.0 + 9.3)
+        "e_pv_direct_today": 8.4,
         "e_battery_charge_today_alt1": 9.0,  # IR(36)
         "e_battery_discharge_today_alt1": 8.9,  # IR(37)
         "countdown": 30,
@@ -887,6 +890,8 @@ def test_from_registers_actual_data(register_cache_inverter_daytime_discharging_
         "e_self_consumption_today": 3.8,
         # computed: max(0, e_pv_generation_total − e_grid_out_total) = max(0, 172.5 − 0.9)
         "e_self_consumption_total": 171.6,
+        # computed: max(0, pv − grid_out − battery_charge + ac_charge) = max(0, 3.8 − 0.0 − 9.1 + 9.3)
+        "e_pv_direct_today": 4.0,
         "e_battery_charge_today_alt1": 9.1,  # IR(36)
         "e_battery_discharge_today_alt1": 3.4,  # IR(37)
         "countdown": 0,
@@ -1457,6 +1462,97 @@ def test_e_self_consumption_none_when_any_input_missing():
     # total: missing grid_out → None
     inv = SinglePhaseInverter.from_register_cache(RegisterCache({IR(45): 0, IR(46): 930}))
     assert inv.e_self_consumption_total is None  # type: ignore[attr-defined]
+
+
+def _gen1_pv_direct_cache(pv_today, grid_out_day, battery_charge, ac_charge):
+    """A HYBRID_GEN1 register cache populated for the e_pv_direct_today inputs.
+
+    GEN1 routes e_battery_charge_today → alt2 (IR183); ac_charge is IR(35).
+    All energy registers are deci-scaled (0.1 kWh).
+    """
+    from givenergy_modbus.model.register import HR, IR
+
+    return RegisterCache(
+        {
+            HR(0): 0x2001,  # HYBRID_GEN1
+            HR(21): 449,
+            IR(44): round(pv_today * 10),  # e_pv_generation_today
+            IR(25): round(grid_out_day * 10),  # e_grid_out_day
+            IR(183): round(battery_charge * 10),  # e_battery_charge_today (GEN1 alt2)
+            IR(35): round(ac_charge * 10),  # e_ac_charge_today
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    "pv_today, grid_out_day, battery_charge, ac_charge, expected",
+    [
+        # PV 10, export 1, battery_charge 7 (3 PV + 4 AC), ac_charge 4 → 10−1−7+4 = 6
+        (10.0, 1.0, 7.0, 4.0, 6.0),
+        # pure-solar (no AC charge): ac_charge term is a no-op → 10−1−3+0 = 6
+        (10.0, 1.0, 3.0, 0.0, 6.0),
+        # export-heavy: difference goes negative → clamped at 0
+        (5.0, 8.0, 0.0, 0.0, 0.0),
+        # all PV straight to load (no charge, no export) → 9
+        (9.0, 0.0, 0.0, 0.0, 9.0),
+    ],
+)
+def test_e_pv_direct_today_formula(pv_today, grid_out_day, battery_charge, ac_charge, expected):
+    """PV-direct = max(0, pv − export − battery_charge + ac_charge) on a DC hybrid (GEN1).
+
+    The + ac_charge term nets out grid-sourced battery charging that e_battery_charge
+    lumps in; the clamp keeps it ≥ 0 when export exceeds available PV.
+    """
+    inv = SinglePhaseInverter.from_register_cache(
+        _gen1_pv_direct_cache(pv_today, grid_out_day, battery_charge, ac_charge)
+    )
+    assert inv.e_pv_direct_today == pytest.approx(expected)  # type: ignore[attr-defined]
+    assert "e_pv_direct_today" in inv.model_dump()
+
+
+def test_e_pv_direct_today_none_on_ineligible_models():
+    """AC-coupled and All-in-One return None — their PV registers are mislabelled (#293).
+
+    Both have e_battery_charge_today resolving (AC/AIO route today→alt1), so a plain
+    None-guard would let them through; the explicit topology gate is what blocks them.
+    """
+    from givenergy_modbus.model.register import HR, IR
+
+    # AC-coupled (0x3001): every input present, but is_ac_coupled gates it out.
+    ac = SinglePhaseInverter.from_register_cache(
+        RegisterCache({HR(0): 0x3001, HR(21): 282, IR(44): 100, IR(25): 10, IR(36): 70, IR(35): 40})
+    )
+    assert ac.is_ac_coupled is True  # type: ignore[attr-defined]
+    assert ac.e_battery_charge_today == 7.0  # resolves (today→alt1) — so the gate, not None-prop, blocks
+    assert ac.e_pv_direct_today is None  # type: ignore[attr-defined]
+
+    # All-in-One (0x8001): PV register is non-PV here (#293) → gated out.
+    aio = SinglePhaseInverter.from_register_cache(
+        RegisterCache({HR(0): 0x8001, HR(21): 612, IR(44): 100, IR(25): 10, IR(36): 70, IR(35): 40})
+    )
+    assert aio.e_battery_charge_today == 7.0
+    assert aio.e_pv_direct_today is None  # type: ignore[attr-defined]
+
+
+def test_e_pv_direct_today_none_when_battery_charge_unavailable():
+    """A DC model with no battery-charge routing (e.g. GEN3) → None, not a wrong value.
+
+    e_battery_charge_today only routes on HYBRID_GEN1 among DC models, so GEN3 returns
+    None and the field propagates that rather than treating charge as zero.
+    """
+    from givenergy_modbus.model.register import HR, IR
+
+    gen3 = SinglePhaseInverter.from_register_cache(
+        RegisterCache({HR(0): 0x2003, HR(21): 303, IR(44): 100, IR(25): 10, IR(35): 40})
+    )
+    assert gen3.e_battery_charge_today is None
+    assert gen3.e_pv_direct_today is None  # type: ignore[attr-defined]
+
+    # Missing ac_charge (IR35) on an otherwise-eligible GEN1 → None (no partial guess).
+    no_ac = SinglePhaseInverter.from_register_cache(
+        RegisterCache({HR(0): 0x2001, HR(21): 449, IR(44): 100, IR(25): 10, IR(183): 70})
+    )
+    assert no_ac.e_pv_direct_today is None  # type: ignore[attr-defined]
 
 
 def test_three_phase_has_no_computed_consumption_and_native_ac_charge():

--- a/tests/model/test_inverter.py
+++ b/tests/model/test_inverter.py
@@ -536,8 +536,9 @@ def test_from_registers(register_cache):
         "e_self_consumption_today": 8.1,
         # computed: max(0, e_pv_generation_total − e_grid_out_total) = max(0, 93.0 − 0.6)
         "e_self_consumption_total": 92.4,
-        # computed: max(0, pv − grid_out − battery_charge + ac_charge) = max(0, 8.1 − 0.0 − 9.0 + 9.3)
-        "e_pv_direct_today": 8.4,
+        # computed: max(0, (pv − grid_out) − max(0, battery_charge − ac_charge))
+        #         = max(0, 8.1 − 0.0 − max(0, 9.0 − 9.3)) = 8.1 (all charge was AC → no PV-to-battery)
+        "e_pv_direct_today": 8.1,
         "e_battery_charge_today_alt1": 9.0,  # IR(36)
         "e_battery_discharge_today_alt1": 8.9,  # IR(37)
         "countdown": 30,
@@ -890,8 +891,9 @@ def test_from_registers_actual_data(register_cache_inverter_daytime_discharging_
         "e_self_consumption_today": 3.8,
         # computed: max(0, e_pv_generation_total − e_grid_out_total) = max(0, 172.5 − 0.9)
         "e_self_consumption_total": 171.6,
-        # computed: max(0, pv − grid_out − battery_charge + ac_charge) = max(0, 3.8 − 0.0 − 9.1 + 9.3)
-        "e_pv_direct_today": 4.0,
+        # computed: max(0, (pv − grid_out) − max(0, battery_charge − ac_charge))
+        #         = max(0, 3.8 − 0.0 − max(0, 9.1 − 9.3)) = 3.8 (all charge was AC → no PV-to-battery)
+        "e_pv_direct_today": 3.8,
         "e_battery_charge_today_alt1": 9.1,  # IR(36)
         "e_battery_discharge_today_alt1": 3.4,  # IR(37)
         "countdown": 0,
@@ -1487,27 +1489,34 @@ def _gen1_pv_direct_cache(pv_today, grid_out_day, battery_charge, ac_charge):
 @pytest.mark.parametrize(
     "pv_today, grid_out_day, battery_charge, ac_charge, expected",
     [
-        # PV 10, export 1, battery_charge 7 (3 PV + 4 AC), ac_charge 4 → 10−1−7+4 = 6
+        # PV 10, export 1, battery_charge 7 (3 PV + 4 AC), ac_charge 4 → pv_to_batt 3 → 10−1−3 = 6
         (10.0, 1.0, 7.0, 4.0, 6.0),
-        # pure-solar (no AC charge): ac_charge term is a no-op → 10−1−3+0 = 6
+        # pure-solar (no AC charge): pv_to_batt = battery_charge → 10−1−3 = 6
         (10.0, 1.0, 3.0, 0.0, 6.0),
-        # export-heavy: difference goes negative → clamped at 0
+        # export-heavy: difference goes negative → clamped at 0 (lower bound)
         (5.0, 8.0, 0.0, 0.0, 0.0),
         # all PV straight to load (no charge, no export) → 9
         (9.0, 0.0, 0.0, 0.0, 9.0),
+        # AC-charge overcompensation: ac_charge (9.3) > battery_charge (9.0) — conversion
+        # loss / counter skew. pv_to_batt floors at 0, so result is clamped to pv − export
+        # (8.1), NOT inflated to 8.4 (upper bound — Codex review on #313).
+        (8.1, 0.0, 9.0, 9.3, 8.1),
     ],
 )
 def test_e_pv_direct_today_formula(pv_today, grid_out_day, battery_charge, ac_charge, expected):
-    """PV-direct = max(0, pv − export − battery_charge + ac_charge) on a DC hybrid (GEN1).
+    """PV-direct = max(0, (pv − export) − max(0, battery_charge − ac_charge)) on a GEN1 hybrid.
 
-    The + ac_charge term nets out grid-sourced battery charging that e_battery_charge
-    lumps in; the clamp keeps it ≥ 0 when export exceeds available PV.
+    The ac_charge term nets out grid-sourced battery charging that e_battery_charge lumps
+    in; the lower clamp keeps it ≥ 0 when export exceeds PV; flooring pv_to_battery at 0
+    keeps direct PV ≤ total on-site PV when ac_charge overshoots battery_charge.
     """
     inv = SinglePhaseInverter.from_register_cache(
         _gen1_pv_direct_cache(pv_today, grid_out_day, battery_charge, ac_charge)
     )
     assert inv.e_pv_direct_today == pytest.approx(expected)  # type: ignore[attr-defined]
     assert "e_pv_direct_today" in inv.model_dump()
+    # Invariant: direct PV is a subset of on-site PV self-consumption, never larger.
+    assert inv.e_pv_direct_today <= inv.e_self_consumption_today + 1e-9  # type: ignore[attr-defined]
 
 
 def test_e_pv_direct_today_none_on_ineligible_models():

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -1244,7 +1244,8 @@ def test_from_actual():
         "e_self_consumption_today": 35.6,
         # computed: max(0, e_pv_generation_total − e_grid_out_total) = max(0, 1698.7 − 163.9)
         "e_self_consumption_total": 1534.8,
-        # computed: max(0, pv − grid_out − battery_charge + ac_charge) = max(0, 38.0 − 2.4 − 5.7 + 4.3)
+        # computed: max(0, (pv − grid_out) − max(0, battery_charge − ac_charge))
+        #         = max(0, 38.0 − 2.4 − max(0, 5.7 − 4.3)) = max(0, 35.6 − 1.4) = 34.2
         "e_pv_direct_today": 34.2,
         "e_battery_charge_today_alt1": 5.7,  # IR(36)
         "e_battery_discharge_today_alt1": 5.9,  # IR(37)

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -1244,6 +1244,8 @@ def test_from_actual():
         "e_self_consumption_today": 35.6,
         # computed: max(0, e_pv_generation_total − e_grid_out_total) = max(0, 1698.7 − 163.9)
         "e_self_consumption_total": 1534.8,
+        # computed: max(0, pv − grid_out − battery_charge + ac_charge) = max(0, 38.0 − 2.4 − 5.7 + 4.3)
+        "e_pv_direct_today": 34.2,
         "e_battery_charge_today_alt1": 5.7,  # IR(36)
         "e_battery_discharge_today_alt1": 5.9,  # IR(37)
         "countdown": 0,


### PR DESCRIPTION
## Summary

Adds `e_pv_direct_today` — PV energy used **directly by load** today (kWh): solar that bypassed both the battery and the grid. The #223 "bonus" that was deferred when `e_self_consumption_*` landed (#312).

```
e_pv_direct_today = max(0, pv_generation − grid_export − battery_charge + ac_charge)
```

### Why the `+ ac_charge` term

`e_battery_charge` is a single counter that lumps PV-sourced and grid-sourced (AC) charging together. The PV-direct figure must only subtract the *PV* that went to battery, so the AC-charge portion is added back:

```
pv_to_load = pv_gen − export − (pv_to_batt + ac_charge) + ac_charge
           = pv_gen − export − battery_charge + ac_charge
```

Worked example — Octopus Go user, 4 kWh charged from grid overnight, daytime PV 10 kWh (6→load, 3→batt, 1→export): naive `10−1−7 = 2` (under by the 4 kWh AC charge); corrected `10−1−7+4 = 6` ✓. It's a **no-op for pure-solar systems** (`ac_charge = 0`).

### Scope decisions

- **DC-coupled only.** On AC-coupled and All-in-One units the PV-generation registers (IR44/45-46) are mislabelled — they read non-zero on battery-only hardware (#293) — so the field returns `None` there via an explicit `is_ac_coupled`/AIO gate (a plain None-guard wouldn't catch AIO, which *does* resolve `e_battery_charge_today`).
- **Effectively HYBRID_GEN1 today.** `e_battery_charge_today` only routes on GEN1 among DC models (`_BATTERY_ENERGY_SOURCE`), so other DC models return `None` until that map widens (#184). Tested on maintainer's GEN1 hardware shape.
- **Daily only.** The lifetime equivalent needs `e_ac_charge_total`, which single-phase firmware doesn't expose (three-phase only, IR1378/9), and `e_battery_charge_total` only resolves on GEN1.
- **Non-monotonic** intraday — documented; consumers using `TOTAL_INCREASING` must apply their own monotonic clamp (same contract as `e_self_consumption_*`).
- Result rounded to the inputs' native 0.1 kWh resolution (a four-term deci-scaled sum accumulates float noise).

Part of #223 (hass-side wiring tracked in givenergy-hass#223).

## Test plan

- [ ] `test_e_pv_direct_today_formula` — parametrized: AC-charge correction, pure-solar no-op, export-clamp, all-to-load
- [ ] `test_e_pv_direct_today_none_on_ineligible_models` — AC-coupled + AIO gated to None despite all inputs present
- [ ] `test_e_pv_direct_today_none_when_battery_charge_unavailable` — GEN3 (no routing) and missing ac_charge → None
- [ ] Existing `model_dump` snapshots updated (null inverter, two inverter fixtures, plant fixture)
- [ ] `uv run tox` → py311–py314 + format + lint + build all OK (1188 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)