### PR TITLE
fix: gate HR311/317 (export priority, EPS enable) on has_ac_config_block (#297)

### DIFF
--- a/givenergy_modbus/client/commands.py
+++ b/givenergy_modbus/client/commands.py
@@ -1362,13 +1362,16 @@ def restore_factory_defaults(*, confirm: bool = False) -> list[WriteHoldingRegis
 
 # HR(300-359) AC-output config-block writes that are gated on capabilities.has_ac_config_block
 # rather than the model-class allowlist — one_shot_command unions these into the safe set only when
-# the detected model exposes the block (Model.AC / All-in-One), never for a DC-coupled hybrid or an
-# undetected client (#295/#296 review). Currently just the AC charge/discharge limits; HR311/317
-# (also HR300-359) predate the gate and stay in the universal set pending a separate cleanup.
+# the detected model exposes the block (Model.AC / All-in-One), never for a DC-coupled hybrid, a
+# three-phase unit, or an undetected client (#295/#296 review). The AC charge/discharge limits plus
+# export priority (HR311) and EPS enable (HR317) — the whole HR(300-359) writable block is now gated
+# here (#297); 311/317 were previously in the universal set, accepted on DC hybrids and undetected.
 _AC_CONFIG_WRITE_SAFE_REGISTERS: frozenset[int] = frozenset(
     {
+        RegisterMap.EXPORT_PRIORITY,  # 311
         RegisterMap.BATTERY_CHARGE_LIMIT_AC,  # 313
         RegisterMap.BATTERY_DISCHARGE_LIMIT_AC,  # 314
+        RegisterMap.ENABLE_EPS,  # 317
     }
 )
 
@@ -1407,19 +1410,16 @@ class _InverterCommands:
     # Single-phase shape: contains HR(96/110/116) and single-phase slot pairs (94/95,
     # 31/32 charge; 56/57, 44/45 discharge). ThreePhaseInverter replaces these via
     # _ThreePhaseCommands.WRITE_SAFE_REGISTERS (defined below, overrides this per MRO).
-    # Excludes 313/314 (BATTERY_*_LIMIT_AC): these belong to the HR(300-359) AC-output config
-    # block, absent (reads time out) on DC-coupled hybrids, so they are gated on
+    # Excludes 311/313/314/317: these belong to the HR(300-359) AC-output config block, absent
+    # (reads time out) on DC-coupled hybrids, so the whole writable block is gated on
     # capabilities.has_ac_config_block at the client boundary instead — one_shot_command unions
-    # _AC_CONFIG_WRITE_SAFE_REGISTERS in for Model.AC/AIO only, never a DC hybrid or an undetected
-    # client (#295/#296 review). (HR311/317 are also HR300-359 registers but predate this and stay
-    # in the universal set; folding them into the same gate is a separate cleanup.) Also excludes
-    # 318-320 (pause mode, firmware-gated), 1078/1109/1111-1123 (native three-phase), and
-    # 2040/2062-2069 (EMS).
+    # _AC_CONFIG_WRITE_SAFE_REGISTERS in for Model.AC/AIO only, never a DC hybrid, three-phase, or an
+    # undetected client (#295/#296/#297 review). Also excludes 318-320 (pause mode, firmware-gated),
+    # 1078/1109/1111-1123 (native three-phase), and 2040/2062-2069 (EMS).
     WRITE_SAFE_REGISTERS: ClassVar[frozenset[int]] = frozenset(
         {
             20,  # ENABLE_CHARGE_TARGET
             27,  # BATTERY_POWER_MODE
-            311,  # EXPORT_PRIORITY (AC-coupled; confirmed writable via hass#52 portal observations)
             29,  # SOC_FORCE_ADJUST
             31,
             32,  # CHARGE_SLOT_2
@@ -1477,7 +1477,6 @@ class _InverterCommands:
             295,
             297,
             298,  # DISCHARGE_SLOT_3..10
-            317,  # ENABLE_EPS (AC-coupled; confirmed writable via hass#52 portal observations)
         }
     )
 

--- a/tests/client/test_client_write_safety.py
+++ b/tests/client/test_client_write_safety.py
@@ -110,6 +110,50 @@ def test_battery_limit_ac_commands_encode():
         req.encode()
 
 
+# HR 311/317 = EXPORT_PRIORITY / ENABLE_EPS — also HR(300-359) AC-output config-block registers.
+# #297 folds them into the same has_ac_config_block gate as 313/314, so they no longer ride the
+# universal allowlist (where DC hybrids and undetected clients accepted them).
+_EXPORT_EPS_REGS = (311, 317)
+
+
+def test_export_priority_eps_gated_not_universal():
+    """311/317 are AC-config-gated, not in the universal or three-phase model allowlists (#297)."""
+    from givenergy_modbus.client.commands import _AC_CONFIG_WRITE_SAFE_REGISTERS
+
+    for reg in _EXPORT_EPS_REGS:
+        assert reg in _AC_CONFIG_WRITE_SAFE_REGISTERS
+        assert reg not in _InverterCommands.WRITE_SAFE_REGISTERS
+        assert reg not in _ThreePhaseCommands.WRITE_SAFE_REGISTERS
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model", [Model.AC, Model.ALL_IN_ONE])
+async def test_ac_config_models_accept_export_priority_eps_writes(model):
+    """Models that expose the HR(300-359) block (AC, AIO) may write HR311/317 (#297)."""
+    client = _client(_caps(model))
+    for reg in _EXPORT_EPS_REGS:
+        await client.one_shot_command([WriteHoldingRegisterRequest(reg, 0)], dry_run=True)  # must not raise
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model", [Model.HYBRID_GEN1, Model.AC_3PH, Model.HYBRID_3PH])
+async def test_non_ac_config_models_reject_export_priority_eps_writes(model):
+    """HR311/317 must be rejected unless has_ac_config_block and not three-phase (#297)."""
+    client = _client(_caps(model))
+    for reg in _EXPORT_EPS_REGS:
+        with pytest.raises(InvalidPduState, match=rf"HR\({reg}\)"):
+            await client.one_shot_command([WriteHoldingRegisterRequest(reg, 0)], dry_run=True)
+
+
+@pytest.mark.asyncio
+async def test_undetected_rejects_export_priority_eps_writes():
+    """An undetected client (no capabilities) must reject HR311/317 — conservative fallback (#297)."""
+    client = _client(None)
+    for reg in _EXPORT_EPS_REGS:
+        with pytest.raises(InvalidPduState, match=rf"HR\({reg}\)"):
+            await client.one_shot_command([WriteHoldingRegisterRequest(reg, 0)], dry_run=True)
+
+
 # ---------------------------------------------------------------------------
 # Three-phase model
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #297. HR311 (`EXPORT_PRIORITY`) and HR317 (`ENABLE_EPS`) are HR(300-359) AC-output
config-block registers — the same family as HR313/314, which #296 moved behind the
`has_ac_config_block` capability gate. 311/317 predated that gate and stayed in the universal
`_InverterCommands.WRITE_SAFE_REGISTERS`, so they were accepted for **DC-coupled hybrids, three-phase
units, and undetected clients** — exactly the imprecision #296 fixed for 313/314.

## Change

- Move `EXPORT_PRIORITY` (311) and `ENABLE_EPS` (317) from the universal
  `_InverterCommands.WRITE_SAFE_REGISTERS` into `_AC_CONFIG_WRITE_SAFE_REGISTERS`.
- `one_shot_command` (and the installer path) now admit them only when
  `capabilities.has_ac_config_block and not is_three_phase` — i.e. Model.AC / All-in-One — exactly
  like 313/314. The whole HR(300-359) writable block is now gated consistently.
- The PDU-level `WRITE_SAFE_REGISTERS` (Gate 2) keeps 311/317, mirroring how 313/314 are handled
  there; the model-awareness is the client-side gate (Gate 1), not the PDU.

## Behaviour change

DC-coupled hybrids, three-phase, and undetected clients now **reject** HR311/317 writes (previously
accepted). AC/AIO single-phase is unchanged. Three-phase EPS / export-priority, if it exists, lives
at three-phase addresses — not the single-phase HR311/317 — so nothing legitimate on 3ph regresses.

## Tests

Mirror the existing 313/314 gating tests for 311/317:
- 311/317 ∈ `_AC_CONFIG_WRITE_SAFE_REGISTERS`, ∉ universal and ∉ three-phase allowlists;
- AC / All-in-One accept the writes;
- HYBRID_GEN1, AC_3PH, HYBRID_3PH, and undetected all reject with `InvalidPduState`.

## Test plan
- [x] `uv run pytest` — 1335 passing
- [x] `tox` green py311–py314 (+ lint, format, build)