### PR TITLE
docs: clarify HR300-359 block is gated on has_ac_config_block

### DIFF
--- a/givenergy_modbus/model/inverter.py
+++ b/givenergy_modbus/model/inverter.py
@@ -613,9 +613,11 @@ class SinglePhaseInverterRegisterGetter(RegisterGetter):
         "smart_load_slot_9": Def(C.timeslot, None, HR(570), HR(571)),
         "smart_load_slot_10": Def(C.timeslot, None, HR(572), HR(573)),
         #
-        # Holding Registers, block 300-359
-        # Single Phase New registers
-        # This block is polled for non-EMS / non-gateway inverters; see client.py.
+        # Holding Registers, block 300-359 — AC-output config.
+        # Polled only when has_ac_config_block is set (AC-coupled and All-in-One
+        # models); DC-coupled/hybrid models time out on it and never poll it (#162),
+        # so every field below stays None there — same as battery_*_limit_ac (HR313/314).
+        # See client.py load_config().
         #
         # HR(308-310): battery topology — rated power (W), rated current (A), max charge
         # percentage. Extracted from GE app 4.0.7 binary; scale unconfirmed on live hardware.


### PR DESCRIPTION
## Summary

A decode-table comment in `SinglePhaseInverterRegisterGetter` claimed the HR300-359 block "is polled for non-EMS / non-gateway inverters". That's inaccurate: `load_config()` only issues the `HR(300,60)` read when `has_ac_config_block` is set (AC-coupled / All-in-One). DC-coupled/hybrid models never poll it (#162), so HR308-310 (and HR313/314) stay `None` there.

The wrong comment prompted a downstream question (from the hass integration) about whether HR308-310 — added in #316 — were being polled universally on DC hybrids and causing wasted reads. They aren't: they ride inside the already-gated, already-tested AC-config block. This corrects the comment so the next reader doesn't make the same assumption.

Comment-only change — no behaviour change.

## Verification

The poll gating is already locked in by `tests/client/test_load_refresh.py`:
- HYBRID / HYBRID_GEN1 / HYBRID_3PH / HYBRID_GEN3 assert the `HR(300,60)` block is **absent** from the request list
- AC and ALL_IN_ONE assert it **is** present

## Test plan

- [x] `ruff check` / `ruff format --check` clean
- [x] `pytest tests/client/test_load_refresh.py tests/model/test_inverter.py` — 109 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the note for the AC-output register block so it’s clearer when these values are read and when they may remain unavailable.
  * Improved guidance for users working with AC-coupled and All-in-One models versus DC-coupled or hybrid models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->