### PR TITLE
feat: Plant.from_caches() — typed plant from a register dump, no live client (#268)

### DIFF
--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -5,6 +5,7 @@ from typing import Any, ClassVar, cast
 
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, model_validator
 
+from givenergy_modbus.exceptions import CommunicationError
 from givenergy_modbus.model import GivEnergyBaseModel
 from givenergy_modbus.model.aio_battery import AioBatteryModule
 from givenergy_modbus.model.battery import Battery, BatteryRegisterGetter
@@ -34,7 +35,7 @@ from givenergy_modbus.model.inverter import (
     resolve_model,
 )
 from givenergy_modbus.model.inverter_threephase import ThreePhaseInverter, select_inverter
-from givenergy_modbus.model.lv_bcu import LvBcu, LvBcuRegisterGetter
+from givenergy_modbus.model.lv_bcu import LV_BCU_ADDRESS, LvBcu, LvBcuRegisterGetter
 from givenergy_modbus.model.meter import Meter, MeterRegisterGetter
 from givenergy_modbus.model.register import HR, IR, Converter, Register, RegisterGetter, is_valid_serial
 from givenergy_modbus.model.register_cache import RegisterCache
@@ -547,6 +548,116 @@ def _validated_serial(device: Any) -> str | None:
     return getattr(device, "serial_number", None) or None
 
 
+#: Maximum battery modules on a single-BCU AIO (addresses 0x50–0x53). Mirrors Client._AIO_MAX_MODULES.
+_AIO_MAX_MODULES = 4
+#: HV BMU per-module address band is 0x50–0x6F; 0x70 is the first BCU.
+_HV_BMU_BAND_END = 0x70
+
+
+def _hv_bmu_candidates(bcu_stacks: list[tuple[int, int]]) -> list[int]:
+    """Cold HV BMU candidate addresses: 0x50 + running module index, clamped to the 0x50–0x6F band."""
+    candidates: list[int] = []
+    next_addr = 0x50
+    for _offset, num_modules in bcu_stacks:
+        end_addr = min(next_addr + max(num_modules, 0), _HV_BMU_BAND_END)
+        candidates.extend(range(next_addr, end_addr))
+        next_addr = end_addr
+    return candidates
+
+
+def _derive_hv_topology(
+    register_caches: dict[int, RegisterCache], prior: "PlantCapabilities | None", caps: "PlantCapabilities"
+) -> None:
+    """Populate caps.bcu_stacks and either aio_battery_module_addresses or hv_bmu_addresses (HV plants).
+
+    Cold: BMS@0xA0 IR(61) gives the BCU count; each BCU's IR(64) its module count; per-module
+    candidates follow from there (AIO: 0x50–0x53; non-AIO HV: the 0x50+k band). Hinted (``prior``):
+    re-check only the previously-seen addresses. is_valid()-gated like detect (see _enumerate note).
+    """
+    if prior is not None:
+        indices: Any = [offset for offset, _ in prior.bcu_stacks]
+    else:
+        bms = register_caches.get(0xA0)
+        indices = range((bms.get(IR(61)) or 0) if bms else 0)
+    caps.bcu_stacks.extend((i, c.get(IR(64)) or 0) for i in indices if (c := register_caches.get(0x70 + i)))
+    if not caps.bcu_stacks:
+        return
+
+    if caps.device_type is Model.ALL_IN_ONE:
+        aio_candidates = (
+            list(prior.aio_battery_module_addresses)
+            if prior is not None
+            else [0x50 + i for i in range(min(caps.bcu_stacks[0][1], _AIO_MAX_MODULES))]
+        )
+        for addr in aio_candidates:
+            c = register_caches.get(addr)
+            if c is not None and AioBatteryModule.from_register_cache(c, addr).is_valid():
+                caps.aio_battery_module_addresses.append(addr)
+    else:
+        bmu_candidates = (
+            list(prior.hv_bmu_addresses)
+            if prior is not None and prior.hv_bmu_addresses
+            else _hv_bmu_candidates(caps.bcu_stacks)
+        )
+        for addr in bmu_candidates:
+            c = register_caches.get(addr)
+            if c is not None and Bmu.from_register_cache(c).is_valid():
+                caps.hv_bmu_addresses.append(addr)
+
+
+def _derive_capabilities(
+    register_caches: dict[int, RegisterCache],
+    prior: PlantCapabilities | None = None,
+) -> PlantCapabilities:
+    """Derive PlantCapabilities from a complete register-cache set, with no wire I/O (#268).
+
+    The offline counterpart to ``Client._detect()``'s enumeration: read HR(0)/HR(21) at 0x11 to
+    resolve the model, then for each peripheral class check presence (``addr in register_caches``)
+    and the SAME ``Model.from_register_cache(cache).is_valid()`` gate detect uses on the wire. This
+    is the cache-agnostic "validate" step the live detect loop will share in a later slice; the
+    parity test pins it equal to a live ``detect()`` over the same captures.
+
+    ``prior`` (v1) restricts candidate addresses to a previously-seen set, mirroring detect's hinted
+    mode, but does NOT raise on mismatch (deferred to the capabilities-as-target slice). Raises
+    :class:`CommunicationError` if HR(0) is absent at 0x11 (mirrors detect's identity-read failure).
+    """
+    cache = register_caches.get(0x11, RegisterCache())
+    raw_dtc = cache.get(HR(0))
+    if raw_dtc is None:
+        raise CommunicationError("from_caches: HR(0) not present at device 0x11 — cannot determine device type")
+    caps = PlantCapabilities(device_type=resolve_model(raw_dtc, cache.get(HR(21)) or 0))
+
+    # HV topology (BCU stacks + AIO/HV-BMU per-module addresses). No try/except around the is_valid()
+    # gates here or below: unlike detect's helpers (which guard against wire garbage), this only ever
+    # sees already-committed, CRC-validated, decoded caches — is_valid() can't raise on those. A
+    # genuinely malformed dump should fail loudly rather than silently drop a peripheral.
+    if caps.is_hv:
+        _derive_hv_topology(register_caches, prior, caps)
+
+    # Meters (0x01–0x08), validated via Meter.is_valid() to drop all-zero ghost slots.
+    meter_candidates = prior.meter_addresses if prior is not None else range(0x01, 0x09)
+    for addr in meter_candidates:
+        c = register_caches.get(addr)
+        if c is not None and Meter.from_register_cache(c).is_valid():
+            caps.meter_addresses.append(addr)
+
+    # LV batteries (0x32–0x37) + LV BCU (0x31). Skipped for HV and EMS plants.
+    if not caps.is_hv and not caps.is_ems:
+        batt_candidates = prior.lv_battery_addresses if prior is not None else range(0x32, 0x38)
+        for addr in batt_candidates:
+            c = register_caches.get(addr)
+            if c is not None and Battery.from_register_cache(c).is_valid():
+                caps.lv_battery_addresses.append(addr)
+        bcu_addr = prior.lv_bcu_address if prior is not None else LV_BCU_ADDRESS
+        bcu_cache = register_caches.get(bcu_addr) if bcu_addr is not None else None
+        if bcu_cache and LvBcu.from_register_cache(bcu_cache).is_valid():
+            caps.lv_bcu_address = bcu_addr
+
+    # The EMS rollup cross-check is a soft sanity log in detect — it mutates no caps fields, so offline
+    # it's a no-op; the .ems/.inverters facades read the IR(2040+) rollup directly.
+    return caps
+
+
 class Plant(GivEnergyBaseModel):
     """Representation of a complete GivEnergy plant."""
 
@@ -678,6 +789,32 @@ class Plant(GivEnergyBaseModel):
         """Ensure a default register cache is always present."""
         if not self.register_caches:
             self.register_caches = {0x32: RegisterCache()}
+
+    @classmethod
+    def from_caches(
+        cls,
+        register_caches: dict[int, RegisterCache],
+        prior: PlantCapabilities | None = None,
+        *,
+        inverter_serial_number: str = "",
+        data_adapter_serial_number: str = "",
+    ) -> "Plant":
+        """Build a fully-typed Plant from an injected register-cache set, with no live client (#268).
+
+        Capabilities are derived from the caches (no wire I/O) via :func:`_derive_capabilities`, so
+        every typed view (``.inverter``/``.batteries``/``.meters``/``.hv_stacks``/``.ems``/
+        ``.inverters``) works exactly as on a live-detected plant. The recipe for a capture dump is
+        ``Plant.from_caches(plant_from_capture(path).register_caches)``.
+
+        Raises :class:`CommunicationError` if HR(0) is absent at device 0x11.
+        """
+        plant = cls(
+            register_caches=register_caches,
+            inverter_serial_number=inverter_serial_number,
+            data_adapter_serial_number=data_adapter_serial_number,
+        )
+        plant.capabilities = _derive_capabilities(register_caches, prior)
+        return plant
 
     # Authoritative device-address map (GivEnergy installer app v1.154.3 `device_address_map`),
     # for orientation — not every band is modelled/routed below:

--- a/tests/client/test_offline_from_caches.py
+++ b/tests/client/test_offline_from_caches.py
@@ -1,0 +1,146 @@
+"""Offline `Plant.from_caches()` — derive a fully-typed plant from a register-cache dump (#268).
+
+The contract: `_derive_capabilities` over a complete cache must reproduce exactly what a live
+`detect()` derives from the same hardware. We drive the real Client through MockPlant (which
+synthesises responses from the captures), then assert `Plant.from_caches(client.plant.register_caches)`
+yields the identical capabilities — proving the offline enumeration matches the wire path with no
+duplicate source of truth to drift.
+"""
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+
+from givenergy_modbus.client.client import Client
+from givenergy_modbus.exceptions import CommunicationError
+from givenergy_modbus.model.inverter import Model
+from givenergy_modbus.model.plant import Plant
+from givenergy_modbus.model.register import HR, IR
+from givenergy_modbus.model.register_cache import RegisterCache
+from givenergy_modbus.testing import MockPlant
+from givenergy_modbus.testing.mock_plant import plant_from_capture
+
+_CAPTURES = Path(__file__).parents[1] / "fixtures" / "captures"
+
+# (relative capture path, expected device_type) — the identity-complete fixtures detect() runs over.
+# (The three_phase_hv_a capture is a passive refresh dump with no HR(0,60) identity block at 0x11, so
+# it is neither detect-capable nor typeable offline — from_caches correctly raises on it; see
+# test_from_caches_raises_without_identity.)
+_FIXTURES = [
+    ("aio_a/aio_arm612_5min.log", Model.ALL_IN_ONE),
+    ("ems_2_inv_3_bat_a/ems_arm1036_60s.log", Model.EMS),
+    ("hybrid_2_bat_a/hybrid_gen1_arm449_0x11_poll_10min.log", Model.HYBRID_GEN1),
+]
+
+# Fast probe params: absent peripheral addresses time out, so keep them short.
+_DETECT = dict(timeout=1.0, retries=0, probe_timeout=0.1, probe_retries=0)
+
+
+async def _client_for(relpath: str) -> AsyncIterator[Client]:
+    mock = MockPlant.from_capture(_CAPTURES / relpath)
+    host, port = await mock.start("127.0.0.1", 0)
+    client = Client(host, port, tx_message_wait=0, tx_jitter=0)
+    await client.connect()
+    try:
+        yield client
+    finally:
+        await client.close()
+        await mock.aclose()
+
+
+@pytest.mark.parametrize("relpath,expected_model", _FIXTURES)
+@pytest.mark.timeout(30)
+async def test_from_caches_capabilities_match_live_detect(relpath, expected_model):
+    """from_caches over detect's resulting caches reproduces detect's capabilities exactly."""
+    async for client in _client_for(relpath):
+        live_caps = await client.detect(**_DETECT)
+        assert live_caps.device_type is expected_model
+
+        offline = Plant.from_caches(client.plant.register_caches)
+        assert offline.capabilities == live_caps
+
+
+@pytest.mark.parametrize("relpath,expected_model", _FIXTURES)
+def test_from_caches_recipe_lights_up_facades(relpath, expected_model):
+    """The documented offline recipe yields a typed plant; facades match the live-detected shape."""
+    caches = plant_from_capture(_CAPTURES / relpath).register_caches
+    plant = Plant.from_caches(caches)
+
+    assert plant.capabilities is not None
+    assert plant.capabilities.device_type is expected_model
+    # The inverter view is always typed; .inverters is non-empty for every plant family.
+    assert plant.inverter is not None
+    assert len(plant.inverters) >= 1
+
+
+@pytest.mark.parametrize("relpath,expected_model", _FIXTURES)
+@pytest.mark.timeout(30)
+async def test_from_caches_hinted_matches_cold(relpath, expected_model):
+    """Passing the derived caps back as a `prior` (hinted candidate restriction) reproduces them."""
+    async for client in _client_for(relpath):
+        live = await client.detect(**_DETECT)
+        hinted = Plant.from_caches(client.plant.register_caches, prior=live)
+        assert hinted.capabilities == live
+
+
+def test_derive_capabilities_aio_hv_lv_bcu_branches():
+    """Exercise the AIO / HV-BMU / LV-BCU enumeration branches (no identity-complete fixture has them).
+
+    Each synthetic stack deliberately claims more BCUs/modules than are present, so the absent-skip
+    paths are taken alongside the append paths.
+    """
+    # A real, valid per-module cache — AIO modules share the HV BMU IR(60-119) block (#265).
+    aio = plant_from_capture(_CAPTURES / "aio_a/aio_arm612_5min.log")
+    module_cache = next(aio.register_caches[a] for a in (0x50, 0x51, 0x52, 0x53) if a in aio.register_caches)
+
+    # ALL_IN_ONE (0x8001): the BCU claims 4 modules but only two are present → absent-module skip.
+    aio_caps = Plant.from_caches(
+        {
+            0x11: RegisterCache({HR(0): 0x8001, HR(21): 612}),
+            0xA0: RegisterCache({IR(61): 1}),
+            0x70: RegisterCache({IR(64): 4}),
+            0x50: module_cache,
+            0x51: module_cache,
+        }
+    ).capabilities
+    assert aio_caps.device_type is Model.ALL_IN_ONE
+    assert aio_caps.aio_battery_module_addresses == [0x50, 0x51]
+
+    # NON-AIO HV (0x8101): BMS claims 2 BCUs (only 0x70 present), which claims 3 modules (only
+    # 0x50/0x51 present) — exercises the absent-BCU skip, the BMU band derivation, and the
+    # absent-module skip.
+    hv_src = {
+        0x11: RegisterCache({HR(0): 0x8101, HR(21): 300}),
+        0xA0: RegisterCache({IR(61): 2}),
+        0x70: RegisterCache({IR(64): 3}),
+        0x50: module_cache,
+        0x51: module_cache,
+    }
+    hv_caps = Plant.from_caches(hv_src).capabilities
+    assert hv_caps.device_type is Model.HYBRID_HV_GEN3
+    assert hv_caps.bcu_stacks == [(0, 3)]
+    assert hv_caps.hv_bmu_addresses == [0x50, 0x51]
+
+    # Hinted re-derive restricts BCU/BMU candidates to the prior's known set and reproduces the caps.
+    assert Plant.from_caches(hv_src, prior=hv_caps).capabilities == hv_caps
+
+    # An HV inverter dump with no BCU/battery data present → empty topology (early return).
+    bare_hv = Plant.from_caches({0x11: RegisterCache({HR(0): 0x8101, HR(21): 300})}).capabilities
+    assert bare_hv.device_type is Model.HYBRID_HV_GEN3
+    assert bare_hv.bcu_stacks == [] and bare_hv.hv_bmu_addresses == []
+
+    # LV system with an LV BCU present at 0x31 (bms_status_1 = IR(60) non-zero → is_valid).
+    lv_caps = Plant.from_caches(
+        {
+            0x11: RegisterCache({HR(0): 0x2001, HR(21): 100}),  # HYBRID_GEN1
+            0x31: RegisterCache({IR(60): 5}),
+        }
+    ).capabilities
+    assert lv_caps.lv_bcu_address == 0x31
+
+
+def test_from_caches_raises_without_identity():
+    """No HR(0) at 0x11 → CommunicationError, mirroring detect's identity-read failure."""
+    with pytest.raises(CommunicationError, match="HR.0."):
+        Plant.from_caches({0x32: RegisterCache({HR(0): 0x2001})})  # data present, but not at 0x11


### PR DESCRIPTION
First slice of the #268 epic (offline-first; see the [epic plan](https://github.com/dewet22/givenergy-modbus/issues/268) sequencing).

## Why

`detect()` couples discovery policy with wire I/O, and `PlantCapabilities` can only be built by a live
client. So a `Plant` rebuilt from a probe/export dump (the cli offline `shell`, cli PR #70) carries
`register_caches` but `capabilities=None` — leaving the typed views (`.inverter`/`.ems`/`.meters`/
`.hv_stacks`/`.batteries`) empty, and forcing consumers to reimplement `resolve_model`/capability
derivation.

The insight: the peripheral *enumeration* in `detect()` is **already register-cache-agnostic** — every
gate is `Model.from_register_cache(register_caches[addr]).is_valid()`, a pure cache read. Only the
*probing* is I/O-coupled. So the same enumeration runs over an injected cache with no wire I/O.

## What

- **`_derive_capabilities(register_caches, prior=None)`** (model layer) — mirrors `detect()`'s
  cold-path enumeration: `HR(0)/HR(21)@0x11 → resolve_model`, then presence + `is_valid()` per
  peripheral class. HV topology is extracted to `_derive_hv_topology` / `_hv_bmu_candidates`
  (mirroring detect's `_detect_*` helpers). Raises `CommunicationError` when HR(0) is absent at 0x11.
- **`Plant.from_caches(register_caches, prior=None, …)`** classmethod — builds the plant and derives
  capabilities, so every typed view works exactly as on a live-detected plant. Recipe:
  `Plant.from_caches(plant_from_capture(path).register_caches)`.
- No `try/except` around the `is_valid()` gates: this only ever sees already-committed, CRC-validated,
  decoded caches (so they can't raise), and a genuinely malformed dump should fail loudly rather than
  silently drop a peripheral — the opposite of detect's flaky-wire posture.

## Zero wire risk

`detect()` and the wire path are **untouched**. The parity test pins `from_caches` over detect's
*resulting* caches equal to detect's own capabilities, across the AIO / EMS / HYBRID_GEN1 fixtures —
proving the offline enumeration matches the wire path, with no duplicate source of truth. (A later
slice refactors detect to reuse this same core, retiring the parallel implementation.)

## Tests

- Parity per fixture: `Plant.from_caches(client.plant.register_caches).capabilities == await client.detect(...)`.
- Recipe/facade smoke via `plant_from_capture` (typed views light up).
- Synthetic AIO / non-AIO-HV / LV-BCU stacks (no identity-complete fixture has these) — exercising the
  absent-module/absent-BCU skips, the BMU band derivation, and the hinted-`prior` path.
- HR(0) absent at 0x11 → `CommunicationError`.
- The passive three-phase refresh fixture (no HR(0) identity block) is intentionally excluded — it is
  not a typeable dump, and `from_caches` correctly refuses it.

## Test plan
- [x] `uv run pytest` — 1419 passing; plant.py coverage 99%
- [x] `tox` green py311–py314 (+ lint, format, build)