### PR TITLE
feat: extract detect() into strategise/probe/validate loop (#268 slice 2)

### DIFF
--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -543,6 +543,7 @@ class Client:
             else:
                 if not await self._probe(request, timeout=probe_timeout, retries=probe_retries):
                     self.plant.mark_absent(pr.device_address, pr.reg_type, pr.base_register, pr.register_count)
+                    self.plant.register_caches.pop(pr.device_address, None)
 
     async def _detect_bcu_stacks(
         self,
@@ -764,6 +765,7 @@ class Client:
                     retries=probe_retries,
                 ):
                     self.plant.mark_absent(batt_addr, "IR", 60, 60)
+                    self.plant.register_caches.pop(batt_addr, None)
                     continue
                 # #233/#289: the first battery bank against an empty cache is held by the cold-start
                 # splice guard (the cache stays empty pending a corroborating re-read). detect()

--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -6,6 +6,7 @@ import socket
 import warnings
 from asyncio import Future, Queue, StreamReader, StreamWriter, Task
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Literal
 
 from givenergy_modbus.client.commands import (
@@ -25,14 +26,18 @@ from givenergy_modbus.exceptions import (
     RefreshPartiallySucceeded,
 )
 from givenergy_modbus.framer import ClientFramer, Framer
-from givenergy_modbus.model.aio_battery import AioBatteryModule
-from givenergy_modbus.model.battery import Battery
 from givenergy_modbus.model.ems import EmsRegisterGetter
-from givenergy_modbus.model.hv_bcu import Bmu
 from givenergy_modbus.model.inverter import Model, resolve_model
-from givenergy_modbus.model.lv_bcu import LV_BCU_ADDRESS, LvBcu
-from givenergy_modbus.model.meter import Meter
-from givenergy_modbus.model.plant import Plant, PlantCapabilities
+from givenergy_modbus.model.lv_bcu import LV_BCU_ADDRESS
+from givenergy_modbus.model.plant import (
+    _COLD_LV_BATTERY_RANGE,
+    _COLD_METER_RANGE,
+    Plant,
+    PlantCapabilities,
+    _aio_module_candidates,
+    _derive_capabilities,
+    _hv_bmu_candidates,
+)
 from givenergy_modbus.model.register import HR, IR
 from givenergy_modbus.model.register_cache import RegisterCache
 from givenergy_modbus.pdu import (
@@ -251,6 +256,61 @@ class FrameRedactor:
         return pdu.encode()
 
 
+@dataclass(frozen=True)
+class ProbeRange:
+    """A single Modbus read to issue during detect, with its timeout tier.
+
+    ``tier="known"`` → full ``timeout``/``retries``; ``tier="probe"`` → fast
+    ``probe_timeout``/``probe_retries`` and ``retry_delay=0``.
+    """
+
+    reg_type: str  # "HR" or "IR"
+    device_address: int
+    base_register: int
+    register_count: int
+    tier: str  # "known" | "probe"
+
+
+def _strategise(
+    caps: PlantCapabilities,
+    prior: PlantCapabilities | None,
+    step: str,
+) -> list[ProbeRange]:
+    """Pure: return the ProbeRanges for one detect step given current caps and prior hint.
+
+    Calls the same candidate helpers as ``_derive_capabilities`` so candidate generation
+    has one implementation.  No I/O.
+    """
+    if step == "aio_modules":
+        num = caps.bcu_stacks[0][1] if caps.bcu_stacks else 0
+        addrs: list[int] | range = (
+            list(prior.aio_battery_module_addresses) if prior is not None else _aio_module_candidates(num)
+        )
+        return [ProbeRange("IR", addr, 60, 60, "probe") for addr in addrs]
+
+    if step == "hv_bmus":
+        if not (caps.is_hv and caps.device_type is not Model.ALL_IN_ONE and caps.bcu_stacks):
+            return []
+        addrs = (
+            list(prior.hv_bmu_addresses)
+            if prior is not None and prior.hv_bmu_addresses
+            else _hv_bmu_candidates(caps.bcu_stacks)
+        )
+        return [ProbeRange("IR", addr, 60, 60, "probe") for addr in addrs]
+
+    if step == "meters":
+        addrs = prior.meter_addresses if prior is not None else _COLD_METER_RANGE
+        return [ProbeRange("IR", addr, 60, 30, "probe") for addr in addrs]
+
+    if step == "lv_bcu":
+        addr = prior.lv_bcu_address if prior is not None else LV_BCU_ADDRESS
+        if addr is None:
+            return []
+        return [ProbeRange("IR", addr, 60, 60, "probe")]
+
+    raise ValueError(f"_strategise: unknown step {step!r}")
+
+
 class Client:
     """Asynchronous client for talking to a GivEnergy inverter over Modbus TCP.
 
@@ -462,6 +522,28 @@ class Client:
         except TimeoutError:
             return False
 
+    async def _probe_ranges(
+        self,
+        ranges: list[ProbeRange],
+        timeout: float,
+        retries: int,
+        probe_timeout: float,
+        probe_retries: int,
+    ) -> None:
+        """Issue each ProbeRange in order by tier; mark_absent on probe-tier failures."""
+        for pr in ranges:
+            req_cls = ReadHoldingRegistersRequest if pr.reg_type == "HR" else ReadInputRegistersRequest
+            request = req_cls(
+                base_register=pr.base_register,
+                register_count=pr.register_count,
+                device_address=pr.device_address,
+            )
+            if pr.tier == "known":
+                await self.send_request_and_await_response(request, timeout=timeout, retries=retries)
+            else:
+                if not await self._probe(request, timeout=probe_timeout, retries=probe_retries):
+                    self.plant.mark_absent(pr.device_address, pr.reg_type, pr.base_register, pr.register_count)
+
     async def _detect_bcu_stacks(
         self,
         caps: PlantCapabilities,
@@ -516,155 +598,6 @@ class Client:
 
     #: Maximum number of battery modules on a single-BCU AIO (addresses 0x50–0x53).
     _AIO_MAX_MODULES = 4
-
-    async def _detect_aio_battery_modules(
-        self,
-        caps: PlantCapabilities,
-        prior: PlantCapabilities | None,
-        probe_timeout: float,
-        probe_retries: int,
-    ) -> None:
-        """Populate caps.aio_battery_module_addresses for an All-in-One (#192).
-
-        Hinted mode (prior is not None): probe only the previously-seen module addresses
-        so detect() stays a confirmation pass rather than a fresh sweep — consistent with
-        the meter and battery hinted contracts.
-
-        Cold mode: derive candidates from the BCU-reported module count (IR 64), bounded
-        to _AIO_MAX_MODULES (0x50–0x53) to guard against stale or corrupt register values.
-
-        Single-BCU AIO only — multi-BCU module addressing is a future extension.
-        """
-        if prior is not None:
-            candidates: list[int] = list(prior.aio_battery_module_addresses)
-        else:
-            if not caps.bcu_stacks:
-                return
-            _offset, num_modules = caps.bcu_stacks[0]
-            if num_modules > self._AIO_MAX_MODULES:
-                _logger.warning(
-                    "detect: BCU reports %d modules but AIO maximum is %d — clamping",
-                    num_modules,
-                    self._AIO_MAX_MODULES,
-                )
-                num_modules = self._AIO_MAX_MODULES
-            candidates = [0x50 + i for i in range(num_modules)]
-        for addr in candidates:
-            if not await self._probe(
-                ReadInputRegistersRequest(base_register=60, register_count=60, device_address=addr),
-                timeout=probe_timeout,
-                retries=probe_retries,
-            ):
-                self.plant.mark_absent(addr, "IR", 60, 60)
-                continue
-            cache = self.plant.register_caches.get(addr)
-            try:
-                if cache is None or not AioBatteryModule.from_register_cache(cache, addr).is_valid():
-                    _logger.debug("detect: AIO module probe at 0x%02x responded but is_valid()=False — skipping", addr)
-                    self.plant.mark_absent(addr, "IR", 60, 60)
-                    continue
-            except Exception:
-                _logger.debug("detect: AIO module probe at 0x%02x failed to decode — skipping", addr, exc_info=True)
-                self.plant.mark_absent(addr, "IR", 60, 60)
-                continue
-            caps.aio_battery_module_addresses.append(addr)
-
-    async def _detect_hv_bmu_modules(
-        self,
-        caps: PlantCapabilities,
-        prior: PlantCapabilities | None,
-        probe_timeout: float,
-        probe_retries: int,
-    ) -> None:
-        """Populate caps.hv_bmu_addresses for a non-AIO HV stack (#265).
-
-        Each HV battery module answers at its own device address (0x50 + running module index,
-        contiguous across stacks) with the same IR(60-119) per-cell block AIO modules use — the
-        earlier stride-within-the-BCU decode read the BCU's cluster registers as cell data.
-        Installer-confirmed, not yet wire-confirmed: probing here both populates the addresses to
-        poll and surfaces whether the band actually responds on real HV hardware.
-
-        Hinted mode (prior is not None): re-probe only the previously-seen addresses. Cold mode:
-        derive candidates 0x50 + k from each BCU's module count. Self-gated: a no-op unless this
-        is a non-AIO HV stack with detected BCUs (AIO modules use aio_battery_module_addresses).
-        """
-        if not (caps.is_hv and caps.device_type is not Model.ALL_IN_ONE and caps.bcu_stacks):
-            return
-        if prior is not None and prior.hv_bmu_addresses:
-            # Hinted mode: re-probe only the addresses the prior recorded.
-            candidates: list[int] = list(prior.hv_bmu_addresses)
-        else:
-            # Cold mode (also used when prior exists but predates this field): derive from BCU module counts.
-            candidates = []
-            next_addr = 0x50
-            for _offset, num_modules in caps.bcu_stacks:
-                end_addr = min(next_addr + max(num_modules, 0), 0x70)
-                candidates.extend(range(next_addr, end_addr))
-                if end_addr < next_addr + num_modules:
-                    _logger.warning(
-                        "detect: BCU module count %d exceeds HV BMU address band (0x50-0x6F) — clamped",
-                        num_modules,
-                    )
-                next_addr = end_addr
-        for addr in candidates:
-            if not await self._probe(
-                ReadInputRegistersRequest(base_register=60, register_count=60, device_address=addr),
-                timeout=probe_timeout,
-                retries=probe_retries,
-            ):
-                self.plant.mark_absent(addr, "IR", 60, 60)
-                continue
-            cache = self.plant.register_caches.get(addr)
-            try:
-                if cache is None or not Bmu.from_register_cache(cache).is_valid():
-                    _logger.debug("detect: HV BMU probe at 0x%02x responded but is_valid()=False — skipping", addr)
-                    self.plant.mark_absent(addr, "IR", 60, 60)
-                    continue
-            except Exception:
-                _logger.debug("detect: HV BMU probe at 0x%02x failed to decode — skipping", addr, exc_info=True)
-                self.plant.mark_absent(addr, "IR", 60, 60)
-                continue
-            caps.hv_bmu_addresses.append(addr)
-        _logger.info("detect: hv_bmu_modules=[%s]", ", ".join(f"0x{a:02x}" for a in caps.hv_bmu_addresses))
-
-    async def _detect_lv_bcu(
-        self,
-        caps: PlantCapabilities,
-        prior: PlantCapabilities | None,
-        probe_timeout: float,
-        probe_retries: int,
-    ) -> None:
-        """Probe the LV BCU page and set caps.lv_bcu_address when present (#241).
-
-        The stack-level BMS block (doc §4.4.1.1) answers at 0x31 IR(60-63) on LV
-        systems, firmware-gated: absent units still respond, just with an all-zero
-        block, so is_valid() (any-word-non-zero) is the presence test and the probe
-        costs nothing on healthy systems. Hinted mode follows the meter convention:
-        only re-check an address the prior captured — prior None-ness is trusted, so
-        a firmware upgrade that adds the block needs a cold detect to notice.
-        """
-        bcu_addr = prior.lv_bcu_address if prior is not None else LV_BCU_ADDRESS
-        if bcu_addr is None:
-            return
-        if not await self._probe(
-            ReadInputRegistersRequest(base_register=60, register_count=60, device_address=bcu_addr),
-            timeout=probe_timeout,
-            retries=probe_retries,
-        ):
-            self.plant.mark_absent(bcu_addr, "IR", 60, 60)
-            return
-        bcu_cache = self.plant.register_caches.get(bcu_addr)
-        if not bcu_cache:
-            self.plant.mark_absent(bcu_addr, "IR", 60, 60)
-            return
-        try:
-            if LvBcu.from_register_cache(bcu_cache).is_valid():
-                caps.lv_bcu_address = bcu_addr
-            else:
-                self.plant.mark_absent(bcu_addr, "IR", 60, 60)
-        except (KeyError, ValueError):
-            _logger.debug("detect: LV BCU probe at 0x%02x failed to decode — skipping", bcu_addr, exc_info=True)
-            self.plant.mark_absent(bcu_addr, "IR", 60, 60)
 
     async def _ems_rollup_cross_check(self, timeout: float, retries: int) -> None:
         """Read IR(2040,55) at detect time and sanity-check the per-managed-inverter rollup.
@@ -804,27 +737,25 @@ class Client:
 
     async def _detect_lv_batteries(
         self,
-        caps: PlantCapabilities,
         prior: PlantCapabilities | None,
         timeout: float,
         retries: int,
         probe_timeout: float,
         probe_retries: int,
     ) -> None:
-        """Enumerate LV battery packs into ``caps.lv_battery_addresses`` (detect step 4).
+        """Populate register caches for LV battery addresses (detect step 4).
 
         Battery pack #1 is at 0x32, additional packs at 0x33–0x37 (the inverter lives at 0x11, not
-        0x32 — issues #119/#189); each slot is validated via ``Battery.is_valid()``. Per-slot (not
-        break-on-fail) like the meter sweep: addresses can be non-contiguous (DIP-switch
-        misconfiguration) and a transient BMS timeout on pack N must not drop pack N+1 onward. Cold
-        detect is affordable since the probe budget only applies on cold sweeps.
+        0x32 — issues #119/#189). Per-slot (not break-on-fail) like the meter sweep: addresses can be
+        non-contiguous and a transient BMS timeout on pack N must not drop pack N+1 onward.
+        is_valid() gating and caps population are handled by _derive_capabilities.
         """
         await self.send_request_and_await_response(
             ReadInputRegistersRequest(base_register=60, register_count=60, device_address=0x32),
             timeout=timeout,
             retries=retries,
         )
-        batt_candidates = prior.lv_battery_addresses if prior is not None else range(0x32, 0x38)
+        batt_candidates = prior.lv_battery_addresses if prior is not None else _COLD_LV_BATTERY_RANGE
         for batt_addr in batt_candidates:
             if batt_addr > 0x32:
                 if not await self._probe(
@@ -849,23 +780,6 @@ class Client:
                     )
                 if not self.plant.register_caches.get(batt_addr):
                     self.plant.mark_absent(batt_addr, "IR", 60, 60)
-                    continue
-            try:
-                if not Battery.from_register_cache(self.plant.register_caches[batt_addr]).is_valid():
-                    _logger.debug(
-                        "detect: battery probe responded at 0x%02x but is_valid()=False — skipping",
-                        batt_addr,
-                    )
-                    self.plant.mark_absent(batt_addr, "IR", 60, 60)
-                    continue
-            except (KeyError, ValueError):
-                self.plant.mark_absent(batt_addr, "IR", 60, 60)
-                continue
-            caps.lv_battery_addresses.append(batt_addr)
-        _logger.info(
-            "detect: lv_battery_addresses=[%s]",
-            ", ".join(f"0x{a:02x}" for a in caps.lv_battery_addresses),
-        )
 
     async def _detect(
         self,
@@ -928,72 +842,66 @@ class Client:
         # battery module at its own device address (0x50+), distinct from the bcu_stacks
         # stride layout, so its per-module cell/temperature/serial data is reachable.
         if caps.device_type is Model.ALL_IN_ONE and caps.bcu_stacks:
-            await self._detect_aio_battery_modules(caps, prior, probe_timeout, probe_retries)
-            _logger.info(
-                "detect: aio_battery_modules=[%s]",
-                ", ".join(f"0x{a:02x}" for a in caps.aio_battery_module_addresses),
+            _offset, num_modules = caps.bcu_stacks[0]
+            if num_modules > self._AIO_MAX_MODULES:
+                _logger.warning(
+                    "detect: BCU reports %d modules but AIO maximum is %d — clamping",
+                    num_modules,
+                    self._AIO_MAX_MODULES,
+                )
+            await self._probe_ranges(
+                _strategise(caps, prior, "aio_modules"), timeout, retries, probe_timeout, probe_retries
             )
 
         # Step 2c — HV BMU per-module probing (#265). Non-AIO HV stacks expose per-cell data at
         # their own BMU addresses (0x50+), distinct from the bcu_stacks stride decode (which read
-        # the BCU's cluster registers as cells). Self-gated to non-AIO HV; a no-op otherwise.
-        await self._detect_hv_bmu_modules(caps, prior, probe_timeout, probe_retries)
+        # the BCU's cluster registers as cells). Self-gated inside _strategise to non-AIO HV.
+        await self._probe_ranges(_strategise(caps, prior, "hv_bmus"), timeout, retries, probe_timeout, probe_retries)
 
         # Step 3 — meter probing. Hinted: only previously-seen addresses. Cold: full 0x01–0x08 sweep.
         # In both modes, a probe response is necessary but not sufficient — some EMS firmwares
         # ACK every slot in 0x01..0x08 with all-zero registers regardless of whether a meter is
-        # actually wired. Validate via Meter.is_valid() to filter those ghosts, matching the
-        # convention used for Battery and BCU validation. Per-slot (not break-on-fail) because
-        # meters can be non-contiguous (e.g. ports 1 and 3 populated, port 2 empty). See #95.
-        meter_candidates = prior.meter_addresses if prior is not None else range(0x01, 0x09)
-        for meter_addr in meter_candidates:
-            if not await self._probe(
-                ReadInputRegistersRequest(base_register=60, register_count=30, device_address=meter_addr),
-                timeout=probe_timeout,
-                retries=probe_retries,
-            ):
-                self.plant.mark_absent(meter_addr, "IR", 60, 30)
-                continue
-            meter_cache = self.plant.register_caches.get(meter_addr)
-            if meter_cache is None or not Meter.from_register_cache(meter_cache).is_valid():
-                _logger.debug(
-                    "detect: meter probe responded at 0x%02x but is_valid()=False — skipping",
-                    meter_addr,
-                )
-                self.plant.mark_absent(meter_addr, "IR", 60, 30)
-                continue
-            caps.meter_addresses.append(meter_addr)
-        _logger.info(
-            "detect: meter_addresses=[%s]",
-            ", ".join(f"0x{a:02x}" for a in caps.meter_addresses),
-        )
+        # actually wired. Validate via Meter.is_valid() to filter those ghosts (in the validate step
+        # below). Per-slot (not break-on-fail): meters can be non-contiguous. See #95.
+        await self._probe_ranges(_strategise(caps, prior, "meters"), timeout, retries, probe_timeout, probe_retries)
 
         # Step 4 — LV battery + LV BCU detection. Skipped for HV systems (handled at step 2) and
         # EMS plant controllers (don't expose IR at the inverter address — see #86).
         if not caps.is_hv and not caps.is_ems:
-            await self._detect_lv_batteries(caps, prior, timeout, retries, probe_timeout, probe_retries)
+            # _detect_lv_batteries stays imperative: it issues a known-tier preamble read
+            # at 0x32 and contains the cold-start splice-guard reprobe (#233/#289/#213).
+            await self._detect_lv_batteries(prior, timeout, retries, probe_timeout, probe_retries)
 
             # Step 4b — LV BCU page probe (#241).
-            await self._detect_lv_bcu(caps, prior, probe_timeout, probe_retries)
-            _logger.info(
-                "detect: lv_bcu_address=%s",
-                f"0x{caps.lv_bcu_address:02x}" if caps.lv_bcu_address is not None else "None",
-            )
+            await self._probe_ranges(_strategise(caps, prior, "lv_bcu"), timeout, retries, probe_timeout, probe_retries)
 
         # Step 5 — EMS rollup cross-check. See `_ems_rollup_cross_check()` for the contract.
         if caps.is_ems:
             await self._ems_rollup_cross_check(timeout=timeout, retries=retries)
 
-        if prior is not None and prior != caps:
+        # Validate: derive the authoritative capabilities from the now-populated register_caches.
+        # is_valid() gating, mark_absent on invalid, and all candidate logic live in _derive_capabilities;
+        # no duplicated enumeration here. on_reject threads mark_absent into the validate step.
+        final_caps = _derive_capabilities(self.plant.register_caches, prior, on_reject=self.plant.mark_absent)
+        _logger.info(
+            "detect: meters=[%s], lv_batteries=[%s], lv_bcu=%s, aio_modules=[%s], hv_bmus=[%s]",
+            ", ".join(f"0x{a:02x}" for a in final_caps.meter_addresses),
+            ", ".join(f"0x{a:02x}" for a in final_caps.lv_battery_addresses),
+            f"0x{final_caps.lv_bcu_address:02x}" if final_caps.lv_bcu_address is not None else "None",
+            ", ".join(f"0x{a:02x}" for a in final_caps.aio_battery_module_addresses),
+            ", ".join(f"0x{a:02x}" for a in final_caps.hv_bmu_addresses),
+        )
+
+        if prior is not None and prior != final_caps:
             self.plant.capabilities = None
             raise PlantTopologyMismatch(
-                f"detect: plant topology does not match prior — prior={prior!r}, actual={caps!r}",
+                f"detect: plant topology does not match prior — prior={prior!r}, actual={final_caps!r}",
                 prior=prior,
-                actual=caps,
+                actual=final_caps,
             )
 
-        self.plant.capabilities = caps
-        return caps
+        self.plant.capabilities = final_caps
+        return final_caps
 
     async def _execute_reads(
         self,

--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -572,6 +572,7 @@ class Client:
                     caps.bcu_stacks.append((offset, actual_modules))
                 else:
                     self.plant.mark_absent(0x70 + offset, "IR", 60, 5)
+                    self.plant.register_caches.pop(0x70 + offset, None)
             return
 
         # Cold path: ask the BMS how many BCUs exist, then probe each.
@@ -582,6 +583,7 @@ class Client:
             retries=probe_retries,
         ):
             self.plant.mark_absent(0xA0, "IR", 60, 5)
+            self.plant.register_caches.pop(0xA0, None)
             return
         bms_cache: RegisterCache = self.plant.register_caches.get(0xA0, RegisterCache())
         num_bcus = bms_cache.get(IR(61)) or 0
@@ -596,6 +598,7 @@ class Client:
                 caps.bcu_stacks.append((i, num_modules))
             else:
                 self.plant.mark_absent(0x70 + i, "IR", 60, 60)
+                self.plant.register_caches.pop(0x70 + i, None)
 
     #: Maximum number of battery modules on a single-BCU AIO (addresses 0x50–0x53).
     _AIO_MAX_MODULES = 4

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -1,5 +1,6 @@
 import logging
 import warnings
+from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import Any, ClassVar, cast
 
@@ -552,6 +553,9 @@ def _validated_serial(device: Any) -> str | None:
 _AIO_MAX_MODULES = 4
 #: HV BMU per-module address band is 0x50–0x6F; 0x70 is the first BCU.
 _HV_BMU_BAND_END = 0x70
+#: Cold candidate ranges shared between _derive_capabilities (validate) and _strategise (policy).
+_COLD_METER_RANGE: range = range(0x01, 0x09)
+_COLD_LV_BATTERY_RANGE: range = range(0x32, 0x38)
 
 
 def _hv_bmu_candidates(bcu_stacks: list[tuple[int, int]]) -> list[int]:
@@ -565,14 +569,24 @@ def _hv_bmu_candidates(bcu_stacks: list[tuple[int, int]]) -> list[int]:
     return candidates
 
 
+def _aio_module_candidates(num_modules: int) -> list[int]:
+    """Cold AIO module candidate addresses: 0x50 + i, clamped to _AIO_MAX_MODULES (0x50–0x53)."""
+    return [0x50 + i for i in range(min(num_modules, _AIO_MAX_MODULES))]
+
+
 def _derive_hv_topology(
-    register_caches: dict[int, RegisterCache], prior: "PlantCapabilities | None", caps: "PlantCapabilities"
+    register_caches: dict[int, RegisterCache],
+    prior: "PlantCapabilities | None",
+    caps: "PlantCapabilities",
+    on_reject: "Callable[[int, str, int, int], None] | None" = None,
 ) -> None:
     """Populate caps.bcu_stacks and either aio_battery_module_addresses or hv_bmu_addresses (HV plants).
 
     Cold: BMS@0xA0 IR(61) gives the BCU count; each BCU's IR(64) its module count; per-module
     candidates follow from there (AIO: 0x50–0x53; non-AIO HV: the 0x50+k band). Hinted (``prior``):
     re-check only the previously-seen addresses. is_valid()-gated like detect (see _enumerate note).
+    ``on_reject`` is called for each cache-present-but-is_valid-False address so the live detect path
+    can call mark_absent; offline passes None.
     """
     if prior is not None:
         indices: Any = [offset for offset, _ in prior.bcu_stacks]
@@ -587,12 +601,22 @@ def _derive_hv_topology(
         aio_candidates = (
             list(prior.aio_battery_module_addresses)
             if prior is not None
-            else [0x50 + i for i in range(min(caps.bcu_stacks[0][1], _AIO_MAX_MODULES))]
+            else _aio_module_candidates(caps.bcu_stacks[0][1])
         )
         for addr in aio_candidates:
             c = register_caches.get(addr)
-            if c is not None and AioBatteryModule.from_register_cache(c, addr).is_valid():
+            try:
+                valid = c is not None and AioBatteryModule.from_register_cache(c, addr).is_valid()
+            except Exception:
+                if on_reject is not None:
+                    on_reject(addr, "IR", 60, 60)
+                else:
+                    raise
+                continue
+            if valid:
                 caps.aio_battery_module_addresses.append(addr)
+            elif c is not None and on_reject is not None:
+                on_reject(addr, "IR", 60, 60)
     else:
         bmu_candidates = (
             list(prior.hv_bmu_addresses)
@@ -601,25 +625,38 @@ def _derive_hv_topology(
         )
         for addr in bmu_candidates:
             c = register_caches.get(addr)
-            if c is not None and Bmu.from_register_cache(c).is_valid():
+            try:
+                valid = c is not None and Bmu.from_register_cache(c).is_valid()
+            except Exception:
+                if on_reject is not None:
+                    on_reject(addr, "IR", 60, 60)
+                else:
+                    raise
+                continue
+            if valid:
                 caps.hv_bmu_addresses.append(addr)
+            elif c is not None and on_reject is not None:
+                on_reject(addr, "IR", 60, 60)
 
 
 def _derive_capabilities(
     register_caches: dict[int, RegisterCache],
     prior: PlantCapabilities | None = None,
+    on_reject: Callable[[int, str, int, int], None] | None = None,
 ) -> PlantCapabilities:
     """Derive PlantCapabilities from a complete register-cache set, with no wire I/O (#268).
 
     The offline counterpart to ``Client._detect()``'s enumeration: read HR(0)/HR(21) at 0x11 to
     resolve the model, then for each peripheral class check presence (``addr in register_caches``)
     and the SAME ``Model.from_register_cache(cache).is_valid()`` gate detect uses on the wire. This
-    is the cache-agnostic "validate" step the live detect loop will share in a later slice; the
-    parity test pins it equal to a live ``detect()`` over the same captures.
+    is the canonical "validate" step shared by offline Plant.from_caches() and the live detect loop;
+    the parity test pins it equal to a live ``detect()`` over the same captures.
 
     ``prior`` (v1) restricts candidate addresses to a previously-seen set, mirroring detect's hinted
     mode, but does NOT raise on mismatch (deferred to the capabilities-as-target slice). Raises
     :class:`CommunicationError` if HR(0) is absent at 0x11 (mirrors detect's identity-read failure).
+    ``on_reject`` is called for each cache-present-but-is_valid-False address so the live detect path
+    can call mark_absent; offline passes None.
     """
     cache = register_caches.get(0x11, RegisterCache())
     raw_dtc = cache.get(HR(0))
@@ -632,26 +669,48 @@ def _derive_capabilities(
     # sees already-committed, CRC-validated, decoded caches — is_valid() can't raise on those. A
     # genuinely malformed dump should fail loudly rather than silently drop a peripheral.
     if caps.is_hv:
-        _derive_hv_topology(register_caches, prior, caps)
+        _derive_hv_topology(register_caches, prior, caps, on_reject=on_reject)
 
     # Meters (0x01–0x08), validated via Meter.is_valid() to drop all-zero ghost slots.
-    meter_candidates = prior.meter_addresses if prior is not None else range(0x01, 0x09)
+    meter_candidates = prior.meter_addresses if prior is not None else _COLD_METER_RANGE
     for addr in meter_candidates:
         c = register_caches.get(addr)
         if c is not None and Meter.from_register_cache(c).is_valid():
             caps.meter_addresses.append(addr)
+        elif c is not None and on_reject is not None:
+            on_reject(addr, "IR", 60, 30)
 
     # LV batteries (0x32–0x37) + LV BCU (0x31). Skipped for HV and EMS plants.
     if not caps.is_hv and not caps.is_ems:
-        batt_candidates = prior.lv_battery_addresses if prior is not None else range(0x32, 0x38)
+        batt_candidates = prior.lv_battery_addresses if prior is not None else _COLD_LV_BATTERY_RANGE
         for addr in batt_candidates:
             c = register_caches.get(addr)
-            if c is not None and Battery.from_register_cache(c).is_valid():
+            try:
+                valid = c is not None and Battery.from_register_cache(c).is_valid()
+            except Exception:
+                if on_reject is not None:
+                    on_reject(addr, "IR", 60, 60)
+                else:
+                    raise
+                continue
+            if valid:
                 caps.lv_battery_addresses.append(addr)
+            elif c is not None and on_reject is not None:
+                on_reject(addr, "IR", 60, 60)
         bcu_addr = prior.lv_bcu_address if prior is not None else LV_BCU_ADDRESS
         bcu_cache = register_caches.get(bcu_addr) if bcu_addr is not None else None
-        if bcu_cache and LvBcu.from_register_cache(bcu_cache).is_valid():
+        try:
+            bcu_valid = bcu_cache is not None and LvBcu.from_register_cache(bcu_cache).is_valid()
+        except Exception:
+            if on_reject is not None and bcu_addr is not None:
+                on_reject(bcu_addr, "IR", 60, 60)
+            else:
+                raise
+            bcu_valid = False
+        if bcu_valid:
             caps.lv_bcu_address = bcu_addr
+        elif bcu_cache is not None and bcu_addr is not None and on_reject is not None:
+            on_reject(bcu_addr, "IR", 60, 60)
 
     # The EMS rollup cross-check is a soft sanity log in detect — it mutates no caps fields, so offline
     # it's a no-op; the .ems/.inverters facades read the IR(2040+) rollup directly.

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -664,10 +664,10 @@ def _derive_capabilities(
         raise CommunicationError("from_caches: HR(0) not present at device 0x11 — cannot determine device type")
     caps = PlantCapabilities(device_type=resolve_model(raw_dtc, cache.get(HR(21)) or 0))
 
-    # HV topology (BCU stacks + AIO/HV-BMU per-module addresses). No try/except around the is_valid()
-    # gates here or below: unlike detect's helpers (which guard against wire garbage), this only ever
-    # sees already-committed, CRC-validated, decoded caches — is_valid() can't raise on those. A
-    # genuinely malformed dump should fail loudly rather than silently drop a peripheral.
+    # HV topology (BCU stacks + AIO/HV-BMU per-module addresses). The is_valid() gates below and in
+    # _derive_hv_topology wrap in try/except only when on_reject is not None (live detect path, where
+    # wire data arrives fresh); on the offline path (on_reject=None) the else: raise branch keeps the
+    # "fail loud on a genuinely malformed dump" contract.
     if caps.is_hv:
         _derive_hv_topology(register_caches, prior, caps, on_reject=on_reject)
 

--- a/tests/client/test_detect.py
+++ b/tests/client/test_detect.py
@@ -1495,6 +1495,53 @@ async def test_detect_topology_mismatch_keeps_connection():
 
 
 @pytest.mark.asyncio
+async def test_detect_stale_cache_not_admitted_on_probe_failure_meter():
+    """A stale meter cache from a prior detect must not re-appear when the probe now times out.
+
+    Regression for the probe-then-validate split: _probe_ranges marks the address absent but
+    previously left the stale RegisterCache entry in place, so _derive_capabilities re-admitted
+    the device from stale data. Cold detect (no prior) avoids the topology-mismatch raise.
+    """
+    from givenergy_modbus.model.register_cache import RegisterCache
+
+    client = _make_client()
+    _prime_cache(client, 0x11, {HR(0): 0x2001, HR(21): 0})
+    _prime_battery_serial(client, 0x32)
+    # Stale valid-looking meter cache at 0x02 — a previous detect run left it there.
+    client.plant.register_caches[0x02] = RegisterCache({IR(60): 1})
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
+        with patch.object(client, "_probe", new=AsyncMock(return_value=False)):
+            caps = await client.detect()
+
+    assert 0x02 not in caps.meter_addresses, "stale meter cache must be evicted when probe fails"
+    assert client.plant.block_present(0x02, "IR", 60, 30) is False
+
+
+@pytest.mark.asyncio
+async def test_detect_stale_cache_not_admitted_on_probe_failure_battery():
+    """A stale battery cache from a prior detect must not re-appear when the probe now times out.
+
+    Same regression as the meter case, but through _detect_lv_batteries's imperative probe loop.
+    0x32 is always found via the known-tier preamble; 0x33's stale cache must be evicted.
+    """
+    from givenergy_modbus.model.register_cache import RegisterCache
+
+    client = _make_client()
+    _prime_cache(client, 0x11, {HR(0): 0x2001, HR(21): 0})
+    _prime_battery_serial(client, 0x32)
+    # Stale valid-looking battery cache at 0x33 — a previous detect run left it there.
+    client.plant.register_caches[0x33] = RegisterCache({IR(60): 1})
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
+        with patch.object(client, "_probe", new=AsyncMock(return_value=False)):
+            caps = await client.detect()
+
+    assert 0x33 not in caps.lv_battery_addresses, "stale battery cache must be evicted when probe fails"
+    assert client.plant.block_present(0x33, "IR", 60, 60) is False
+
+
+@pytest.mark.asyncio
 async def test_detect_success_leaves_connected():
     """A successful detect() leaves the connection up (regression guard)."""
     client = _make_client()

--- a/tests/client/test_detect.py
+++ b/tests/client/test_detect.py
@@ -1565,7 +1565,7 @@ async def test_detect_stale_cache_not_admitted_on_probe_failure_bcu():
 
     with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
         with patch.object(client, "_probe", side_effect=_probe_side_effect):
-            with pytest.raises(Exception):  # PlantTopologyMismatch or similar — topology changed
+            with pytest.raises(PlantTopologyMismatch):
                 await client.detect(prior=prior)
 
     assert client.plant.block_present(0x71, "IR", 60, 5) is False

--- a/tests/client/test_detect.py
+++ b/tests/client/test_detect.py
@@ -1542,6 +1542,37 @@ async def test_detect_stale_cache_not_admitted_on_probe_failure_battery():
 
 
 @pytest.mark.asyncio
+async def test_detect_stale_cache_not_admitted_on_probe_failure_bcu():
+    """A stale BCU cache from a prior detect must not re-appear when the probe now times out.
+
+    Regression: _derive_hv_topology reads register_caches.get(0x70+i) directly to populate
+    bcu_stacks. A stale cache from a prior run would re-admit the BCU even though the probe
+    failed and mark_absent was called.
+    """
+    from givenergy_modbus.model.register_cache import RegisterCache
+
+    client = _make_client()
+    # ALL_IN_ONE with two BCU stacks in the prior.
+    _prime_cache(client, 0x11, {HR(0): 0x8001, HR(21): 612})
+    # Stale caches for BCU offset 0 (0x70) and offset 1 (0x71) — a prior detect left them.
+    client.plant.register_caches[0x70] = RegisterCache({IR(64): 3})
+    client.plant.register_caches[0x71] = RegisterCache({IR(64): 2})
+    prior = PlantCapabilities(device_type=Model.ALL_IN_ONE, inverter_address=0x11, bcu_stacks=[(0, 3), (1, 2)])
+
+    # Only 0x70 responds; 0x71 probe fails.
+    async def _probe_side_effect(request, *, timeout, retries):
+        return request.device_address == 0x70
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
+        with patch.object(client, "_probe", side_effect=_probe_side_effect):
+            with pytest.raises(Exception):  # PlantTopologyMismatch or similar — topology changed
+                await client.detect(prior=prior)
+
+    assert client.plant.block_present(0x71, "IR", 60, 5) is False
+    assert 0x71 not in client.plant.register_caches, "stale BCU cache must be evicted when probe fails"
+
+
+@pytest.mark.asyncio
 async def test_detect_success_leaves_connected():
     """A successful detect() leaves the connection up (regression guard)."""
     client = _make_client()

--- a/tests/client/test_detect.py
+++ b/tests/client/test_detect.py
@@ -87,135 +87,6 @@ def test_plant_capabilities_round_trip_with_hv_bmu_modules():
     assert restored.hv_bmu_addresses == [0x50, 0x51]
 
 
-@pytest.mark.asyncio
-async def test_detect_hv_bmu_modules_records_responding_addresses():
-    """A non-AIO HV stack records per-module BMU addresses at 0x50+ (#265)."""
-    client = _make_client()
-    caps = PlantCapabilities(device_type=Model.HYBRID_HV_GEN3, inverter_address=0x11, bcu_stacks=[(0, 2)])
-    for addr in (0x50, 0x51):
-        _prime_aio_module_serial(client, addr, serial=f"BM2414G83{addr - 0x50}")
-    responders = {0x50, 0x51}
-
-    async def _probe_side_effect(request, *, timeout, retries):
-        return request.device_address in responders
-
-    with patch.object(client, "_probe", side_effect=_probe_side_effect):
-        await client._detect_hv_bmu_modules(caps, None, 1.0, 1)
-
-    assert caps.hv_bmu_addresses == [0x50, 0x51]
-
-
-@pytest.mark.asyncio
-async def test_detect_hv_bmu_skips_modules_with_no_serial():
-    """An HV BMU that responds but reports no serial is not recorded (ghost guard, #265)."""
-    client = _make_client()
-    caps = PlantCapabilities(device_type=Model.HYBRID_HV_GEN3, inverter_address=0x11, bcu_stacks=[(0, 2)])
-    _prime_aio_module_serial(client, 0x50)  # 0x51 responds but has no serial primed
-    responders = {0x50, 0x51}
-
-    async def _probe_side_effect(request, *, timeout, retries):
-        return request.device_address in responders
-
-    with patch.object(client, "_probe", side_effect=_probe_side_effect):
-        await client._detect_hv_bmu_modules(caps, None, 1.0, 1)
-
-    assert caps.hv_bmu_addresses == [0x50]
-    assert client.plant.block_present(0x51, "IR", 60, 60) is False  # responded but is_valid()=False → ABSENT
-
-
-@pytest.mark.asyncio
-async def test_detect_hv_bmu_hinted_mode_uses_prior_addresses():
-    """Hinted detect re-probes only prior.hv_bmu_addresses, not the BCU module count.
-
-    If prior recorded [0x50] but the BCU now says 2 modules, only 0x50 is probed.
-    An address that no longer responds is dropped.
-    """
-    client = _make_client()
-    # BCU says 2 modules, but prior only knew about 0x50.
-    caps = PlantCapabilities(device_type=Model.HYBRID_HV_GEN3, inverter_address=0x11, bcu_stacks=[(0, 2)])
-    prior = PlantCapabilities(device_type=Model.HYBRID_HV_GEN3, hv_bmu_addresses=[0x50, 0x51])
-    _prime_aio_module_serial(client, 0x50, serial="BM2414G830")
-    # 0x51 is in prior but no longer responds.
-    probed = []
-
-    async def _probe_side_effect(request, *, timeout, retries):
-        probed.append(request.device_address)
-        return request.device_address == 0x50
-
-    with patch.object(client, "_probe", side_effect=_probe_side_effect):
-        await client._detect_hv_bmu_modules(caps, prior, 1.0, 1)
-
-    assert probed == [0x50, 0x51], "hinted mode must probe exactly the prior addresses"
-    assert caps.hv_bmu_addresses == [0x50], "non-responding prior address must be dropped"
-    assert client.plant.block_present(0x51, "IR", 60, 60) is False  # probe timeout → ABSENT
-
-
-@pytest.mark.asyncio
-async def test_detect_hv_bmu_skips_on_decode_exception():
-    """If Bmu.from_register_cache raises, the address is skipped without propagating."""
-    client = _make_client()
-    caps = PlantCapabilities(device_type=Model.HYBRID_HV_GEN3, inverter_address=0x11, bcu_stacks=[(0, 1)])
-    _prime_aio_module_serial(client, 0x50)
-
-    async def _probe_side_effect(request, *, timeout, retries):
-        return True
-
-    with patch.object(client, "_probe", side_effect=_probe_side_effect):
-        with patch("givenergy_modbus.client.client.Bmu.from_register_cache", side_effect=RuntimeError("boom")):
-            await client._detect_hv_bmu_modules(caps, None, 1.0, 1)
-
-    assert caps.hv_bmu_addresses == []
-
-
-@pytest.mark.asyncio
-async def test_detect_hv_bmu_empty_prior_falls_back_to_cold_detect():
-    """Prior with empty hv_bmu_addresses (pre-#326 upgrade) falls back to cold candidate derivation.
-
-    An upgraded system whose prior PlantCapabilities predate the hv_bmu_addresses field will have
-    prior.hv_bmu_addresses == [] even though bcu_stacks is populated. The hinted path must treat
-    this like a cold detect rather than silently probing nothing.
-    """
-    client = _make_client()
-    caps = PlantCapabilities(device_type=Model.HYBRID_HV_GEN3, inverter_address=0x11, bcu_stacks=[(0, 1)])
-    # prior exists but has no BMU addresses (simulates a pre-#326 persisted capability)
-    prior = PlantCapabilities(device_type=Model.HYBRID_HV_GEN3, bcu_stacks=[(0, 1)])
-    assert prior.hv_bmu_addresses == []
-    _prime_aio_module_serial(client, 0x50, serial="BM2414G830")
-    probed = []
-
-    async def _probe_side_effect(request, *, timeout, retries):
-        probed.append(request.device_address)
-        return request.device_address == 0x50
-
-    with patch.object(client, "_probe", side_effect=_probe_side_effect):
-        await client._detect_hv_bmu_modules(caps, prior, 1.0, 1)
-
-    assert 0x50 in probed, "cold fallback must probe 0x50 derived from bcu_stacks"
-    assert caps.hv_bmu_addresses == [0x50]
-
-
-@pytest.mark.asyncio
-async def test_detect_hv_bmu_clamps_to_band_on_corrupt_module_count(caplog):
-    """A corrupt or unexpectedly large num_modules is clamped so probes stay within 0x50-0x6F."""
-    import logging
-
-    client = _make_client()
-    # BCU claims 100 modules — would spill into 0x70+ BCU territory without the clamp.
-    caps = PlantCapabilities(device_type=Model.HYBRID_HV_GEN3, inverter_address=0x11, bcu_stacks=[(0, 100)])
-    probed = []
-
-    async def _probe_side_effect(request, *, timeout, retries):
-        probed.append(request.device_address)
-        return False
-
-    with patch.object(client, "_probe", side_effect=_probe_side_effect):
-        with caplog.at_level(logging.WARNING):
-            await client._detect_hv_bmu_modules(caps, None, 1.0, 1)
-
-    assert all(0x50 <= addr < 0x70 for addr in probed), "all probed addresses must be within the BMU band"
-    assert "clamped" in caplog.text
-
-
 def test_plant_capabilities_round_trip_with_lv_bcu():
     caps = PlantCapabilities(
         device_type=Model.HYBRID,
@@ -709,7 +580,7 @@ async def test_detect_lv_bcu_decode_error_is_swallowed():
 
     with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock):
         with patch.object(client, "_probe", side_effect=_probe_succeed_at_0x31):
-            with _patch("givenergy_modbus.client.client.LvBcu.from_register_cache", side_effect=ValueError("corrupt")):
+            with _patch("givenergy_modbus.model.plant.LvBcu.from_register_cache", side_effect=ValueError("corrupt")):
                 caps = await client.detect()
 
     assert caps.lv_bcu_address is None

--- a/tests/client/test_detect_characterisation.py
+++ b/tests/client/test_detect_characterisation.py
@@ -1,0 +1,133 @@
+"""Characterisation harness: pin detect()'s outbound wire sequence frame-for-frame (#268 slice 2).
+
+The bit-identical wire bar: extracting `detect()` into a strategise / probe / validate loop must
+not change the request *sequence* it puts on the wire — frame count, HR-vs-IR, device address, base
+register, register count, and order. These golden snapshots lock that sequence before the refactor
+and assert it is reproduced after.
+
+The recording seam is `send_request_and_await_response`: both `_probe` (probe tier) and the direct
+known-tier reads funnel through it, so one tap captures the complete outbound stream in call order.
+
+The goldens are **literal recordings**, never computed from the same rules the production code uses —
+a golden test that recomputes the expected sequence can let a bug match a bug. They were captured
+from the unchanged `detect()` over each MockPlant fixture.
+
+Coverage — the three identity-complete fixtures that drive a live detect over MockPlant
+deterministically (the same set `test_offline_from_caches.py` uses, for the same reason):
+  - hybrid_gen1: Step 1 (identity), Step 3 (meter sweep), Step 4 (LV batteries — incl. the cold-start
+    re-read at 0x33, #233/#289), Step 4b (LV BCU).
+  - aio:         Step 1, Step 2 (BMS@0xA0 + BCU@0x70), Step 2b (AIO modules 0x50–0x53), Step 3.
+  - ems:         Step 1, Step 3, Step 5 (EMS rollup IR(2040,55) — a known-tier read).
+The non-AIO HV BMU path (Step 2c) has no live-drivable fixture (three_phase_hv_a is a passive refresh
+dump with no HR(0,60) identity block at 0x11), so it stays pinned by the unit tests in test_detect.py.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from givenergy_modbus.client.client import Client
+from givenergy_modbus.pdu import ReadHoldingRegistersRequest, TransparentRequest
+from givenergy_modbus.testing import MockPlant
+
+_CAPTURES = Path(__file__).parents[1] / "fixtures" / "captures"
+
+# Fast probe params: absent peripheral addresses time out, so keep them short. Matches the
+# integration / offline tests so the recorded sequence is the one those suites already exercise.
+_DETECT = dict(timeout=1.0, retries=0, probe_timeout=0.1, probe_retries=0)
+
+# Golden outbound sequences as (reg_type, device_address, base_register, register_count) — literal
+# recordings from the unchanged detect(). Order is significant.
+_GOLDEN: dict[str, list[tuple[str, int, int, int]]] = {
+    # HYBRID_GEN1 — meters (Step 3) precede the LV battery sweep (Step 4); 0x32 is read once via the
+    # known-tier preamble, 0x33 twice (the cold-start corroborating re-read), 0x34–0x37 once each
+    # (absent → mark_absent), then the LV BCU at 0x31 (Step 4b).
+    "hybrid_2_bat_a/hybrid_gen1_arm449_0x11_poll_10min.log": [
+        ("HR", 0x11, 0, 60),
+        ("IR", 0x01, 60, 30),
+        ("IR", 0x02, 60, 30),
+        ("IR", 0x03, 60, 30),
+        ("IR", 0x04, 60, 30),
+        ("IR", 0x05, 60, 30),
+        ("IR", 0x06, 60, 30),
+        ("IR", 0x07, 60, 30),
+        ("IR", 0x08, 60, 30),
+        ("IR", 0x32, 60, 60),
+        ("IR", 0x33, 60, 60),
+        ("IR", 0x33, 60, 60),
+        ("IR", 0x34, 60, 60),
+        ("IR", 0x35, 60, 60),
+        ("IR", 0x36, 60, 60),
+        ("IR", 0x37, 60, 60),
+        ("IR", 0x31, 60, 60),
+    ],
+    # ALL_IN_ONE — identity, then BMS@0xA0 (IR 60,5) and the single BCU@0x70, then the four AIO
+    # modules 0x50–0x53 (Step 2b), then the meter sweep. HV BMU (Step 2c) and LV (Step 4) are skipped.
+    "aio_a/aio_arm612_5min.log": [
+        ("HR", 0x11, 0, 60),
+        ("IR", 0xA0, 60, 5),
+        ("IR", 0x70, 60, 60),
+        ("IR", 0x50, 60, 60),
+        ("IR", 0x51, 60, 60),
+        ("IR", 0x52, 60, 60),
+        ("IR", 0x53, 60, 60),
+        ("IR", 0x01, 60, 30),
+        ("IR", 0x02, 60, 30),
+        ("IR", 0x03, 60, 30),
+        ("IR", 0x04, 60, 30),
+        ("IR", 0x05, 60, 30),
+        ("IR", 0x06, 60, 30),
+        ("IR", 0x07, 60, 30),
+        ("IR", 0x08, 60, 30),
+    ],
+    # EMS — identity, the meter sweep, then the EMS rollup cross-check IR(2040,55)@0x11 (Step 5,
+    # known tier). HV/AIO/LV steps are all skipped.
+    "ems_2_inv_3_bat_a/ems_arm1036_60s.log": [
+        ("HR", 0x11, 0, 60),
+        ("IR", 0x01, 60, 30),
+        ("IR", 0x02, 60, 30),
+        ("IR", 0x03, 60, 30),
+        ("IR", 0x04, 60, 30),
+        ("IR", 0x05, 60, 30),
+        ("IR", 0x06, 60, 30),
+        ("IR", 0x07, 60, 30),
+        ("IR", 0x08, 60, 30),
+        ("IR", 0x11, 2040, 55),
+    ],
+}
+
+
+def _tap_outbound(client: Client) -> list[tuple[str, int, int, int]]:
+    """Wrap ``client.send_request_and_await_response`` to record every outbound read, in order.
+
+    Returns the list it appends to (the client is discarded after the run, so no restore needed).
+    """
+    original = client.send_request_and_await_response
+    recorded: list[tuple[str, int, int, int]] = []
+
+    async def _recording(request: TransparentRequest, *args: object, **kwargs: object) -> object:
+        reg_type = "HR" if isinstance(request, ReadHoldingRegistersRequest) else "IR"
+        recorded.append((reg_type, request.device_address, request.base_register, request.register_count))
+        return await original(request, *args, **kwargs)  # type: ignore[arg-type]
+
+    client.send_request_and_await_response = _recording  # type: ignore[method-assign]
+    return recorded
+
+
+@pytest.mark.parametrize("relpath", list(_GOLDEN))
+@pytest.mark.timeout(30)
+async def test_detect_wire_sequence_is_bit_identical(relpath: str):
+    """detect() over each fixture issues exactly the recorded outbound request sequence."""
+    mock = MockPlant.from_capture(_CAPTURES / relpath)
+    host, port = await mock.start("127.0.0.1", 0)
+    client = Client(host, port, tx_message_wait=0, tx_jitter=0)
+    await client.connect()
+    recorded = _tap_outbound(client)
+    try:
+        caps = await client.detect(**_DETECT)
+    finally:
+        await client.close()
+        await mock.aclose()
+
+    assert caps is not None  # detect completed; the sequence below is a full run, not a partial one
+    assert recorded == _GOLDEN[relpath]

--- a/tests/client/test_detect_characterisation.py
+++ b/tests/client/test_detect_characterisation.py
@@ -107,10 +107,10 @@ def _tap_outbound(client: Client) -> list[tuple[str, int, int, int]]:
 
     async def _recording(request: TransparentRequest, *args: object, **kwargs: object) -> object:
         reg_type = "HR" if isinstance(request, ReadHoldingRegistersRequest) else "IR"
-        recorded.append((reg_type, request.device_address, request.base_register, request.register_count))
+        recorded.append((reg_type, request.device_address, request.base_register, request.register_count))  # type: ignore[attr-defined]
         return await original(request, *args, **kwargs)  # type: ignore[arg-type]
 
-    client.send_request_and_await_response = _recording  # type: ignore[method-assign]
+    client.send_request_and_await_response = _recording  # type: ignore[assignment]
     return recorded
 
 
@@ -124,7 +124,7 @@ async def test_detect_wire_sequence_is_bit_identical(relpath: str):
     await client.connect()
     recorded = _tap_outbound(client)
     try:
-        caps = await client.detect(**_DETECT)
+        caps = await client.detect(**_DETECT)  # type: ignore[arg-type]
     finally:
         await client.close()
         await mock.aclose()

--- a/tests/client/test_offline_from_caches.py
+++ b/tests/client/test_offline_from_caches.py
@@ -15,7 +15,7 @@ import pytest
 from givenergy_modbus.client.client import Client
 from givenergy_modbus.exceptions import CommunicationError
 from givenergy_modbus.model.inverter import Model
-from givenergy_modbus.model.plant import Plant
+from givenergy_modbus.model.plant import Plant, _aio_module_candidates, _hv_bmu_candidates
 from givenergy_modbus.model.register import HR, IR
 from givenergy_modbus.model.register_cache import RegisterCache
 from givenergy_modbus.testing import MockPlant
@@ -144,3 +144,47 @@ def test_from_caches_raises_without_identity():
     """No HR(0) at 0x11 → CommunicationError, mirroring detect's identity-read failure."""
     with pytest.raises(CommunicationError, match="HR.0."):
         Plant.from_caches({0x32: RegisterCache({HR(0): 0x2001})})  # data present, but not at 0x11
+
+
+# --- Unit tests for pure candidate helpers (#268 slice 2) ---
+
+
+def test_hv_bmu_candidates_basic():
+    """Two BCUs with 2 modules each pack into 0x50-0x53 contiguously."""
+    assert _hv_bmu_candidates([(0, 2), (1, 2)]) == [0x50, 0x51, 0x52, 0x53]
+
+
+def test_hv_bmu_candidates_single_bcu():
+    assert _hv_bmu_candidates([(0, 3)]) == [0x50, 0x51, 0x52]
+
+
+def test_hv_bmu_candidates_clamped_at_band_end():
+    """A stack whose module count would overflow 0x6F is clamped silently."""
+    result = _hv_bmu_candidates([(0, 32)])
+    assert all(addr < 0x70 for addr in result)
+    assert result == list(range(0x50, 0x70))
+
+
+def test_hv_bmu_candidates_zero_modules():
+    assert _hv_bmu_candidates([(0, 0)]) == []
+
+
+def test_hv_bmu_candidates_empty():
+    assert _hv_bmu_candidates([]) == []
+
+
+def test_aio_module_candidates_normal():
+    assert _aio_module_candidates(2) == [0x50, 0x51]
+
+
+def test_aio_module_candidates_clamped():
+    """BCU-reported count > 4 is clamped to the 0x50–0x53 band."""
+    assert _aio_module_candidates(6) == [0x50, 0x51, 0x52, 0x53]
+
+
+def test_aio_module_candidates_exact_max():
+    assert _aio_module_candidates(4) == [0x50, 0x51, 0x52, 0x53]
+
+
+def test_aio_module_candidates_zero():
+    assert _aio_module_candidates(0) == []


### PR DESCRIPTION
## Summary

- Deduplicates capability-derivation logic: `_detect()` previously recapitulated the same is_valid() gating and address enumeration that `_derive_capabilities()` (offline path, #343) already owned. Now there is one implementation — the loop runs `_strategise → _probe_ranges → _derive_capabilities`.
- Three dead detect helpers removed (`_detect_aio_battery_modules`, `_detect_hv_bmu_modules`, `_detect_lv_bcu`) — replaced by `_strategise` + `_probe_ranges`.
- The bit-identical wire bar was locked before the refactor: the characterisation harness (`test_detect_characterisation.py`) pins the outbound request sequence frame-for-frame for all three identity-complete fixtures (hybrid_gen1, aio, ems) and confirmed identical sequences before and after.
- Pure candidate helpers (`_aio_module_candidates`, `_COLD_METER_RANGE`, `_COLD_LV_BATTERY_RANGE`) extracted to `plant.py` so both live and offline paths share a single enumeration policy.

**What stays imperative:** Steps 1 (identity bootstrap), 2 (BMS/BCU probes), 4 (LV batteries), and 5 (EMS rollup). Step 4 is explicitly quarantined: the cold-start corroborating re-read (#233/#289) resists pure decomposition and is marked for removal with #213.

## Loop design

```
ProbeRange(reg_type, device_address, base_register, register_count, tier)
  tier "known" → send_request_and_await_response (full timeout/retries)
  tier "probe" → _probe (probe_timeout/probe_retries, retry_delay=0)

_strategise(caps, prior, step) → list[ProbeRange]    # pure, no I/O
_probe_ranges(ranges, ...)     → None                 # single I/O seam
_derive_capabilities(caches, prior, on_reject=plant.mark_absent)  # validate
```

Steps covered by the loop: 2b (AIO modules), 2c (HV BMUs), 3 (meters), 4b (LV BCU).

## Test plan

- [x] Characterisation harness (`test_detect_characterisation.py`) — outbound wire sequence bit-identical before and after across all three fixtures
- [x] `test_detect.py` — existing policy/reprobe/held-battery/BCU-mark-absent pins all green; 6 tests for the deleted `_detect_hv_bmu_modules`/`_detect_lv_bcu` methods removed; `test_detect_lv_bcu_decode_error_is_swallowed` updated to patch at the correct module path
- [x] `test_offline_from_caches.py` — parity test (live detect == offline from_caches) green; 9 unit tests for extracted pure helpers added
- [x] Full tox matrix py311–py314 + lint + build green

Closes a portion of #268 (slices 1/3 already merged as #344/#343).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Device detection now uses a strategy-driven probing plan with deterministic candidate selection, including “cold” fallback ranges when hints are missing.
  * Probing tiers (known vs probe) improve consistency when identifying connected hardware.

* **Bug Fixes**
  * Prevents stale register-cache data from re-admitting meters, LV batteries, or BCUs after a probe failure.
  * Improves handling of validation/decoding failures during offline capability derivation via a rejection callback.

* **Tests**
  * Added wire-sequence “bit-identical” characterisation for `detect()`.
  * Added regression coverage for stale cache eviction and extended candidate-helper unit tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->