### PR TITLE
feat: decode HV BMU per-cell data from per-module device addresses (#265)

### DIFF
--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -582,14 +582,22 @@ class Client:
         """
         if not (caps.is_hv and caps.device_type is not Model.ALL_IN_ONE and caps.bcu_stacks):
             return
-        if prior is not None:
+        if prior is not None and prior.hv_bmu_addresses:
+            # Hinted mode: re-probe only the addresses the prior recorded.
             candidates: list[int] = list(prior.hv_bmu_addresses)
         else:
+            # Cold mode (also used when prior exists but predates this field): derive from BCU module counts.
             candidates = []
             next_addr = 0x50
             for _offset, num_modules in caps.bcu_stacks:
-                candidates.extend(range(next_addr, next_addr + num_modules))
-                next_addr += num_modules
+                end_addr = min(next_addr + max(num_modules, 0), 0x70)
+                candidates.extend(range(next_addr, end_addr))
+                if end_addr < next_addr + num_modules:
+                    _logger.warning(
+                        "detect: BCU module count %d exceeds HV BMU address band (0x50-0x6F) — clamped",
+                        num_modules,
+                    )
+                next_addr = end_addr
         for addr in candidates:
             if not await self._probe(
                 ReadInputRegistersRequest(base_register=60, register_count=60, device_address=addr),

--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -28,6 +28,7 @@ from givenergy_modbus.framer import ClientFramer, Framer
 from givenergy_modbus.model.aio_battery import AioBatteryModule
 from givenergy_modbus.model.battery import Battery
 from givenergy_modbus.model.ems import EmsRegisterGetter
+from givenergy_modbus.model.hv_bcu import Bmu
 from givenergy_modbus.model.inverter import Model, resolve_model
 from givenergy_modbus.model.lv_bcu import LV_BCU_ADDRESS, LvBcu
 from givenergy_modbus.model.meter import Meter
@@ -560,6 +561,53 @@ class Client:
                 continue
             caps.aio_battery_module_addresses.append(addr)
 
+    async def _detect_hv_bmu_modules(
+        self,
+        caps: PlantCapabilities,
+        prior: PlantCapabilities | None,
+        probe_timeout: float,
+        probe_retries: int,
+    ) -> None:
+        """Populate caps.hv_bmu_addresses for a non-AIO HV stack (#265).
+
+        Each HV battery module answers at its own device address (0x50 + running module index,
+        contiguous across stacks) with the same IR(60-119) per-cell block AIO modules use — the
+        earlier stride-within-the-BCU decode read the BCU's cluster registers as cell data.
+        Installer-confirmed, not yet wire-confirmed: probing here both populates the addresses to
+        poll and surfaces whether the band actually responds on real HV hardware.
+
+        Hinted mode (prior is not None): re-probe only the previously-seen addresses. Cold mode:
+        derive candidates 0x50 + k from each BCU's module count. Self-gated: a no-op unless this
+        is a non-AIO HV stack with detected BCUs (AIO modules use aio_battery_module_addresses).
+        """
+        if not (caps.is_hv and caps.device_type is not Model.ALL_IN_ONE and caps.bcu_stacks):
+            return
+        if prior is not None:
+            candidates: list[int] = list(prior.hv_bmu_addresses)
+        else:
+            candidates = []
+            next_addr = 0x50
+            for _offset, num_modules in caps.bcu_stacks:
+                candidates.extend(range(next_addr, next_addr + num_modules))
+                next_addr += num_modules
+        for addr in candidates:
+            if not await self._probe(
+                ReadInputRegistersRequest(base_register=60, register_count=60, device_address=addr),
+                timeout=probe_timeout,
+                retries=probe_retries,
+            ):
+                continue
+            cache = self.plant.register_caches.get(addr)
+            try:
+                if cache is None or not Bmu.from_register_cache(cache).is_valid():
+                    _logger.debug("detect: HV BMU probe at 0x%02x responded but is_valid()=False — skipping", addr)
+                    continue
+            except Exception:
+                _logger.debug("detect: HV BMU probe at 0x%02x failed to decode — skipping", addr, exc_info=True)
+                continue
+            caps.hv_bmu_addresses.append(addr)
+        _logger.info("detect: hv_bmu_modules=[%s]", ", ".join(f"0x{a:02x}" for a in caps.hv_bmu_addresses))
+
     async def _detect_lv_bcu(
         self,
         caps: PlantCapabilities,
@@ -796,6 +844,11 @@ class Client:
                 "detect: aio_battery_modules=[%s]",
                 ", ".join(f"0x{a:02x}" for a in caps.aio_battery_module_addresses),
             )
+
+        # Step 2c — HV BMU per-module probing (#265). Non-AIO HV stacks expose per-cell data at
+        # their own BMU addresses (0x50+), distinct from the bcu_stacks stride decode (which read
+        # the BCU's cluster registers as cells). Self-gated to non-AIO HV; a no-op otherwise.
+        await self._detect_hv_bmu_modules(caps, prior, probe_timeout, probe_retries)
 
         # Step 3 — meter probing. Hinted: only previously-seen addresses. Cold: full 0x01–0x08 sweep.
         # In both modes, a probe response is necessary but not sufficient — some EMS firmwares
@@ -1107,6 +1160,10 @@ class Client:
             reqs.append(ReadInputRegistersRequest(base_register=60, register_count=60, device_address=0x70 + offset))
         # AIO per-module battery caches (#192) — each module answers at its own address.
         for addr in caps.aio_battery_module_addresses:
+            reqs.append(ReadInputRegistersRequest(base_register=60, register_count=60, device_address=addr))
+        # HV BMU per-module per-cell caches (#265) — each module answers at its own 0x50+ address
+        # (installer-confirmed, not yet wire-confirmed). Empty until detect probes the band.
+        for addr in caps.hv_bmu_addresses:
             reqs.append(ReadInputRegistersRequest(base_register=60, register_count=60, device_address=addr))
         await self._execute_reads(reqs, timeout=timeout, retries=retries, retry_delay=retry_delay)
         return self.plant

--- a/givenergy_modbus/model/hv_bcu.py
+++ b/givenergy_modbus/model/hv_bcu.py
@@ -5,10 +5,11 @@ BMU device addresses: 0x50–0x6F
 
 `HvStack` bundles a BCU and its BMUs for one physical battery stack.
 
-The BMU register layout is offset by 120 * bmu_index within the BCU device, which
-means register addresses depend on which BMU is being read.  Because Pydantic models
-require a fixed schema, `Bmu` is constructed by `Bmu.from_register_cache(cache, offset)`
-which resolves all addresses before model creation.
+Each BMU answers at its **own device address** (0x50+) with a plain ``IR(60-119)`` block —
+24 cell voltages, temperatures and the module serial — the same separate-address layout as
+`AioBatteryModule` (see `model/aio_battery.py`), decoded at ``base = 0`` via
+:func:`decode_cells_temps_serial`. (Installer-confirmed; the earlier stride-within-the-BCU-cache
+decode read the BCU's own cluster registers as cell data — see #265. Not yet wire-confirmed.)
 """
 
 import warnings
@@ -88,8 +89,6 @@ class Bcu(_BcuBase, RegisterMetadataMixin):  # type: ignore[misc,valid-type]
 
 # Cell count per BMU (all known HV stacks use 24 cells per module)
 _BMU_CELLS = 24
-# Register stride between BMUs within a BCU device's address space
-_BMU_STRIDE = 120
 # Base register addresses (relative to a module's ``base`` offset) for the per-cell block.
 # Shared by the field schema, the decode, and the register LUT so they can't drift (#273).
 _V_CELL_BASE = 60  # IR(60+base .. 83+base) — 24 cell voltages, milli (÷1000)
@@ -115,11 +114,11 @@ def module_cell_temp_serial_fields() -> dict[str, tuple[Any, None]]:
 def cell_temp_serial_register_lut(base: int = 0) -> dict[str, Def]:
     """field→register LUT matching :func:`decode_cells_temps_serial` for the given ``base``.
 
-    Base-parametrised the same way the decode is, so a future `Bmu` getter could offset by
-    ``120 * bmu_index``; `AioBatteryModule` uses ``base = 0``. Converters mirror the decode:
-    voltages milli (÷1000), temperatures deci (÷10), serial the 5-register string decode.
-    Drives ``registers_of()`` / ``precision_of()`` for staleness gating (#273); the min/max on
-    voltages mirror `BatteryRegisterGetter` and are inert under the imperative decode.
+    Both `BmuRegisterGetter` (#265) and `AioBatteryModuleRegisterGetter` (#192) use ``base = 0``
+    — one cache per module device address. Converters mirror the decode: voltages milli (÷1000),
+    temperatures deci (÷10), serial the 5-register string decode. Drives ``registers_of()`` /
+    ``precision_of()`` for staleness gating (#273); the min/max on voltages mirror
+    `BatteryRegisterGetter` and are inert under the imperative decode.
     """
     lut: dict[str, Def] = {}
     for i in range(_BMU_CELLS):
@@ -133,10 +132,10 @@ def decode_cells_temps_serial(register_cache, base: int = 0) -> dict[str, Any]:
     """Decode a battery module's cells, temperatures and serial from a cache, offset by ``base``.
 
     Reads 24 cell voltages (IR 60-83), temperatures (IR 90-113) and the module serial
-    (IR 114-118). Shared decode for both module layouts: `Bmu` passes ``base = 120 * bmu_index`` (stride
-    within one BCU cache); `AioBatteryModule` passes ``base = 0`` (one cache per module
-    device address). Voltages are milli (÷1000), temperatures deci (÷10). A missing register
-    decodes as None; an incomplete serial group yields ``serial_number = None``.
+    (IR 114-118). Shared decode for the separate-address module layout: both `Bmu` (HV, #265)
+    and `AioBatteryModule` (#192) pass ``base = 0`` — one cache per module device address.
+    Voltages are milli (÷1000), temperatures deci (÷10). A missing register decodes as None;
+    an incomplete serial group yields ``serial_number = None``.
     """
     data: dict[str, Any] = {}
 
@@ -162,8 +161,18 @@ def decode_cells_temps_serial(register_cache, base: int = 0) -> dict[str, Any]:
     return data
 
 
-# Build the Bmu pydantic model schema using dummy offset 0 to infer field types,
-# then instantiate with real data in from_register_cache.
+class BmuRegisterGetter(RegisterGetter):
+    """field→register metadata for HV BMU per-module data (#265).
+
+    Same separate-address layout as AIO modules — each BMU decodes its own ``IR(60-119)``
+    cache at ``base = 0``; this LUT drives ``registers_of()`` / ``precision_of()`` for
+    staleness gating, matching `AioBatteryModuleRegisterGetter`.
+    """
+
+    REGISTER_LUT = cell_temp_serial_register_lut(base=0)
+
+
+# Pydantic model schema: the shared per-cell fields plus the module's 0-based index.
 def _bmu_fields() -> dict[str, tuple[Any, None]]:
     fields = module_cell_temp_serial_fields()
     fields["bmu_index"] = (int | None, None)
@@ -177,22 +186,26 @@ _BmuBase = create_model(  # type: ignore[call-overload]
 )
 
 
-class Bmu(_BmuBase):  # type: ignore[misc,valid-type]
+class Bmu(_BmuBase, RegisterMetadataMixin):  # type: ignore[misc,valid-type]
     """GivEnergy HV Battery Module Unit (BMU) per-module data.
 
-    `bmu_index` is 0-based within the BCU (module 0 uses registers 60–179,
-    module 1 uses 180–299, etc.).
+    Decoded from the module's **own** register cache (``base = 0``), keyed by its 0-based
+    ``bmu_index`` within the stack (module *k* answers at device address 0x50 + k). The earlier
+    stride-within-the-BCU-cache layout addressed the wrong device, reading the BCU's cluster
+    registers as cell data — see #265. Installer-derived; not yet wire-confirmed.
     """
+
+    REGISTER_GETTER: ClassVar[type[RegisterGetter]] = BmuRegisterGetter
 
     @classmethod
     def from_register_cache(cls, register_cache, bmu_index: int = 0) -> "Bmu":
-        """Construct a Bmu from a RegisterCache for the given bmu_index."""
-        data = decode_cells_temps_serial(register_cache, base=_BMU_STRIDE * bmu_index)
+        """Construct a Bmu from its own register cache (no stride)."""
+        data = decode_cells_temps_serial(register_cache, base=0)
         data["bmu_index"] = bmu_index
         return cls.model_validate(data)
 
     def is_valid(self) -> bool:
-        """Try to detect if a BMU is present based on its attributes."""
+        """True if the module reports a non-blank serial (i.e. a module is present)."""
         return self.serial_number not in (None, "", "          ")  # type: ignore[attr-defined]
 
 

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -219,6 +219,10 @@ class PlantCapabilities(BaseModel):
     # AIO (All-in-One) per-module battery device addresses (0x50-0x53). Separate-address
     # layout, distinct from the bcu_stacks stride model — see model/aio_battery.py (#192).
     aio_battery_module_addresses: list[int] = Field(default_factory=list)
+    # HV BMU per-module device addresses (0x50+), populated by detect for non-AIO HV stacks.
+    # Each module answers at its own IR(60-119) cache (same separate-address layout as AIO);
+    # installer-confirmed, not yet wire-confirmed — see model/hv_bcu.py (#265).
+    hv_bmu_addresses: list[int] = Field(default_factory=list)
     # LV BCU page address (observed only at 0x31 — see model/lv_bcu.py). None when the
     # block read all-zero at detect time (firmware-gated, #241).
     lv_bcu_address: int | None = None
@@ -231,6 +235,7 @@ class PlantCapabilities(BaseModel):
         lv_battery_addresses: list[int] | None = None,
         bcu_stacks: list[tuple[int, int]] | None = None,
         aio_battery_module_addresses: list[int] | None = None,
+        hv_bmu_addresses: list[int] | None = None,
         lv_bcu_address: int | None = None,
         **kwargs: Any,
     ) -> None:
@@ -254,6 +259,8 @@ class PlantCapabilities(BaseModel):
             kwargs["bcu_stacks"] = bcu_stacks
         if aio_battery_module_addresses is not None:
             kwargs["aio_battery_module_addresses"] = aio_battery_module_addresses
+        if hv_bmu_addresses is not None:
+            kwargs["hv_bmu_addresses"] = hv_bmu_addresses
         if lv_bcu_address is not None:
             kwargs["lv_bcu_address"] = lv_bcu_address
         _map_legacy_aliases(kwargs, stacklevel=3)
@@ -375,6 +382,7 @@ class PlantCapabilities(BaseModel):
             "lv_battery_addresses": [f"0x{a:02x}" for a in self.lv_battery_addresses],
             "bcu_stacks": [[offset, modules] for offset, modules in self.bcu_stacks],
             "aio_battery_module_addresses": [f"0x{a:02x}" for a in self.aio_battery_module_addresses],
+            "hv_bmu_addresses": [f"0x{a:02x}" for a in self.hv_bmu_addresses],
             "lv_bcu_address": f"0x{self.lv_bcu_address:02x}" if self.lv_bcu_address is not None else None,
         }
 
