### PR TITLE
fix: mock-server fails loud on a capture that parses to zero frames (#322)

### DIFF
--- a/givenergy_modbus/testing/mock_plant.py
+++ b/givenergy_modbus/testing/mock_plant.py
@@ -69,19 +69,32 @@ _FALLBACK_SERIAL = "MK0000G000"
 def _iter_capture_frames(*paths: str | Path) -> list[bytes]:
     """Return complete rx frames from one or more capture ``.log`` files, ts-sorted.
 
-    Each line is ``<ts> rx <hex>``; the hex is a socket chunk, so frames may span lines.
-    We concatenate the rx stream in timestamp order and split on the frame marker using
-    the MBAP length field — the same framing the wire uses.
+    Two line shapes are accepted: the canonical ``<ts> rx <hex>`` and the integration
+    capture's ``rx: <hex>`` / ``tx: <hex>`` (no timestamp, colon-suffixed direction). Only
+    rx lines are kept; the hex is a socket chunk, so frames may span lines, so we concatenate
+    the rx stream in timestamp order and split on the frame marker using the MBAP length
+    field — the same framing the wire uses. Timestamp-less lines sort stably in file order.
     """
     entries: list[tuple[str, bytes]] = []
     for path in paths:
         for line in Path(path).read_text(encoding="utf-8").splitlines():
             parts = line.split()
-            if len(parts) >= 3 and parts[1] == "rx":
-                try:
-                    entries.append((parts[0], bytes.fromhex(parts[-1])))
-                except ValueError:
-                    continue
+            if len(parts) < 2:
+                continue
+            # Direction token is either parts[0] ("rx:"/"tx:", no timestamp) or parts[1]
+            # ("rx"/"tx", canonical with timestamp). Tolerate a trailing colon either way.
+            if parts[0].rstrip(":").lower() in ("rx", "tx"):
+                direction, ts = parts[0].rstrip(":").lower(), ""
+            elif len(parts) >= 3 and parts[1].rstrip(":").lower() in ("rx", "tx"):
+                direction, ts = parts[1].rstrip(":").lower(), parts[0]
+            else:
+                continue
+            if direction != "rx":
+                continue
+            try:
+                entries.append((ts, bytes.fromhex(parts[-1])))
+            except ValueError:
+                continue
     entries.sort(key=lambda e: e[0])
     buf = b"".join(raw for _, raw in entries)
 
@@ -110,8 +123,17 @@ def plant_from_capture(*paths: str | Path) -> Plant:
     ``plant.register_caches`` (keyed by device address) is exactly what the library would
     hold after polling the real plant.
     """
+    frames = _iter_capture_frames(*paths)
+    if not frames:
+        # Zero frames means none of the lines matched the accepted shapes — almost always a
+        # capture-format mismatch. Fail loudly rather than silently serving an empty plant
+        # (which would report "0 devices seeded" and answer "absent" for every read). See #322.
+        joined = ", ".join(str(p) for p in paths)
+        raise ValueError(
+            f"No rx frames parsed from capture(s): {joined}. Expected lines shaped '<ts> rx <hex>' or 'rx: <hex>'."
+        )
     plant = Plant()
-    for frame in _iter_capture_frames(*paths):
+    for frame in frames:
         try:
             pdu = ClientIncomingMessage.decode_bytes(frame)
         except Exception:  # noqa: BLE001  # nosec B112 — skipping an undecodable frame is intended  # pragma: no cover

--- a/tests/client/test_mock_plant_integration.py
+++ b/tests/client/test_mock_plant_integration.py
@@ -23,7 +23,7 @@ from givenergy_modbus.pdu import (
     WriteHoldingRegisterRequest,
 )
 from givenergy_modbus.testing import MockPlant
-from givenergy_modbus.testing.mock_plant import _iter_capture_frames
+from givenergy_modbus.testing.mock_plant import _iter_capture_frames, plant_from_capture
 
 _CAPTURES = Path(__file__).parents[1] / "fixtures" / "captures"
 
@@ -130,6 +130,24 @@ def test_iter_capture_frames_skips_non_rx(tmp_path: Path):
     log = tmp_path / "tx.log"
     log.write_text("2026-01-01T00:00:00Z tx 5959000100060102ab0000003c000f\n")
     assert _iter_capture_frames(log) == []
+
+
+def test_iter_capture_frames_tolerates_colon_rx_form(tmp_path: Path):
+    """The integration capture's ``rx:/tx: <hex>`` form (no timestamp) is parsed; tx excluded (#322)."""
+    good_frame = ReadHoldingRegistersRequest(base_register=0, register_count=60, device_address=0x11).encode()
+    log = tmp_path / "colon.log"
+    # Blank and single-token lines are skipped; only the rx line yields a frame (tx excluded).
+    log.write_text(f"\nheader-line\ntx: {good_frame.hex()}\nrx: {good_frame.hex()}\n")
+    frames = _iter_capture_frames(log)
+    assert frames == [good_frame]  # only the rx line, decoded as one frame
+
+
+def test_plant_from_capture_raises_on_zero_frames(tmp_path: Path):
+    """A capture that parses to zero rx frames fails loudly rather than serving an empty plant (#322)."""
+    log = tmp_path / "wrongformat.log"
+    log.write_text("nothing here matches the expected line shape\n")
+    with pytest.raises(ValueError, match="No rx frames parsed"):
+        plant_from_capture(log)
 
 
 def test_iter_capture_frames_handles_junk_before_marker(tmp_path: Path):

--- a/tests/model/test_three_phase_from_capture.py
+++ b/tests/model/test_three_phase_from_capture.py
@@ -13,52 +13,27 @@ real wire→model path, and it locks in the fixes these frames drove:
 See ``tests/fixtures/captures/three_phase_hv_a/README.md`` for provenance.
 """
 
-import asyncio
 from pathlib import Path
 
 import pytest
 
-from givenergy_modbus.framer import ClientFramer
 from givenergy_modbus.model.hv_bcu import Bcu
 from givenergy_modbus.model.inverter_threephase import ThreePhaseInverter
 from givenergy_modbus.model.plant import Plant
-from givenergy_modbus.pdu.transparent import TransparentResponse
+from givenergy_modbus.testing.mock_plant import plant_from_capture
 
 _CAPTURE = Path(__file__).parents[1] / "fixtures" / "captures" / "three_phase_hv_a" / "giv3hy11_hass174_180s.txt"
-
-
-def _frames() -> list[bytes]:
-    """Read frames from the integration's ``tx:/rx: <hex>`` capture format."""
-    frames: list[bytes] = []
-    for line in _CAPTURE.read_text(encoding="utf-8").splitlines():
-        for prefix in ("rx: ", "tx: "):
-            if line.startswith(prefix):
-                try:
-                    frames.append(bytes.fromhex(line[len(prefix) :]))
-                except ValueError:
-                    pass
-    return frames
-
-
-async def _replay() -> Plant:
-    """Decode the capture into a bare (no-capabilities) Plant — raw caches keyed by wire address."""
-    framer = ClientFramer()
-    plant = Plant()
-    for raw in _frames():
-        async for pdu in framer.decode(raw):
-            if isinstance(pdu, TransparentResponse) and not pdu.error:
-                plant.update(pdu)
-    return plant
 
 
 @pytest.fixture(scope="module")
 def replayed_plant() -> Plant:
     """Decode the capture once for the module (the frames are immutable, so share the Plant).
 
-    A plain sync fixture wrapping ``asyncio.run`` rather than a module-scoped async fixture,
-    which is brittle under pytest-asyncio's per-function event-loop scoping.
+    Routed through the shared ``plant_from_capture`` loader, which now parses this fixture's
+    ``rx:/tx: <hex>`` line form directly (#322) — so this also regression-tests that the
+    integration capture loads through the same path ``mock-server`` uses.
     """
-    return asyncio.run(_replay())
+    return plant_from_capture(_CAPTURE)
 
 
 @pytest.mark.timeout(15)


### PR DESCRIPTION
## Summary

Closes #322. `MockPlant.from_capture` → `_iter_capture_frames` only parsed the canonical
`<ts> rx <hex>` line shape. The one HV fixture committed in the integration `rx: <hex>` / `tx: <hex>`
form (no leading timestamp, colon-suffixed direction) matched nothing → zero frames → an empty mock,
while `mock-server` happily started and logged "0 devices seeded" and answered "absent" for every
read. A format mismatch looked like a healthy-but-empty plant.

## Change

- **`_iter_capture_frames` tolerates the `rx:/tx: <hex>` form** (only `rx` kept), so that fixture
  now loads through the same path `mock-server` uses. The canonical `<ts> rx <hex>` shape is
  unchanged.
- **`plant_from_capture` raises on zero frames**, naming the path(s) and the accepted line shapes —
  so a format mismatch fails loudly rather than silently serving an empty plant. (Kept out of
  `_iter_capture_frames` itself, which legitimately returns `[]` for "no rx lines" — that contract
  is covered by existing unit tests.)
- **Consolidated `test_three_phase_from_capture.py`** onto the shared `plant_from_capture` loader,
  removing the local `rx:/tx:` workaround it had been carrying. Its existing value assertions
  (battery decode, HV BCU, grid block) now double as a regression test that the fixture loads
  end-to-end through the shared loader.

## Tests

- New: the `rx:/tx:` colon form parses (rx only); a capture that parses to zero frames raises
  `ValueError`.
- The three-phase decode tests pass unchanged through the shared loader — proving the loader change
  produces byte-identical frames.

Tooling only; no library runtime change.

## Test plan
- [x] `uv run pytest` — 1330 passing
- [x] `tox` green py311–py314 (+ lint, format, build)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved capture-file parsing to handle more line formats, including `rx:`/`tx:` entries without timestamps and mixed direction tokens.
  * Ensured only received data is used when rebuilding frames, with entries processed in the right order.
  * Loading from an empty capture now fails clearly instead of creating an unusable empty plant, helping surface bad input sooner.

* **Tests**
  * Added coverage for colon-separated capture lines and empty-capture failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->