### PR TITLE
fix: re-enumerate a cold-start-held LV battery in detect() (hass#233)

### DIFF
--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -786,6 +786,67 @@ class Client:
                 _logger.exception("detect: error during connection teardown after failure")
             raise
 
+    async def _detect_lv_batteries(
+        self,
+        caps: PlantCapabilities,
+        prior: PlantCapabilities | None,
+        timeout: float,
+        retries: int,
+        probe_timeout: float,
+        probe_retries: int,
+    ) -> None:
+        """Enumerate LV battery packs into ``caps.lv_battery_addresses`` (detect step 4).
+
+        Battery pack #1 is at 0x32, additional packs at 0x33–0x37 (the inverter lives at 0x11, not
+        0x32 — issues #119/#189); each slot is validated via ``Battery.is_valid()``. Per-slot (not
+        break-on-fail) like the meter sweep: addresses can be non-contiguous (DIP-switch
+        misconfiguration) and a transient BMS timeout on pack N must not drop pack N+1 onward. Cold
+        detect is affordable since the probe budget only applies on cold sweeps.
+        """
+        await self.send_request_and_await_response(
+            ReadInputRegistersRequest(base_register=60, register_count=60, device_address=0x32),
+            timeout=timeout,
+            retries=retries,
+        )
+        batt_candidates = prior.lv_battery_addresses if prior is not None else range(0x32, 0x38)
+        for batt_addr in batt_candidates:
+            if batt_addr > 0x32:
+                if not await self._probe(
+                    ReadInputRegistersRequest(base_register=60, register_count=60, device_address=batt_addr),
+                    timeout=probe_timeout,
+                    retries=probe_retries,
+                ):
+                    continue
+                # #233/#289: the first battery bank against an empty cache is held by the cold-start
+                # splice guard (the cache stays empty pending a corroborating re-read). detect()
+                # probes each address once, so without this confirming read the address is dropped at
+                # the gate below and refresh() never re-polls it — a permanent hold for a recovered/
+                # returned pack. One healthy re-read corroborates and commits; a flapping/spliced bank
+                # fails to corroborate and correctly stays out (#289 anti-poison intact). Removed once
+                # #213's placeholder model decouples enumeration from data adoption.
+                if not self.plant.register_caches.get(batt_addr):
+                    await self._probe(
+                        ReadInputRegistersRequest(base_register=60, register_count=60, device_address=batt_addr),
+                        timeout=probe_timeout,
+                        retries=probe_retries,
+                    )
+                if not self.plant.register_caches.get(batt_addr):
+                    continue
+            try:
+                if not Battery.from_register_cache(self.plant.register_caches[batt_addr]).is_valid():
+                    _logger.debug(
+                        "detect: battery probe responded at 0x%02x but is_valid()=False — skipping",
+                        batt_addr,
+                    )
+                    continue
+            except (KeyError, ValueError):
+                continue
+            caps.lv_battery_addresses.append(batt_addr)
+        _logger.info(
+            "detect: lv_battery_addresses=[%s]",
+            ", ".join(f"0x{a:02x}" for a in caps.lv_battery_addresses),
+        )
+
     async def _detect(
         self,
         timeout: float,
@@ -885,45 +946,10 @@ class Client:
             ", ".join(f"0x{a:02x}" for a in caps.meter_addresses),
         )
 
-        # Step 4 — LV battery detection. Battery pack #1 is at 0x32, additional batteries at
-        # 0x33–0x37 (the inverter itself lives at 0x11, not 0x32 — issues #119/#189). All
-        # slots are validated via Battery.is_valid(). Skipped for HV systems (handled at step 2)
-        # and EMS plant controllers (don't expose IR at the inverter address — see #86).
-        # Per-slot (not break-on-fail) for the same reasons as the meter sweep above: battery
-        # addresses can be non-contiguous (DIP-switch misconfiguration) and a transient BMS
-        # timeout on pack N must not silently drop pack N+1 onward. Cold detect is affordable
-        # since the probe budget only applies on cold sweeps; warm/hinted starts skip this.
+        # Step 4 — LV battery + LV BCU detection. Skipped for HV systems (handled at step 2) and
+        # EMS plant controllers (don't expose IR at the inverter address — see #86).
         if not caps.is_hv and not caps.is_ems:
-            await self.send_request_and_await_response(
-                ReadInputRegistersRequest(base_register=60, register_count=60, device_address=0x32),
-                timeout=timeout,
-                retries=retries,
-            )
-            batt_candidates = prior.lv_battery_addresses if prior is not None else range(0x32, 0x38)
-            for batt_addr in batt_candidates:
-                if batt_addr > 0x32:
-                    if not await self._probe(
-                        ReadInputRegistersRequest(base_register=60, register_count=60, device_address=batt_addr),
-                        timeout=probe_timeout,
-                        retries=probe_retries,
-                    ):
-                        continue
-                    if not self.plant.register_caches.get(batt_addr):
-                        continue
-                try:
-                    if not Battery.from_register_cache(self.plant.register_caches[batt_addr]).is_valid():
-                        _logger.debug(
-                            "detect: battery probe responded at 0x%02x but is_valid()=False — skipping",
-                            batt_addr,
-                        )
-                        continue
-                except (KeyError, ValueError):
-                    continue
-                caps.lv_battery_addresses.append(batt_addr)
-            _logger.info(
-                "detect: lv_battery_addresses=[%s]",
-                ", ".join(f"0x{a:02x}" for a in caps.lv_battery_addresses),
-            )
+            await self._detect_lv_batteries(caps, prior, timeout, retries, probe_timeout, probe_retries)
 
             # Step 4b — LV BCU page probe (#241).
             await self._detect_lv_bcu(caps, prior, probe_timeout, probe_retries)

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -620,7 +620,9 @@ class Plant(GivEnergyBaseModel):
     # value held). A held bank never updates the cache, so the next poll re-compares against
     # the same last-good; the held value commits only if the device reads it again within
     # threshold (genuine step persists) rather than snapping back (transient splice reverts).
-    # Ephemeral runtime state, rebuilt with a fresh Plant on reconnect; not serialised.
+    # Ephemeral runtime state, not serialised. It lives on the Plant instance and persists across
+    # connect()/close()/detect() — Client builds self.plant once (__init__) and reconnecting reuses
+    # it, so this state is cleared only by constructing a new Client/Plant, never by a reconnect.
     _splice_escrow: dict[int, tuple[int, int]] = PrivateAttr(default_factory=dict)
 
     # Cold-start baseline confirmation (#289): per battery device address, the first full bank seen
@@ -630,7 +632,8 @@ class Plant(GivEnergyBaseModel):
     # garbage each poll — never corroborates and never poisons the baseline. Most-recent-wins on a
     # disagreement. A persistently-identical scalar-immutable poison corroborates and is left to the
     # #286 heal; a corroborated temp-zero corruption cohort is refused outright (it would hard-reject
-    # all healthy data, which the scalar heal can't recover). Ephemeral; rebuilt on reconnect.
+    # all healthy data, which the scalar heal can't recover). Ephemeral; not serialised; persists
+    # across reconnect on the same Plant instance (see _splice_escrow).
     _splice_pending_baseline: dict[int, tuple[list[int], datetime]] = PrivateAttr(default_factory=dict)
 
     # Splice-guard observation clock (#256): per battery device address, the ingestion time of the
@@ -638,8 +641,8 @@ class Plant(GivEnergyBaseModel):
     # keys off this, NOT the last accepted commit: a sustained corruption run (every poll rejected)
     # leaves the last-good commit ageing past the bypass window, but keeps arriving each poll, so
     # this clock stays ~one poll old and the bypass never fires. Only a genuine polling gap (real
-    # outage, no banks at all) makes it stale and resets to cold-start adoption. Ephemeral; resets
-    # with a fresh Plant on reconnect; not serialised.
+    # outage, no banks at all) makes it stale and resets to cold-start adoption. Ephemeral; not
+    # serialised; persists across reconnect on the same Plant instance (see _splice_escrow).
     _splice_last_seen: dict[int, datetime] = PrivateAttr(default_factory=dict)
 
     # Scalar-immutable poison-recovery streak (#281): per battery device address,

--- a/tests/client/test_detect.py
+++ b/tests/client/test_detect.py
@@ -536,7 +536,7 @@ async def test_detect_enumerates_battery_held_on_first_frame():
 
     client = _make_client()
     _prime_cache(client, 0x11, {HR(0): 0x2001, HR(21): 0})
-    _prime_battery_serial(client, 0x32)  # master commits first-read via the inverter getter
+    _prime_battery_serial(client, 0x32)  # primary pack commits first-read via the inverter getter
     probes: list[int] = []
 
     async def _probe_side_effect(request, *, timeout, retries):

--- a/tests/client/test_detect.py
+++ b/tests/client/test_detect.py
@@ -519,6 +519,78 @@ async def test_detect_finds_lv_batteries():
     assert caps.lv_battery_addresses == [0x32, 0x33]
 
 
+@pytest.mark.asyncio
+async def test_detect_enumerates_battery_held_on_first_frame():
+    """detect() must enumerate a battery whose first probe is cold-start-held (#233/#289).
+
+    The #289 cold-start guard holds the first bank against an empty cache (the cache stays empty,
+    pending a corroborating re-read). detect() probes each address once, so without a confirming
+    read the address is dropped at the ``register_caches`` gate and refresh() never re-polls it — a
+    permanent hold for a recovered/returned pack (hass#233). The confirming re-read corroborates a
+    healthy bank so the returned battery re-enumerates within a single detect pass.
+
+    Unlike test_detect_finds_lv_batteries, this drives the response through the REAL guard via
+    plant.update() rather than pre-priming the cache — that is what exercises the cold-start hold.
+    """
+    from tests.model.test_plant import _coherent_battery_bank, _make_ir_pdu
+
+    client = _make_client()
+    _prime_cache(client, 0x11, {HR(0): 0x2001, HR(21): 0})
+    _prime_battery_serial(client, 0x32)  # master commits first-read via the inverter getter
+    probes: list[int] = []
+
+    async def _probe_side_effect(request, *, timeout, retries):
+        addr = request.device_address
+        if addr != 0x33:
+            return False
+        probes.append(addr)
+        # First call: the guard holds it (cache stays empty). The confirming re-read feeds the same
+        # healthy bank, which corroborates and commits.
+        client.plant.update(
+            _make_ir_pdu(_coherent_battery_bank(), device_address=0x33, base_register=60, register_count=60)
+        )
+        return True
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
+        with patch.object(client, "_probe", side_effect=_probe_side_effect):
+            caps = await client.detect()
+
+    assert 0x33 in caps.lv_battery_addresses, "a cold-start-held battery must still be enumerated"
+    assert probes.count(0x33) == 2, "detect must issue one confirming re-read when the first frame is held"
+
+
+@pytest.mark.asyncio
+async def test_detect_does_not_enumerate_flapping_battery():
+    """A battery that responds but never corroborates is NOT enumerated (#289 safety at detect layer).
+
+    The confirming re-read must not enumerate a pack whose two reads disagree by >=2 physics-impossible
+    deltas (a sub-bus splice / flapping BMS) — it stays held with an empty cache, exactly as a transient
+    splice should.
+    """
+    from tests.model.test_plant import _coherent_battery_bank, _make_ir_pdu
+
+    client = _make_client()
+    _prime_cache(client, 0x11, {HR(0): 0x2001, HR(21): 0})
+    _prime_battery_serial(client, 0x32)
+    # Two disagreeing reads: healthy, then the temp-zero corruption cohort (4 temps 250→0 = >=2 physics).
+    banks = [_coherent_battery_bank(), _coherent_battery_bank({76 + i: 0 for i in range(4)})]
+    calls = {"n": 0}
+
+    async def _probe_side_effect(request, *, timeout, retries):
+        if request.device_address != 0x33:
+            return False
+        bank = banks[min(calls["n"], len(banks) - 1)]
+        calls["n"] += 1
+        client.plant.update(_make_ir_pdu(bank, device_address=0x33, base_register=60, register_count=60))
+        return True
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
+        with patch.object(client, "_probe", side_effect=_probe_side_effect):
+            caps = await client.detect()
+
+    assert 0x33 not in caps.lv_battery_addresses, "a flapping/uncorroborated battery must not enumerate"
+
+
 async def test_detect_finds_lv_bcu():
     """A populated BCU block at 0x31 sets lv_bcu_address (#241)."""
     client = _make_client()


### PR DESCRIPTION
## Summary

Fixes givenergy-hass#233: a recovered LV battery (a slave pack taken offline for a manual
recharge, returned healthy and visible in GE's own app) would not re-list in Home Assistant,
deterministically — surviving retries, an inverter restart, and a full HACS reinstall.

## Root cause

`detect()` probes each LV battery address once. The #289 cold-start splice guard holds that
first bank against an empty cache (`register_caches[addr]` stays empty pending a corroborating
second read — the anti-poison contract). The detect gate then drops the address from
`lv_battery_addresses`, and `refresh()` only polls the enumerated list — so the address never
gets its second read and stays held forever. A fresh `Client`/`Plant` (reinstall) re-enters the
identical one-probe hold, so there is no operator workaround.

(The master at 0x32 is unaffected: during a cold detect `capabilities is None`, so its bank
routes to the inverter getter and bypasses the battery splice guard, committing first-read.)

## Fix (stopgap)

In detect()'s LV sweep, when a probed address is still uncached (cold-start-held), issue **one**
confirming re-read. A healthy returned battery corroborates and commits within the detect pass;
a flapping/spliced bank fails to corroborate and correctly stays out — so the #289 anti-poison
guarantee is fully preserved. The LV sweep is extracted to `Client._detect_lv_batteries`
(mirroring `_detect_lv_bcu` / `_detect_hv_bmu_modules`) to keep `_detect` within the complexity
budget and make the cold-start path exercisable.

The principled fix — decoupling topology enumeration from data adoption (a present-but-
uncorroborated device is the same shape as the transiently-absent device in #213) — is deferred
to #213 and the #106 device-graph, which will remove this stopgap.

Also corrects three `plant.py` splice-state comments that wrongly claimed the state "resets on
reconnect": it lives on the Plant instance and persists across `connect()`/`close()`/`detect()`,
cleared only by a new Client/Plant.

## Tests

Detect-level regression that drives the probe response through the **real** guard via
`plant.update()` (existing detect tests pre-prime caches and so never exercised the hold):
- a cold-start-held battery now enumerates within one detect pass — **fails before this change**
- a non-corroborating (flapping/spliced) battery is still not enumerated (#289 safety at the
  detect layer)

Read-path only (IR reads); no register writes, no write-surface change.

## Test plan
- [ ] `uv run pytest` — 1328 passing
- [ ] `tox` green py311–py314 (+ lint, format, build)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LV battery detection so batteries are more reliably found during connect/detect flows.
  * Added an extra confirmation read for batteries that initially appear present but have incomplete data, reducing false removals.
  * Prevents unstable or inconsistent battery responses from being incorrectly listed as detected.

* **Documentation**
  * Clarified that certain plant state is retained across reconnects on the same instance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->