@@ -436,6 +444,7 @@ class PlantCapabilities(BaseModel):
             # (`0x70 + offset` in detect()). Fail loud at parse time instead.
             bcu_stacks=[(int(offset), int(modules)) for offset, modules in (normalised.get("bcu_stacks") or [])],
             aio_battery_module_addresses=[_addr(a) for a in (normalised.get("aio_battery_module_addresses") or [])],
+            hv_bmu_addresses=[_addr(a) for a in (normalised.get("hv_bmu_addresses") or [])],
             lv_bcu_address=(
                 _addr(normalised["lv_bcu_address"]) if normalised.get("lv_bcu_address") is not None else None
             ),
@@ -446,6 +455,7 @@ class PlantCapabilities(BaseModel):
         batts = ", ".join(f"0x{a:02x}" for a in self.lv_battery_addresses)
         bcus = ", ".join(f"({o}, {n})" for o, n in self.bcu_stacks)
         aio_mods = ", ".join(f"0x{a:02x}" for a in self.aio_battery_module_addresses)
+        hv_bmus = ", ".join(f"0x{a:02x}" for a in self.hv_bmu_addresses)
         lv_bcu = f"0x{self.lv_bcu_address:02x}" if self.lv_bcu_address is not None else "None"
         return (
             f"PlantCapabilities("
@@ -455,6 +465,7 @@ class PlantCapabilities(BaseModel):
             f"lv_battery_addresses=[{batts}], "
             f"bcu_stacks=[{bcus}], "
             f"aio_battery_module_addresses=[{aio_mods}], "
+            f"hv_bmu_addresses=[{hv_bmus}], "
             f"lv_bcu_address={lv_bcu})"
         )
 
