### PR TITLE
fix: decode 3ph per-phase active power as signed watts; rename off p_load_ac*/p_out_ac* (#185)

### DIFF
--- a/docs/reference/registers/v4.1.6_inventory.json
+++ b/docs/reference/registers/v4.1.6_inventory.json
@@ -11152,13 +11152,13 @@
         "doc_unit": "1W",
         "doc_scale": 1.0,
         "code_attrs": [
-          "inverter_3ph.p_load_ac1"
+          "inverter_3ph.p_meter_active_ac1"
         ],
         "code_convs": [
-          "deci"
+          "int16"
         ],
-        "code_scale": 0.1,
-        "factor_off": 0.1
+        "code_scale": 1.0,
+        "factor_off": 1.0
       },
       {
         "reg": "IR1084",
@@ -11166,13 +11166,13 @@
         "doc_unit": "1W",
         "doc_scale": 1.0,
         "code_attrs": [
-          "inverter_3ph.p_load_ac2"
+          "inverter_3ph.p_meter_active_ac2"
         ],
         "code_convs": [
-          "deci"
+          "int16"
         ],
-        "code_scale": 0.1,
-        "factor_off": 0.1
+        "code_scale": 1.0,
+        "factor_off": 1.0
       },
       {
         "reg": "IR1085",
@@ -11180,13 +11180,13 @@
         "doc_unit": "1W",
         "doc_scale": 1.0,
         "code_attrs": [
-          "inverter_3ph.p_load_ac3"
+          "inverter_3ph.p_meter_active_ac3"
         ],
         "code_convs": [
-          "deci"
+          "int16"
         ],
-        "code_scale": 0.1,
-        "factor_off": 0.1
+        "code_scale": 1.0,
+        "factor_off": 1.0
       },
       {
         "reg": "IR1091",
@@ -11194,13 +11194,13 @@
         "doc_unit": "1W",
         "doc_scale": 1.0,
         "code_attrs": [
-          "inverter_3ph.p_out_ac1"
+          "inverter_3ph.p_inverter_active_ac1"
         ],
         "code_convs": [
-          "deci"
+          "int16"
         ],
-        "code_scale": 0.1,
-        "factor_off": 0.1
+        "code_scale": 1.0,
+        "factor_off": 1.0
       },
       {
         "reg": "IR1092",
@@ -11208,13 +11208,13 @@
         "doc_unit": "1W",
         "doc_scale": 1.0,
         "code_attrs": [
-          "inverter_3ph.p_out_ac2"
+          "inverter_3ph.p_inverter_active_ac2"
         ],
         "code_convs": [
-          "deci"
+          "int16"
         ],
-        "code_scale": 0.1,
-        "factor_off": 0.1
+        "code_scale": 1.0,
+        "factor_off": 1.0
       },
       {
         "reg": "IR1093",
@@ -11222,13 +11222,13 @@
         "doc_unit": "1W",
         "doc_scale": 1.0,
         "code_attrs": [
-          "inverter_3ph.p_out_ac3"
+          "inverter_3ph.p_inverter_active_ac3"
         ],
         "code_convs": [
-          "deci"
+          "int16"
         ],
-        "code_scale": 0.1,
-        "factor_off": 0.1
+        "code_scale": 1.0,
+        "factor_off": 1.0
       },
       {
         "reg": "IR1140",

--- a/givenergy_modbus/model/inverter_threephase.py
+++ b/givenergy_modbus/model/inverter_threephase.py
@@ -1,7 +1,7 @@
 """GivEnergy three-phase inverter data model."""
 
 import warnings
-from typing import ClassVar
+from typing import ClassVar, NoReturn
 
 from pydantic import ConfigDict, computed_field, create_model
 
@@ -203,6 +203,18 @@ _DROP_ON_THREE_PHASE = (
     "enable_battery_self_heating",
 )
 
+# IR(1083-1085)/IR(1091-1093) per-phase active power were renamed (#185): the old p_load_ac*/p_out_ac*
+# names decoded unsigned C.deci (10x low, negatives silently dropped), so their contract was always
+# wrong. The new names decode signed watts. Old names hard-fail rather than return a wrong value.
+_RENAMED_PER_PHASE_POWER = {
+    "p_load_ac1": "p_meter_active_ac1",
+    "p_load_ac2": "p_meter_active_ac2",
+    "p_load_ac3": "p_meter_active_ac3",
+    "p_out_ac1": "p_inverter_active_ac1",
+    "p_out_ac2": "p_inverter_active_ac2",
+    "p_out_ac3": "p_inverter_active_ac3",
+}
+
 # Registers that are three-phase specific or that shadow single-phase registers at higher addresses.
 # When merged with InverterRegisterGetter.REGISTER_LUT these entries win (dict update semantics).
 _THREE_PHASE_LUT = {
@@ -298,7 +310,7 @@ _THREE_PHASE_LUT = {
     # watts: the v4.1.6 doc names it BackflowPowerRateSet (unit 0.1%, range 0~1000) and the
     # installer app names it EXPORT_LIMIT_POWER_SET on the three-phase register map. C.deci
     # scales the 0.1% raw to 0-100.0%. The old name "p_export_limit" (with max=6500, modelled
-    # like the watt-valued p_load_ac* fields) was wrong on both count and contract; it now
+    # like the per-phase power fields) was wrong on both count and contract; it now
     # hard-fails as a property. set_export_power_rate() writes this register.
     "export_power_rate": Def(C.deci, None, HR(1063), min=0.0, max=100.0),
     "battery_reserve_soc": Def(C.uint16, None, HR(1078)),
@@ -395,13 +407,20 @@ _THREE_PHASE_LUT = {
     "start_delay_time": Def(C.uint16, None, IR(1077)),
     "p_meter_import": Def(C.uint32, C.deci, IR(1079), IR(1080), max=100000),
     "p_meter_export": Def(C.uint32, C.deci, IR(1081), IR(1082), max=100000),
-    "p_load_ac1": Def(C.deci, None, IR(1083), max=6500),
-    "p_load_ac2": Def(C.deci, None, IR(1084), max=6500),
-    "p_load_ac3": Def(C.deci, None, IR(1085), max=6500),
+    # IR(1083-1085): per-phase grid-METER active power (installer METER_ACTIVE_POWER_R/S/T), and
+    # IR(1091-1093): per-phase INVERTER active power (installer ACTIVE_POWER_R/S/T). Both are signed
+    # 16-bit watts (installer: signed, no divide_by; doc: 1W) — not the unsigned C.deci the library
+    # had, which read 10× low and dropped negatives entirely. Corroborated on the lamztib GIV-3HY-11
+    # capture: the three meter phases (-80/-185/+269 W) sum to +4 W, matching p_meter_export (4.0 W);
+    # under deci they'd sum to 0.4 W. Renamed from p_load_ac*/p_out_ac* (the old unsigned-deci, and
+    # "load"-mislabelled, contract was always wrong); the old names hard-fail. See #185.
+    "p_meter_active_ac1": Def(C.int16, None, IR(1083)),
+    "p_meter_active_ac2": Def(C.int16, None, IR(1084)),
+    "p_meter_active_ac3": Def(C.int16, None, IR(1085)),
     "p_load_all": Def(C.uint32, C.deci, IR(1089), IR(1090), max=100000),
-    "p_out_ac1": Def(C.deci, None, IR(1091), max=6500),
-    "p_out_ac2": Def(C.deci, None, IR(1092), max=6500),
-    "p_out_ac3": Def(C.deci, None, IR(1093), max=6500),
+    "p_inverter_active_ac1": Def(C.int16, None, IR(1091)),
+    "p_inverter_active_ac2": Def(C.int16, None, IR(1092)),
+    "p_inverter_active_ac3": Def(C.int16, None, IR(1093)),
     "v_out_ac1": Def(C.deci, None, IR(1094), min=0.0, max=500.0),
     "v_out_ac2": Def(C.deci, None, IR(1095), min=0.0, max=500.0),
     "v_out_ac3": Def(C.deci, None, IR(1096), min=0.0, max=500.0),
@@ -665,7 +684,7 @@ class ThreePhaseInverter(  # type: ignore[valid-type,misc]
         return self.work_time_total_hours  # type: ignore[attr-defined,no-any-return]
 
     # HR(1063) was exposed as p_export_limit and modelled as a power (max=6500, like the
-    # watt-valued p_load_ac* fields). It is actually an export-rate percentage (0-100%), so
+    # per-phase power fields). It is actually an export-rate percentage (0-100%), so
     # the old name and bound were always wrong. Renamed to export_power_rate; the old name
     # hard-fails rather than silently returning a differently-scaled, differently-meaning value.
     @property
@@ -947,6 +966,25 @@ THREE_PHASE_MODELS: frozenset[Model] = frozenset(
         Model.ALL_IN_ONE_HYBRID,
     }
 )
+
+
+def _removed_per_phase_power_property(old: str, new: str) -> property:
+    """Build a hard-failing property for a per-phase active-power field renamed in #185."""
+
+    def _fail(self: "ThreePhaseInverter") -> NoReturn:
+        raise AttributeError(
+            f"ThreePhaseInverter.{old} has been removed: per-phase active power is signed watts, "
+            f"not the unsigned C.deci the old name decoded (10x low, negatives dropped). Use {new}."
+        )
+
+    _fail.__doc__ = f"Removed: use `{new}` (signed-watt per-phase active power)."
+    return property(_fail)
+
+
+# Attach the six removed names as hard-failing properties (kept off the model fields, so model_dump
+# is unaffected; accessing one raises rather than silently returning a wrong value).
+for _old_name, _new_name in _RENAMED_PER_PHASE_POWER.items():
+    setattr(ThreePhaseInverter, _old_name, _removed_per_phase_power_property(_old_name, _new_name))
 
 
 def select_inverter(model: Model, register_cache) -> "SinglePhaseInverter | ThreePhaseInverter":

--- a/tests/model/test_inverter_threephase.py
+++ b/tests/model/test_inverter_threephase.py
@@ -336,6 +336,30 @@ def test_export_power_rate_rename_and_hard_fail():
         _ = tph.p_export_limit  # type: ignore[attr-defined]
 
 
+def test_per_phase_active_power_signed_watts_and_rename():
+    """IR(1083-1085)/IR(1091-1093) are signed watts (#185), renamed off p_load_ac*/p_out_ac*."""
+    from givenergy_modbus.model.inverter_threephase import _RENAMED_PER_PHASE_POWER
+
+    # Signed int16 raw watts: 65456 → -80, 65351 → -185, 269 → +269; inverter side raw 0 → 0.
+    cache = _cache({IR(1083): 65456, IR(1084): 65351, IR(1085): 269, IR(1091): 0, IR(1092): 1234, IR(1093): 65036})
+    tph = ThreePhaseInverter.from_register_cache(cache)
+    assert tph.p_meter_active_ac1 == -80  # type: ignore[attr-defined]
+    assert tph.p_meter_active_ac2 == -185  # type: ignore[attr-defined]
+    assert tph.p_meter_active_ac3 == 269  # type: ignore[attr-defined]
+    assert tph.p_inverter_active_ac1 == 0  # type: ignore[attr-defined]
+    assert tph.p_inverter_active_ac2 == 1234  # type: ignore[attr-defined]
+    assert tph.p_inverter_active_ac3 == -500  # raw 65036 → int16 -500  # type: ignore[attr-defined]
+
+    dumped = tph.model_dump()
+    for new in _RENAMED_PER_PHASE_POWER.values():
+        assert new in dumped
+    # Every old name is removed from the model and hard-fails on access (contract was always wrong).
+    for old in _RENAMED_PER_PHASE_POWER:
+        assert old not in dumped
+        with pytest.raises(AttributeError, match=_RENAMED_PER_PHASE_POWER[old]):
+            getattr(tph, old)
+
+
 def test_p_pv_sum():
     tph = ThreePhaseInverter.from_register_cache(_cache({IR(1017): 0, IR(1018): 3000, IR(1019): 0, IR(1020): 2000}))
     assert tph.p_pv() == pytest.approx(300.0 + 200.0)  # type: ignore[attr-defined]

--- a/tests/model/test_three_phase_from_capture.py
+++ b/tests/model/test_three_phase_from_capture.py
@@ -92,10 +92,10 @@ def test_three_phase_grid_block_decode_from_capture(replayed_plant: Plant):
     assert inv.p_grid_apparent == pytest.approx(652.0)  # type: ignore[attr-defined]
     assert inv.p_load_all == pytest.approx(339.0)  # type: ignore[attr-defined]
 
-    # Per-phase inverter output — all zero on this idle capture.
-    assert inv.p_out_ac1 == pytest.approx(0.0)  # type: ignore[attr-defined]
-    assert inv.p_out_ac2 == pytest.approx(0.0)  # type: ignore[attr-defined]
-    assert inv.p_out_ac3 == pytest.approx(0.0)  # type: ignore[attr-defined]
+    # Per-phase inverter active power IR(1091-1093) — all zero on this idle capture.
+    assert inv.p_inverter_active_ac1 == 0  # type: ignore[attr-defined]
+    assert inv.p_inverter_active_ac2 == 0  # type: ignore[attr-defined]
+    assert inv.p_inverter_active_ac3 == 0  # type: ignore[attr-defined]
 
     # Inherited single-phase grid nodes — IR(30) p_grid_out reads as 0 on 3-phase. With the
     # inverter idle here we can't tell whether 3ph firmware ever populates it; #141 stays
@@ -103,12 +103,13 @@ def test_three_phase_grid_block_decode_from_capture(replayed_plant: Plant):
     assert inv.p_grid_out == 0  # type: ignore[attr-defined]
     assert inv.p_grid_out_ph1 == 0  # type: ignore[attr-defined]
 
-    # Per-phase loads IR(1083-1085) — IR(1083) raw=65456 and IR(1084) raw=65351 silently
-    # decode to ``None`` because the current ``Def(C.deci, ...)`` uses unsigned uint16 and
-    # the values fall outside the (0, 6500) bounds. Read as int16 they're -8.0 W / -18.5 W
-    # respectively, which would make sense as net per-phase load on an exporting house.
-    # Calling that out here rather than asserting either interpretation; tracked as a
-    # follow-up because confirming wants an active-grid 3-phase capture.
-    assert inv.p_load_ac1 is None  # type: ignore[attr-defined]
-    assert inv.p_load_ac2 is None  # type: ignore[attr-defined]
-    assert inv.p_load_ac3 == pytest.approx(26.9)  # type: ignore[attr-defined]
+    # Per-phase grid-METER active power IR(1083-1085) — signed watts (#185). The old unsigned
+    # C.deci decode dropped IR1083/1084 as out-of-bounds (raw 65456/65351) and mis-scaled IR1085;
+    # as signed int16 they read -80 / -185 / +269 W, summing to +4 W — matching p_meter_export
+    # (4.0 W) on this exporting house. That sum identity is what confirms the signed-watt scale.
+    assert inv.p_meter_active_ac1 == -80  # type: ignore[attr-defined]
+    assert inv.p_meter_active_ac2 == -185  # type: ignore[attr-defined]
+    assert inv.p_meter_active_ac3 == 269  # type: ignore[attr-defined]
+    assert (  # the per-phase sum reconciles with the aggregate meter export
+        inv.p_meter_active_ac1 + inv.p_meter_active_ac2 + inv.p_meter_active_ac3  # type: ignore[attr-defined]
+    ) == pytest.approx(inv.p_meter_export)  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

Partial fix for #185. The three-phase per-phase active-power registers IR(1083-1085) and
IR(1091-1093) were decoded as **unsigned `C.deci`** — reading 10× low and silently dropping negative
values (out-of-bounds → `None`). Both the v4.1.6 doc (`1W`) and the installer app (`signed`, no
`divide_by`) say they are **signed 16-bit watts**.

## Confirmed on real hardware

Decoding the lamztib GIV-3HY-11 capture, the three grid-meter phases read **-80 / -185 / +269 W**,
which sum to **+4 W** — exactly `p_meter_export` (4.0 W) on that (exporting) house. Under the old
`deci` they'd sum to 0.4 W. That per-phase ↔ aggregate identity is independent confirmation of the
signed-watt scale, beyond the doc/installer agreement. (The capture test now asserts this sum.)

## Change

- IR(1083-1085) `p_load_ac1/2/3` → **`p_meter_active_ac1/2/3`** — grid-meter active power per phase
  (doc `MeterActivePower_R/S/T`, installer `METER_ACTIVE_POWER_R/S/T`; the old "load" name was wrong).
- IR(1091-1093) `p_out_ac1/2/3` → **`p_inverter_active_ac1/2/3`** — inverter active power per phase
  (doc/installer `ActivePower_R/S/T`).
- `Def(C.deci, …, max=6500)` → `Def(C.int16)` — signed watts; the deci-era bound is dropped.
- The old names **hard-fail** (`AttributeError`) — their unsigned-deci, load-mislabelled contract was
  always wrong, so returning a value would be returning a wrong one. Same treatment as the
  `export_power_rate` rename in #263.
- The v4.1.6 audit inventory's cross-refs for these six registers are synced to the new names and the
  now-resolved 1:1 scale (a full regen needs the private doc source, which isn't in the repo).

## Still open in #185 (not this PR)

The holding-register protection-timing/slope scales (HR1034/1051/1052/1011/1067/…) remain blocked:
the installer's 3ph *holding*-register map carries names only, no scale, so it can't adjudicate those
— they still need three-phase hardware. (`i_battery` IR1140 is also left alone: its `centi` was
wire-validated in #264, and the installer's `deci` is treated as the lesser evidence.)

## Test plan
- [x] `uv run pytest` — 1342 passing (incl. the capture sum-identity assertion)
- [x] `tox` green py311–py314 (+ lint, format, build)