### PR TITLE
fix: scale e_inverter_export_total as 0.1 kWh (#182)

### DIFF
--- a/givenergy_modbus/model/inverter.py
+++ b/givenergy_modbus/model/inverter.py
@@ -841,7 +841,12 @@ class SinglePhaseInverterRegisterGetter(RegisterGetter):
         #
         # Holding Registers, block 4140-4199
         #
-        "e_inverter_export_total": Def(C.uint32, None, HR(4141), HR(4142)),
+        # 0.1 kWh per the v4.1.6 doc, matching the sibling cumulative totals (e_pv_total,
+        # e_battery_throughput) which already use C.deci; raw uint32 over-reported 10×. Not
+        # currently in the library poll path (max base HR240), so this corrects any direct read
+        # (#182). Doc-driven — no wire capture confirms the magnitude, as for the adjacent _alt
+        # energy block.
+        "e_inverter_export_total": Def(C.uint32, C.deci, HR(4141), HR(4142)),
         #
         # Input Registers, block 0-59
         #

--- a/tests/model/test_inverter.py
+++ b/tests/model/test_inverter.py
@@ -1549,6 +1549,16 @@ def test_fault_code_split_and_deprecated_alias():
         assert empty.fault_code is None
 
 
+def test_e_inverter_export_total_deci_scale():
+    """HR4141/4142 e_inverter_export_total is 0.1 kWh (C.deci), not raw uint32 (#182)."""
+    from givenergy_modbus.model.register import HR
+
+    # raw uint32 = 12345 → 1234.5 kWh under deci (was 12345 when read raw — 10× too high).
+    cache = RegisterCache({HR(4141): 0, HR(4142): 12345})
+    inv = SinglePhaseInverter.from_register_cache(cache)
+    assert inv.e_inverter_export_total == pytest.approx(1234.5)  # type: ignore[attr-defined]
+
+
 def _cache(**entries):
     from givenergy_modbus.model.register import IR
 


### PR DESCRIPTION
## Summary

Closes #182. `e_inverter_export_total` (HR4141/4142) was decoded as a raw `uint32`, but the v4.1.6
doc gives it `0.1 kWh` units — like the sibling cumulative totals `e_pv_total` (IR11/12) and
`e_battery_throughput` (IR6/7), which already use `C.deci`. Raw decoding over-reported by 10×.

## Change

Add `C.deci`. That's the established convention for these 0.1 kWh cumulative totals, and the
adjacent `_alt` energy block already uses it.

## Scope notes

- **Not live today.** The register sits above the library's poll path (max base HR240), so this
  corrects any *direct* read rather than a value the library currently surfaces.
- **Doc-driven.** No wire capture confirms the magnitude (the register is never populated in any
  fixture), and it's absent from both reverse-engineered app inventories — only the v4.1.6 doc covers
  it. The fix rests on the doc unit + sibling-total consistency.
- **HR4107/4108 `pv_power_setting` deliberately left raw.** Same doc unit, but it's a writable seed
  of undocumented effect (not a reported total), with no setter — its scale stays unresolved pending
  intent rather than changed blind. (Per the issue's own caution.)

## Tests

New `test_e_inverter_export_total_deci_scale`: raw uint32 12345 → 1234.5 kWh. Existing `None`
snapshots are unaffected (`deci(None)` is `None`).

## Test plan
- [x] `uv run pytest` — 1342 passing
- [x] `tox` green py311–py314 (+ lint, format, build)