@@ -1545,15 +1556,27 @@ class Plant(GivEnergyBaseModel):
 
     @property
     def hv_stacks(self) -> list[HvStack]:
-        """Return HV battery stacks (BCU + BMUs) for HV systems; empty list for LV systems."""
+        """Return HV battery stacks (BCU + per-module BMUs) for HV systems; [] for LV systems.
+
+        Each BMU is decoded from its **own** device-address cache (0x50 + running module index,
+        contiguous across stacks), matching the separate-address AIO layout. Single-stack
+        allocation is installer-confirmed; the multi-stack stride is not yet wire-confirmed
+        (#265). Module caches that haven't been polled (or don't respond) decode to all-None and
+        report ``is_valid() == False``.
+        """
         if not self.capabilities or not self.capabilities.bcu_stacks:
             return []
         stacks = []
+        next_bmu_addr = 0x50
         for offset, num_modules in self.capabilities.bcu_stacks:
             device_addr = 0x70 + offset
             cache = self.register_caches.get(device_addr, RegisterCache())
             bcu = Bcu.from_register_cache(cache)
-            bmus = [Bmu.from_register_cache(cache, i) for i in range(num_modules)]
+            bmus = []
+            for i in range(num_modules):
+                bmu_cache = self.register_caches.get(next_bmu_addr + i, RegisterCache())
+                bmus.append(Bmu.from_register_cache(bmu_cache, i))
+            next_bmu_addr += num_modules
             stacks.append(HvStack(device_address=device_addr, bcu=bcu, bmus=bmus))
         return stacks
 

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -24,7 +24,7 @@ from givenergy_modbus.model.devices import DeviceType, PlantDevice
 from givenergy_modbus.model.devices import Inverter as UnifiedInverter
 from givenergy_modbus.model.ems import Ems
 from givenergy_modbus.model.gateway import GatewayV1, GatewayV2, select_gateway
