### PR TITLE
fix: split single-phase fault_code into inverter_fault_code + inverter_warning_code (#330)

### DIFF
--- a/givenergy_modbus/model/inverter.py
+++ b/givenergy_modbus/model/inverter.py
@@ -905,7 +905,14 @@ class SinglePhaseInverterRegisterGetter(RegisterGetter):
         "e_battery_charge_today_alt1": Def(C.deci, None, IR(36)),
         "e_battery_discharge_today_alt1": Def(C.deci, None, IR(37)),
         "countdown": Def(C.uint16, None, IR(38)),
-        "fault_code": Def(C.uint32, (C.hex, 8), IR(39), IR(40)),
+        # IR(39)/IR(40) are two distinct 16-bit words per the GivEnergy installer app
+        # v1.154.3 (IR39 INVERTER_FAULT_CODE, IR40 INVERTER_WARNING_CODE), not one uint32.
+        # The old combined "fault_code" (uint32 over both) is kept as a deprecated alias on
+        # SinglePhaseInverter that recombines them. Left as raw hex words — IR(39)'s bitfield
+        # enum isn't confirmed, and the separate HR(223/224) inverter_fault_messages source
+        # is unreconciled (see #330), so no message decode here.
+        "inverter_fault_code": Def(C.uint16, (C.hex, 4), IR(39)),
+        "inverter_warning_code": Def(C.uint16, (C.hex, 4), IR(40)),
         "t_inverter_heatsink": Def(C.deci, None, IR(41), min=-40.0, max=100.0),
         # House load / consumption at the busbar, independently sensed — empirically NOT
         # a derived IR(24)−IR(30) identity (residual non-zero in 68% of samples, though
@@ -1281,6 +1288,25 @@ class SinglePhaseInverter(  # type: ignore[valid-type,misc]
             stacklevel=2,
         )
         return self.work_time_total_hours  # type: ignore[attr-defined,no-any-return]
+
+    # Plain @property so the deprecated alias doesn't appear in model_dump().
+    # IR(39)/IR(40) were decoded as one uint32 "fault_code"; the installer app names them as
+    # two distinct words (IR39 fault, IR40 warning), now split into inverter_fault_code /
+    # inverter_warning_code. This alias recombines them into the old 8-hex form for a release.
+    @property
+    def fault_code(self) -> str | None:
+        """Deprecated alias for `inverter_fault_code` + `inverter_warning_code` (recombined)."""
+        warnings.warn(
+            "SinglePhaseInverter.fault_code is deprecated; use inverter_fault_code "
+            "(IR39) and inverter_warning_code (IR40)",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        fault = self.inverter_fault_code  # type: ignore[attr-defined]
+        warning = self.inverter_warning_code  # type: ignore[attr-defined]
+        if fault is None or warning is None:
+            return None
+        return f"{fault}{warning}"
 
     # Plain @property so the deprecated alias doesn't appear in model_dump().
     # HR(199) was decoded as enable_standard_self_consumption_logic (GivTCP-era guess);

--- a/tests/model/test_inverter.py
+++ b/tests/model/test_inverter.py
@@ -164,7 +164,8 @@ def test_inverter():
             "e_battery_charge_today_alt1": None,
             "e_battery_discharge_today_alt1": None,
             "countdown": None,
-            "fault_code": None,
+            "inverter_fault_code": None,
+            "inverter_warning_code": None,
             "t_inverter_heatsink": None,
             "p_load_demand": None,
             "p_grid_apparent": None,
@@ -715,7 +716,8 @@ def test_from_registers(register_cache):
         "e_battery_charge_today_alt1": 9.0,  # IR(36)
         "e_battery_discharge_today_alt1": 8.9,  # IR(37)
         "countdown": 30,
-        "fault_code": "00000000",
+        "inverter_fault_code": "0000",
+        "inverter_warning_code": "0000",
         "t_inverter_heatsink": 22.2,
         "p_load_demand": 342,
         "p_grid_apparent": 680,
@@ -1202,7 +1204,8 @@ def test_from_registers_actual_data(register_cache_inverter_daytime_discharging_
         "e_battery_charge_today_alt1": 9.1,  # IR(36)
         "e_battery_discharge_today_alt1": 3.4,  # IR(37)
         "countdown": 0,
-        "fault_code": "00000000",
+        "inverter_fault_code": "0000",
+        "inverter_warning_code": "0000",
         "t_inverter_heatsink": 24.4,
         "p_load_demand": 515,
         "p_grid_apparent": 554,
@@ -1512,6 +1515,38 @@ def test_single_phase_inverter_p_pv_and_e_pv_day():
     inv = SinglePhaseInverter.from_register_cache(cache)
     assert inv.p_pv() == 1500  # type: ignore[attr-defined]
     assert inv.e_pv_day() == 2.0  # type: ignore[attr-defined]
+
+
+def test_fault_code_split_and_deprecated_alias():
+    """IR(39)/IR(40) split into inverter_fault_code/inverter_warning_code; fault_code recombines."""
+    from givenergy_modbus.model.register import IR
+
+    cache = RegisterCache({IR(39): 0x1234, IR(40): 0x5678})
+    inv = SinglePhaseInverter.from_register_cache(cache)
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        assert inv.inverter_fault_code == "1234"  # type: ignore[attr-defined]
+        assert inv.inverter_warning_code == "5678"  # type: ignore[attr-defined]
+    assert [x for x in w if issubclass(x.category, DeprecationWarning)] == []
+
+    dumped = inv.model_dump()
+    assert dumped["inverter_fault_code"] == "1234"
+    assert dumped["inverter_warning_code"] == "5678"
+    assert "fault_code" not in dumped
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        assert inv.fault_code == "12345678"  # recombined to the old 8-hex form
+    deprecations = [x for x in w if issubclass(x.category, DeprecationWarning)]
+    assert len(deprecations) == 1
+    assert "inverter_fault_code" in str(deprecations[0].message)
+
+    # Either word absent → the recombined alias is None (matches the old uint32 None behaviour).
+    empty = SinglePhaseInverter.from_register_cache(RegisterCache())
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        assert empty.fault_code is None
 
 
 def _cache(**entries):

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -1291,7 +1291,8 @@ def test_from_actual():
         "e_battery_charge_today_alt1": 5.7,  # IR(36)
         "e_battery_discharge_today_alt1": 5.9,  # IR(37)
         "countdown": 0,
-        "fault_code": "00000000",
+        "inverter_fault_code": "0000",
+        "inverter_warning_code": "0000",
         "t_inverter_heatsink": 32.2,
         "p_load_demand": 745,
         "p_grid_apparent": 654,


### PR DESCRIPTION
## Summary

Closes #330. `SinglePhaseInverterRegisterGetter` decoded IR(39)/IR(40) as a single `uint32`
`fault_code`. The GivEnergy installer app (v1.154.3) names them as two distinct 16-bit words:

- IR(39) `INVERTER_FAULT_CODE`
- IR(40) `INVERTER_WARNING_CODE`

so the combined value conflated a fault word and a warning word.

## Change

- Split into `inverter_fault_code` (IR39) and `inverter_warning_code` (IR40), each a raw 4-hex word.
- `fault_code` is kept as a **deprecated alias** on `SinglePhaseInverter` that warns and recombines
  the two words into the original 8-hex form (so existing consumers keep working for a release).

Left deliberately out of scope:
- **No message decode.** IR(39)'s bitfield enum isn't confirmed, so the new fields stay raw hex
  rather than risk a wrong decode.
- **HR(223)/HR(224) untouched.** `inverter_fault_messages` decodes HR(223)/HR(224); the installer
  reference points the inverter fault word at IR(39). Whether those are two sources for the same
  thing or one is stale is unresolved — noted in #330, not guessed at here.

## Tests

- New `test_fault_code_split_and_deprecated_alias`: the two words decode independently, appear in
  `model_dump()` (and `fault_code` does not), and the deprecated `fault_code` recombines to the old
  8-hex form with exactly one `DeprecationWarning` (None when either word is absent).
- Updated the four model-dump snapshots (three in `test_inverter.py`, one in `test_plant.py`).

Read-path only (IR reads); no register writes.

## Test plan
- [x] `uv run pytest` — 1329 passing
- [x] `tox` green py311–py314 (+ lint, format, build)