### PR TITLE
feat: extend _DTC_RATED_POWER from the app v4.0.7 model-code table (#320)

### DIFF
--- a/givenergy_modbus/model/inverter.py
+++ b/givenergy_modbus/model/inverter.py
@@ -96,7 +96,10 @@ _DTC_PREFIX_TO_MODEL: dict[str, Model] = {
 AC_COUPLED_MODELS: frozenset[Model] = frozenset({Model.AC, Model.AC_3PH})
 
 # Rated AC output power in watts, keyed by 4-char hex device type code.
-# Sourced from britkat1980/giv_tcp:dev3; likely not exhaustive for all variants.
+# Original entries from britkat1980/giv_tcp:dev3. Entries marked "(app v4.0.7)" were added from
+# the GivEnergy app's authoritative HR(0) model-code table (#320): all 36 codes that overlapped the
+# existing table agreed exactly, so the additions are purely new codes (the table only resolves codes
+# that previously returned None). The two Gateway codes (7001/7002) carry no kW rating in the table.
 _DTC_RATED_POWER: dict[str, int] = {
     "2001": 5000,
     "2002": 4600,
@@ -117,12 +120,35 @@ _DTC_RATED_POWER: dict[str, int] = {
     "2302": 4600,
     "2303": 3600,
     "2304": 6000,
+    "2401": 5000,  # ALPS-CUBE-HY5.0 5KW (app v4.0.7)
+    "2402": 4600,  # ALPS-CUBE-HY5.0 4.6KW (app v4.0.7)
+    "2403": 3600,  # ALPS-CUBE-HY5.0 3.6KW (app v4.0.7)
+    "2404": 6000,  # ALPS-CUBE-HY5.0 6KW (app v4.0.7)
+    "2405": 7000,  # ALPS-CUBE-HY5.0 7KW (app v4.0.7)
+    "2406": 8000,  # ALPS-CUBE-HY5.0 8KW (app v4.0.7)
+    "2501": 5000,  # POL-HY-8.0-GL 5KW (app v4.0.7)
+    "2502": 4600,  # POL-HY-8.0-GL 4.6KW (app v4.0.7)
+    "2503": 3600,  # POL-HY-8.0-GL 3.6KW (app v4.0.7)
+    "2504": 6000,  # POL-HY-8.0-GL 6KW (app v4.0.7)
+    "2505": 7000,  # POL-HY-8.0-GL 7KW (app v4.0.7)
+    "2506": 8000,  # POL-HY-8.0-GL 8KW (app v4.0.7)
     "3001": 3000,
     "3002": 3600,
     "4001": 6000,
     "4002": 8000,
     "4003": 10000,
     "4004": 11000,
+    "4005": 15000,  # GIV-3HY-20-HV 15KW (app v4.0.7)
+    "4006": 20000,  # GIV-3HY-20-HV 20KW (app v4.0.7)
+    "4007": 5000,  # GIV-PM-30/50 5KW (app v4.0.7)
+    "4101": 30000,  # GIV-PM-30/50 30KW (app v4.0.7)
+    "4103": 50000,  # GIV-PM-30/50 50KW (app v4.0.7)
+    "6001": 6000,  # AcCouple 6KW (app v4.0.7)
+    "6002": 8000,  # AcCouple 8KW (app v4.0.7)
+    "6003": 10000,  # AcCouple 10KW (app v4.0.7)
+    "6004": 11000,  # AcCouple 11KW (app v4.0.7)
+    "6005": 15000,  # AcCouple 15KW (app v4.0.7)
+    "6006": 20000,  # AcCouple 20KW (app v4.0.7)
     "7001": 12000,
     "8001": 6000,
     "8002": 3600,
@@ -134,6 +160,10 @@ _DTC_RATED_POWER: dict[str, int] = {
     "8202": 8000,
     "8203": 10000,
     "8204": 12000,
+    "8205": 11000,  # All in One-HY 11KW (app v4.0.7)
+    "8301": 3600,  # Battery Ready 3.6KW (app v4.0.7)
+    "8302": 4600,  # Battery Ready 4.6KW (app v4.0.7)
+    "8303": 5000,  # Battery Ready 5KW (app v4.0.7)
     "8304": 6000,
 }
 

--- a/tests/model/test_inverter.py
+++ b/tests/model/test_inverter.py
@@ -1444,6 +1444,90 @@ def test_resolve_model(raw_dtc, arm_fw, expected):
     assert resolve_model(raw_dtc, arm_fw) is expected
 
 
+# Characterisation + extension lock for _DTC_RATED_POWER (#320). Drives the real inverter_max_power
+# property via HR(0). The pre-existing codes pin the table that previously had no test; the codes
+# commented "app v4.0.7" are the additive vendor entries (all overlaps agreed exactly, so existing
+# values are unchanged). Expected watts are written explicitly here, independent of the source dict.
+@pytest.mark.parametrize(
+    "code,watts",
+    [
+        ("2001", 5000),
+        ("2002", 4600),
+        ("2003", 3600),
+        ("2101", 5000),
+        ("2102", 4600),
+        ("2103", 3600),
+        ("2104", 6000),
+        ("2105", 7000),
+        ("2106", 8000),
+        ("2201", 5000),
+        ("2202", 4600),
+        ("2203", 3600),
+        ("2204", 6000),
+        ("2205", 7000),
+        ("2206", 8000),
+        ("2301", 5000),
+        ("2302", 4600),
+        ("2303", 3600),
+        ("2304", 6000),
+        ("2401", 5000),
+        ("2402", 4600),
+        ("2403", 3600),
+        ("2404", 6000),
+        ("2405", 7000),  # app v4.0.7
+        ("2406", 8000),
+        ("2501", 5000),
+        ("2502", 4600),
+        ("2503", 3600),
+        ("2504", 6000),  # app v4.0.7
+        ("2505", 7000),
+        ("2506", 8000),  # app v4.0.7
+        ("3001", 3000),
+        ("3002", 3600),
+        ("4001", 6000),
+        ("4002", 8000),
+        ("4003", 10000),
+        ("4004", 11000),
+        ("4005", 15000),
+        ("4006", 20000),
+        ("4007", 5000),
+        ("4101", 30000),
+        ("4103", 50000),  # app v4.0.7
+        ("6001", 6000),
+        ("6002", 8000),
+        ("6003", 10000),
+        ("6004", 11000),
+        ("6005", 15000),  # app v4.0.7
+        ("6006", 20000),  # app v4.0.7
+        ("7001", 12000),
+        ("8001", 6000),
+        ("8002", 3600),
+        ("8003", 5000),
+        ("8101", 6000),
+        ("8102", 8000),
+        ("8103", 10000),
+        ("8201", 6000),
+        ("8202", 8000),
+        ("8203", 10000),
+        ("8204", 12000),
+        ("8205", 11000),
+        ("8301", 3600),
+        ("8302", 4600),
+        ("8303", 5000),  # app v4.0.7
+        ("8304", 6000),
+    ],
+)
+def test_inverter_max_power_rated_table(code, watts):
+    inv = SinglePhaseInverter.from_register_cache(RegisterCache({HR(0): int(code, 16)}))
+    assert inv.inverter_max_power == watts  # type: ignore[attr-defined]
+
+
+def test_inverter_max_power_unknown_code_is_none():
+    """An unmapped device-type code returns None (e.g. the rating-less Gateway codes)."""
+    inv = SinglePhaseInverter.from_register_cache(RegisterCache({HR(0): 0x7002}))
+    assert inv.inverter_max_power is None  # type: ignore[attr-defined]
+
+
 @pytest.mark.parametrize(
     "model,expected",
     [


### PR DESCRIPTION
## Summary

Closes #320 (the rated-power half; see "Out of scope" below). The GivEnergy app v4.0.7 embeds an
authoritative HR(0) model-code → model-name table. All **36 codes that overlapped** the library's
existing `_DTC_RATED_POWER` agreed **exactly** (zero mismatches), so this adds the **27 new codes**
the library previously couldn't rate:

- ALPS-CUBE-HY5.0 (`2401-2406`), POL-HY-8.0-GL (`2501-2506`)
- GIV-3HY-20-HV (`4005/4006`), GIV-PM commercial (`4007/4101/4103`)
- AcCouple (`6001-6006`), AIO-HY 11kW (`8205`), Battery-Ready (`8301-8303`)

**Purely additive.** Codes that returned `None` now return the vendor watt rating; no known code's
rating changes. The two Gateway codes (`7001/7002`) carry no kW in the table and are left as-is
(`7001` keeps its existing `12000`).

## Out of scope (stays hardware-blocked)

`resolve_model()` is deliberately untouched. The table **lumps** the 0x20xx Gen1/2/3 family under one
code — which *confirms* the generation split lives in firmware, not HR(0) — offers no EA-prefix code,
and its marketing names (e.g. "GIV-PM-30/50") don't map cleanly to `Model` enum members. So it can't
safely improve model *identity*, only ratings. The Gen-split and EA-prefix gaps remain blocked on a
field report, exactly as before.

## Tests

Adds a characterisation test driving the real `inverter_max_power` property via HR(0) across the
**full 64-code table** — the pre-existing codes had **no test at all**, so this both pins them
(catching any future accidental edit) and asserts the 27 new codes return the vendor watts. Plus an
unknown-code (`0x7002`) → `None` case. Expected watts are written explicitly in the test, independent
of the source dict.

## Test plan
- [x] `uv run pytest` — 1406 passing
- [x] `tox` green py311–py314 (+ lint, format, build)