-from givenergy_modbus.model.hv_bcu import Bcu, BcuRegisterGetter, Bmu, HvStack
+from givenergy_modbus.model.hv_bcu import Bcu, BcuRegisterGetter, Bmu, BmuRegisterGetter, HvStack
 from givenergy_modbus.model.inverter import (
     AC_COUPLED_MODELS,
     Model,
@@ -695,6 +695,8 @@ class Plant(GivEnergyBaseModel):
             # inverter_address=0x31 still routes to the inverter getter.
             if device_address == self.capabilities.lv_bcu_address:
                 return LvBcuRegisterGetter
+            if device_address in self.capabilities.hv_bmu_addresses:
+                return BmuRegisterGetter
             if 0x32 <= device_address <= 0x37:
                 return BatteryRegisterGetter
         else:

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -235,8 +235,8 @@ class PlantCapabilities(BaseModel):
         lv_battery_addresses: list[int] | None = None,
         bcu_stacks: list[tuple[int, int]] | None = None,
         aio_battery_module_addresses: list[int] | None = None,
-        hv_bmu_addresses: list[int] | None = None,
         lv_bcu_address: int | None = None,
+        hv_bmu_addresses: list[int] | None = None,
         **kwargs: Any,
     ) -> None:
         # Custom __init__ for two reasons:
@@ -259,10 +259,10 @@ class PlantCapabilities(BaseModel):
             kwargs["bcu_stacks"] = bcu_stacks
         if aio_battery_module_addresses is not None:
             kwargs["aio_battery_module_addresses"] = aio_battery_module_addresses
-        if hv_bmu_addresses is not None:
-            kwargs["hv_bmu_addresses"] = hv_bmu_addresses
         if lv_bcu_address is not None:
             kwargs["lv_bcu_address"] = lv_bcu_address
+        if hv_bmu_addresses is not None:
+            kwargs["hv_bmu_addresses"] = hv_bmu_addresses
         _map_legacy_aliases(kwargs, stacklevel=3)
         super().__init__(**kwargs)
 

--- a/tests/client/test_detect.py
+++ b/tests/client/test_detect.py
@@ -122,6 +122,49 @@ async def test_detect_hv_bmu_skips_modules_with_no_serial():
     assert caps.hv_bmu_addresses == [0x50]
 
 
+@pytest.mark.asyncio
+async def test_detect_hv_bmu_hinted_mode_uses_prior_addresses():
+    """Hinted detect re-probes only prior.hv_bmu_addresses, not the BCU module count.
+
+    If prior recorded [0x50] but the BCU now says 2 modules, only 0x50 is probed.
+    An address that no longer responds is dropped.
+    """
+    client = _make_client()
+    # BCU says 2 modules, but prior only knew about 0x50.
+    caps = PlantCapabilities(device_type=Model.HYBRID_HV_GEN3, inverter_address=0x11, bcu_stacks=[(0, 2)])
+    prior = PlantCapabilities(device_type=Model.HYBRID_HV_GEN3, hv_bmu_addresses=[0x50, 0x51])
+    _prime_aio_module_serial(client, 0x50, serial="BM2414G830")
+    # 0x51 is in prior but no longer responds.
+    probed = []
+
+    async def _probe_side_effect(request, *, timeout, retries):
+        probed.append(request.device_address)
+        return request.device_address == 0x50
+
+    with patch.object(client, "_probe", side_effect=_probe_side_effect):
+        await client._detect_hv_bmu_modules(caps, prior, 1.0, 1)
+
+    assert probed == [0x50, 0x51], "hinted mode must probe exactly the prior addresses"
+    assert caps.hv_bmu_addresses == [0x50], "non-responding prior address must be dropped"
+
+
+@pytest.mark.asyncio
+async def test_detect_hv_bmu_skips_on_decode_exception():
+    """If Bmu.from_register_cache raises, the address is skipped without propagating."""
+    client = _make_client()
+    caps = PlantCapabilities(device_type=Model.HYBRID_HV_GEN3, inverter_address=0x11, bcu_stacks=[(0, 1)])
+    _prime_aio_module_serial(client, 0x50)
+
+    async def _probe_side_effect(request, *, timeout, retries):
+        return True
+
+    with patch.object(client, "_probe", side_effect=_probe_side_effect):
+        with patch("givenergy_modbus.client.client.Bmu.from_register_cache", side_effect=RuntimeError("boom")):
+            await client._detect_hv_bmu_modules(caps, None, 1.0, 1)
+
+    assert caps.hv_bmu_addresses == []
+
+
 def test_plant_capabilities_round_trip_with_lv_bcu():
     caps = PlantCapabilities(
         device_type=Model.HYBRID,

--- a/tests/client/test_detect.py
+++ b/tests/client/test_detect.py
@@ -75,6 +75,53 @@ def test_plant_capabilities_round_trip_with_aio_modules():
     assert restored.aio_battery_module_addresses == [0x50, 0x51, 0x52, 0x53]
 
 
+def test_plant_capabilities_round_trip_with_hv_bmu_modules():
+    caps = PlantCapabilities(
+        device_type=Model.HYBRID_HV_GEN3,
+        inverter_address=0x11,
+        bcu_stacks=[(0, 2)],
+        hv_bmu_addresses=[0x50, 0x51],
+    )
+    restored = PlantCapabilities.from_dict(caps.to_dict())
+    assert restored == caps
+    assert restored.hv_bmu_addresses == [0x50, 0x51]
+
+
+@pytest.mark.asyncio
+async def test_detect_hv_bmu_modules_records_responding_addresses():
+    """A non-AIO HV stack records per-module BMU addresses at 0x50+ (#265)."""
+    client = _make_client()
+    caps = PlantCapabilities(device_type=Model.HYBRID_HV_GEN3, inverter_address=0x11, bcu_stacks=[(0, 2)])
+    for addr in (0x50, 0x51):
+        _prime_aio_module_serial(client, addr, serial=f"BM2414G83{addr - 0x50}")
+    responders = {0x50, 0x51}
+
+    async def _probe_side_effect(request, *, timeout, retries):
+        return request.device_address in responders
+
+    with patch.object(client, "_probe", side_effect=_probe_side_effect):
+        await client._detect_hv_bmu_modules(caps, None, 1.0, 1)
+
+    assert caps.hv_bmu_addresses == [0x50, 0x51]
+
+
+@pytest.mark.asyncio
+async def test_detect_hv_bmu_skips_modules_with_no_serial():
+    """An HV BMU that responds but reports no serial is not recorded (ghost guard, #265)."""
+    client = _make_client()
+    caps = PlantCapabilities(device_type=Model.HYBRID_HV_GEN3, inverter_address=0x11, bcu_stacks=[(0, 2)])
+    _prime_aio_module_serial(client, 0x50)  # 0x51 responds but has no serial primed
+    responders = {0x50, 0x51}
+
+    async def _probe_side_effect(request, *, timeout, retries):
+        return request.device_address in responders
+
+    with patch.object(client, "_probe", side_effect=_probe_side_effect):
+        await client._detect_hv_bmu_modules(caps, None, 1.0, 1)
+
+    assert caps.hv_bmu_addresses == [0x50]
+
+
 def test_plant_capabilities_round_trip_with_lv_bcu():
     caps = PlantCapabilities(
         device_type=Model.HYBRID,
@@ -532,6 +579,8 @@ async def test_detect_finds_aio_battery_modules():
     assert caps.device_type is Model.ALL_IN_ONE
     assert caps.bcu_stacks == [(0, 4)]
     assert caps.aio_battery_module_addresses == [0x50, 0x51, 0x52, 0x53]
+    # AIO modules must not also be detected via the HV BMU path — that's gated to non-AIO (#265).
+    assert caps.hv_bmu_addresses == []
 
 
 @pytest.mark.asyncio

--- a/tests/client/test_detect.py
+++ b/tests/client/test_detect.py
@@ -165,6 +165,55 @@ async def test_detect_hv_bmu_skips_on_decode_exception():
     assert caps.hv_bmu_addresses == []
 
 
+@pytest.mark.asyncio
+async def test_detect_hv_bmu_empty_prior_falls_back_to_cold_detect():
+    """Prior with empty hv_bmu_addresses (pre-#326 upgrade) falls back to cold candidate derivation.
+
+    An upgraded system whose prior PlantCapabilities predate the hv_bmu_addresses field will have
+    prior.hv_bmu_addresses == [] even though bcu_stacks is populated. The hinted path must treat
+    this like a cold detect rather than silently probing nothing.
+    """
+    client = _make_client()
+    caps = PlantCapabilities(device_type=Model.HYBRID_HV_GEN3, inverter_address=0x11, bcu_stacks=[(0, 1)])
+    # prior exists but has no BMU addresses (simulates a pre-#326 persisted capability)
+    prior = PlantCapabilities(device_type=Model.HYBRID_HV_GEN3, bcu_stacks=[(0, 1)])
+    assert prior.hv_bmu_addresses == []
+    _prime_aio_module_serial(client, 0x50, serial="BM2414G830")
+    probed = []
+
+    async def _probe_side_effect(request, *, timeout, retries):
+        probed.append(request.device_address)
+        return request.device_address == 0x50
+
+    with patch.object(client, "_probe", side_effect=_probe_side_effect):
+        await client._detect_hv_bmu_modules(caps, prior, 1.0, 1)
+
+    assert 0x50 in probed, "cold fallback must probe 0x50 derived from bcu_stacks"
+    assert caps.hv_bmu_addresses == [0x50]
+
+
+@pytest.mark.asyncio
+async def test_detect_hv_bmu_clamps_to_band_on_corrupt_module_count(caplog):
+    """A corrupt or unexpectedly large num_modules is clamped so probes stay within 0x50-0x6F."""
+    import logging
+
+    client = _make_client()
+    # BCU claims 100 modules — would spill into 0x70+ BCU territory without the clamp.
+    caps = PlantCapabilities(device_type=Model.HYBRID_HV_GEN3, inverter_address=0x11, bcu_stacks=[(0, 100)])
+    probed = []
+
+    async def _probe_side_effect(request, *, timeout, retries):
+        probed.append(request.device_address)
+        return False
+
+    with patch.object(client, "_probe", side_effect=_probe_side_effect):
+        with caplog.at_level(logging.WARNING):
+            await client._detect_hv_bmu_modules(caps, None, 1.0, 1)
+
+    assert all(0x50 <= addr < 0x70 for addr in probed), "all probed addresses must be within the BMU band"
+    assert "clamped" in caplog.text
+
+
 def test_plant_capabilities_round_trip_with_lv_bcu():
     caps = PlantCapabilities(
         device_type=Model.HYBRID,

--- a/tests/client/test_load_refresh.py
+++ b/tests/client/test_load_refresh.py
@@ -352,6 +352,16 @@ async def test_refresh_aio_battery_modules():
         assert _ir(60, 60, device=addr) in reqs
 
 
+async def test_refresh_hv_bmu_modules():
+    """Non-AIO HV BMU modules each add an IR 60+60 read at their own 0x50+ address (#265)."""
+    client = _client_with_caps(Model.HYBRID_HV_GEN3, bcu_stacks=[(0, 2)], hv_bmu_addresses=[0x50, 0x51])
+    with patch.object(client, "_execute_reads", new_callable=AsyncMock) as mock_exec:
+        await client.refresh()
+    reqs = _reqs(mock_exec)
+    for addr in (0x50, 0x51):
+        assert _ir(60, 60, device=addr) in reqs
+
+
 async def test_refresh_plant_forwards_timeout_retries_and_retry_delay_post_detect():
     """Once capabilities is set, refresh_plant() must thread timeout/retries/retry_delay through.
 

--- a/tests/model/test_hv_bcu.py
+++ b/tests/model/test_hv_bcu.py
@@ -101,20 +101,19 @@ def test_bmu_index_0():
     assert bmu.serial_number == "ABCDEFGHI"  # type: ignore[attr-defined]
 
 
-def test_bmu_index_1_uses_offset_registers():
-    # BMU index 1: registers start at base + 1*120 = 120
-    # v_cell_01 at IR(60 + 120) = IR(180)
-    # t_cell_01 at IR(90 + 120) = IR(210)
-    # serial at IR(114 + 120) = IR(234)
+def test_bmu_index_is_a_label_not_a_stride():
+    # Post-#265: every BMU reads its OWN device-address cache at base=0 (IR 60-118). bmu_index
+    # is just a label; it no longer shifts the register window (the old 120*index stride read
+    # the BCU's own cluster registers as cell data).
     cache = _cache(
         {
-            IR(180): 3300,  # v_cell_01 for BMU 1 = 3.300 V
-            IR(210): 280,  # t_cell_01 for BMU 1 = 28.0 °C
-            IR(234): 0x4142,
-            IR(235): 0x4344,
-            IR(236): 0x4546,
-            IR(237): 0x4748,
-            IR(238): 0x4900,
+            IR(60): 3300,  # v_cell_01 = 3.300 V (milli)
+            IR(90): 280,  # t_cell_01 = 28.0 °C (deci)
+            IR(114): 0x4142,
+            IR(115): 0x4344,
+            IR(116): 0x4546,
+            IR(117): 0x4748,
+            IR(118): 0x4900,
         }
     )
     bmu = Bmu.from_register_cache(cache, bmu_index=1)
@@ -125,11 +124,13 @@ def test_bmu_index_1_uses_offset_registers():
     assert bmu.serial_number == "ABCDEFGHI"  # type: ignore[attr-defined]
 
 
-def test_bmu_index_0_does_not_see_index_1_registers():
-    # Data placed only at BMU 1 offsets should not appear in BMU 0
+def test_bmu_reads_only_its_own_cache_window():
+    # Each BMU decodes IR(60-118) from its own cache; data outside that window — e.g. the old
+    # stride offset IR(180), or the BCU cluster block — is never read.
     cache = _cache({IR(180): 3300})
-    bmu0 = Bmu.from_register_cache(cache, bmu_index=0)
-    assert bmu0.v_cell_01 is None  # type: ignore[attr-defined]
+    bmu = Bmu.from_register_cache(cache, bmu_index=1)
+    assert bmu.v_cell_01 is None  # type: ignore[attr-defined]
+    assert bmu.is_valid() is False
 
 
 def test_bmu_has_24_cell_voltage_fields():

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -1674,6 +1674,20 @@ def test_getter_for_device_address_lv_bcu():
     assert plant._getter_for_device_address(0x31) is LvBcuRegisterGetter
 
 
+def test_getter_for_device_address_hv_bmu():
+    """Addresses in hv_bmu_addresses route to BmuRegisterGetter for refresh validation (#265)."""
+    from givenergy_modbus.model.hv_bcu import BmuRegisterGetter
+
+    plant = Plant(
+        capabilities=PlantCapabilities(
+            device_type=Model.HYBRID_HV_GEN3, hv_bmu_addresses=[0x50, 0x51]
+        )
+    )
+    assert plant._getter_for_device_address(0x50) is BmuRegisterGetter
+    assert plant._getter_for_device_address(0x51) is BmuRegisterGetter
+    assert plant._getter_for_device_address(0x52) is None  # not in the list → unrouted
+
+
 def test_commit_bank_incoherent_serial_discards_bank(plant: Plant, caplog):
     """A battery bank whose serial number registers decode to garbage must be discarded.
 

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -1678,11 +1678,7 @@ def test_getter_for_device_address_hv_bmu():
     """Addresses in hv_bmu_addresses route to BmuRegisterGetter for refresh validation (#265)."""
     from givenergy_modbus.model.hv_bcu import BmuRegisterGetter
 
-    plant = Plant(
-        capabilities=PlantCapabilities(
-            device_type=Model.HYBRID_HV_GEN3, hv_bmu_addresses=[0x50, 0x51]
-        )
-    )
+    plant = Plant(capabilities=PlantCapabilities(device_type=Model.HYBRID_HV_GEN3, hv_bmu_addresses=[0x50, 0x51]))
     assert plant._getter_for_device_address(0x50) is BmuRegisterGetter
     assert plant._getter_for_device_address(0x51) is BmuRegisterGetter
     assert plant._getter_for_device_address(0x52) is None  # not in the list → unrouted

--- a/tests/model/test_plant_accessors.py
+++ b/tests/model/test_plant_accessors.py
@@ -1,5 +1,7 @@
 """Tests for Plant typed accessors that depend on PlantCapabilities."""
 
+import pytest
+
 from givenergy_modbus.model.hv_bcu import HvStack
 from givenergy_modbus.model.inverter import Model
 from givenergy_modbus.model.inverter_threephase import ThreePhaseInverter
@@ -109,6 +111,35 @@ def test_hv_stacks_returns_stack_per_bcu():
     assert stacks[1].device_address == 0x71
     assert len(stacks[0].bmus) == 2
     assert len(stacks[1].bmus) == 3
+
+
+def test_hv_stacks_decodes_bmus_from_own_address_caches():
+    # #265: each BMU decodes from its own device-address cache (0x50 + running index), NOT a
+    # stride within the BCU cache. A two-module stack → BMUs at 0x50, 0x51.
+    plant = _plant_with_caps(device_type=Model.HYBRID_HV_GEN3, bcu_stacks=[(0, 2)])
+    _prime(plant, 0x70, {IR(64): 2})  # BCU cluster: 2 modules
+    _prime(plant, 0x50, {IR(60): 3200, IR(90): 250})  # BMU 0: v_cell_01=3.2 V, t_cell_01=25.0 °C
+    _prime(plant, 0x51, {IR(60): 3300, IR(90): 260})  # BMU 1: v_cell_01=3.3 V, t_cell_01=26.0 °C
+    bmus = plant.hv_stacks[0].bmus
+    assert len(bmus) == 2
+    assert bmus[0].bmu_index == 0
+    assert bmus[0].v_cell_01 == pytest.approx(3.2)
+    assert bmus[0].t_cell_01 == pytest.approx(25.0)
+    assert bmus[1].bmu_index == 1
+    assert bmus[1].v_cell_01 == pytest.approx(3.3)
+    assert bmus[1].t_cell_01 == pytest.approx(26.0)
+
+
+def test_hv_stacks_bmu_does_not_read_bcu_cluster_registers():
+    # Regression for the #265 bug: the BCU cluster cache (0x70) carries pack_software_version,
+    # counts and cluster V/I/SoC at IR(60-105). With no per-module 0x50+ cache primed, BMUs must
+    # decode to None — they must not mistake the BCU's own registers for cell data.
+    plant = _plant_with_caps(device_type=Model.HYBRID_HV_GEN3, bcu_stacks=[(0, 1)])
+    _prime(plant, 0x70, {IR(60): 1234, IR(67): 3300, IR(90): 250})  # BCU cluster regs, not cells
+    bmus = plant.hv_stacks[0].bmus
+    assert len(bmus) == 1
+    assert bmus[0].v_cell_01 is None
+    assert bmus[0].is_valid() is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_deprecation_aliases.py
+++ b/tests/test_deprecation_aliases.py
@@ -179,6 +179,7 @@ def test_capabilities_to_dict_format():
         "lv_battery_addresses": ["0x33"],
         "bcu_stacks": [[0, 2]],
         "aio_battery_module_addresses": [],
+        "hv_bmu_addresses": [],
         "lv_bcu_address": None,
     }
 


### PR DESCRIPTION
## What

The HV `Bmu` per-cell decode was reading the BCU's *own cluster registers* and mislabelling them as cell voltages. `Bmu.from_register_cache` offset into the BCU cache by `120 * bmu_index`, but module 0's window (IR60-83) overlaps the BCU's cluster block (pack version, counts, cluster V·I·SoC), and the refresh poll only ever fetched IR(60-119) from the BCU — so modules beyond the first were never read at all. Every HV per-cell field was therefore suspect.

The GivEnergy Installer app (v1.154.3) confirms per-cell data lives at each BMU's **own** device address (0x50-0x6F), one `IR(60-119)` block per module — the same separate-address layout `AioBatteryModule` already uses.

## Changes

- `Bmu` now decodes its own cache at `base=0` via a new `BmuRegisterGetter`, mirroring `AioBatteryModule` (and gains staleness metadata via `RegisterMetadataMixin`). The `120 * bmu_index` stride is gone.
- `detect()` probes `0x50+` for non-AIO HV stacks and records responders in a new `PlantCapabilities.hv_bmu_addresses`; `refresh()` polls them; `Plant.hv_stacks` decodes each BMU from its own cache.
- AIO is unchanged — its modules keep using `aio_battery_module_addresses`; the HV probe is gated to non-AIO.

## Caveat

The 0x50-0x6F layout is confirmed against the installer app but **not yet wire-confirmed** — I don't have an HV capture that addresses the band. The detect probe is a no-op where the band doesn't respond, so on non-matching hardware the fields stay `None` rather than emitting garbage. Docstrings carry the same caveat, and I'll follow up with a targeted probe to a contributor with HV hardware to confirm it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for discovering and polling HV BMU modules in compatible HV stacks.
  * Plant capabilities now retain a list of HV BMU device addresses for later refreshes and serialisation.

* **Bug Fixes**
  * Improved BMU decoding so each module reads from its own device address and data window.
  * Prevented invalid or incomplete BMU modules from being recorded during discovery.
  * Ensured HV BMU data is refreshed alongside existing battery and meter data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->