### PR TITLE
feat: generalise refresh skip-if-fresh to all banks via max_age (#268 slice 4)

### DIFF
--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -281,34 +281,48 @@ def _strategise(
     Calls the same candidate helpers as ``_derive_capabilities`` so candidate generation
     has one implementation.  No I/O.
     """
+    ranges: list[ProbeRange]
+
     if step == "aio_modules":
         num = caps.bcu_stacks[0][1] if caps.bcu_stacks else 0
         addrs: list[int] | range = (
             list(prior.aio_battery_module_addresses) if prior is not None else _aio_module_candidates(num)
         )
-        return [ProbeRange("IR", addr, 60, 60, "probe") for addr in addrs]
+        ranges = [ProbeRange("IR", addr, 60, 60, "probe") for addr in addrs]
 
-    if step == "hv_bmus":
+    elif step == "hv_bmus":
         if not (caps.is_hv and caps.device_type is not Model.ALL_IN_ONE and caps.bcu_stacks):
-            return []
-        addrs = (
-            list(prior.hv_bmu_addresses)
-            if prior is not None and prior.hv_bmu_addresses
-            else _hv_bmu_candidates(caps.bcu_stacks)
-        )
-        return [ProbeRange("IR", addr, 60, 60, "probe") for addr in addrs]
+            ranges = []
+        else:
+            addrs = (
+                list(prior.hv_bmu_addresses)
+                if prior is not None and prior.hv_bmu_addresses
+                else _hv_bmu_candidates(caps.bcu_stacks)
+            )
+            ranges = [ProbeRange("IR", addr, 60, 60, "probe") for addr in addrs]
 
-    if step == "meters":
+    elif step == "meters":
         addrs = prior.meter_addresses if prior is not None else _COLD_METER_RANGE
-        return [ProbeRange("IR", addr, 60, 30, "probe") for addr in addrs]
+        ranges = [ProbeRange("IR", addr, 60, 30, "probe") for addr in addrs]
 
-    if step == "lv_bcu":
+    elif step == "lv_bcu":
         addr = prior.lv_bcu_address if prior is not None else LV_BCU_ADDRESS
         if addr is None:
-            return []
-        return [ProbeRange("IR", addr, 60, 60, "probe")]
+            ranges = []
+        else:
+            ranges = [ProbeRange("IR", addr, 60, 60, "probe")]
 
-    raise ValueError(f"_strategise: unknown step {step!r}")
+    else:
+        raise ValueError(f"_strategise: unknown step {step!r}")
+
+    _logger.debug(
+        "_strategise(%s, prior=%s): %d range(s) → %s",
+        step,
+        "hinted" if prior is not None else "cold",
+        len(ranges),
+        [(f"0x{r.device_address:02x}", r.reg_type, r.base_register, r.register_count) for r in ranges],
+    )
+    return ranges
 
 
 class Client:
@@ -541,7 +555,16 @@ class Client:
             if pr.tier == "known":
                 await self.send_request_and_await_response(request, timeout=timeout, retries=retries)
             else:
-                if not await self._probe(request, timeout=probe_timeout, retries=probe_retries):
+                ok = await self._probe(request, timeout=probe_timeout, retries=probe_retries)
+                _logger.debug(
+                    "_probe_ranges: 0x%02x %s(%d,%d) → %s",
+                    pr.device_address,
+                    pr.reg_type,
+                    pr.base_register,
+                    pr.register_count,
+                    "present" if ok else "absent",
+                )
+                if not ok:
                     self.plant.mark_absent(pr.device_address, pr.reg_type, pr.base_register, pr.register_count)
                     self.plant.register_caches.pop(pr.device_address, None)
 

--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -7,6 +7,7 @@ import warnings
 from asyncio import Future, Queue, StreamReader, StreamWriter, Task
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Literal
 
 from givenergy_modbus.client.commands import (
@@ -323,6 +324,71 @@ def _strategise(
         [(f"0x{r.device_address:02x}", r.reg_type, r.base_register, r.register_count) for r in ranges],
     )
     return ranges
+
+
+def _refresh_banks(caps: PlantCapabilities) -> list[tuple[int, int, int]]:
+    """Return (device_address, base_register, register_count) for every IR bank to poll."""
+    inverter = caps.inverter_address
+    banks: list[tuple[int, int, int]] = []
+    if not caps.is_ems:
+        banks += [(inverter, 0, 60), (inverter, 180, 60)]
+    if caps.is_three_phase:
+        for base in range(1000, 1414, 60):
+            banks.append((inverter, base, min(60, 1414 - base)))
+    if caps.is_ems:
+        banks.append((inverter, 2040, 55))
+    if caps.is_gateway:
+        for base in range(1600, 1860, 60):
+            banks.append((inverter, base, min(60, 1860 - base)))
+    for addr in caps.lv_battery_addresses:
+        banks.append((addr, 60, 60))
+    if caps.lv_bcu_address is not None:
+        banks.append((caps.lv_bcu_address, 60, 60))
+    for addr in caps.meter_addresses:
+        banks.append((addr, 60, 30))
+    for offset, _ in caps.bcu_stacks:
+        banks.append((0x70 + offset, 60, 60))
+    for addr in caps.aio_battery_module_addresses:
+        banks.append((addr, 60, 60))
+    for addr in caps.hv_bmu_addresses:
+        banks.append((addr, 60, 60))
+    return banks
+
+
+def _refresh_ranges(
+    caps: PlantCapabilities,
+    max_age: float | None,
+    plant: Plant,
+    *,
+    now: datetime | None = None,
+) -> list[TransparentRequest]:
+    """Return the TransparentRequests for one refresh cycle, skipping fresh banks.
+
+    When ``max_age`` is None every bank is included (bit-identical to the pre-#268
+    behaviour). When set, any bank whose ``plant.block_age()`` is not None and ≤
+    ``max_age`` seconds is omitted. No I/O.
+    """
+    banks = _refresh_banks(caps)
+    if max_age is None:
+        return [
+            ReadInputRegistersRequest(base_register=base, register_count=count, device_address=addr)
+            for addr, base, count in banks
+        ]
+    reqs: list[TransparentRequest] = []
+    for addr, base, count in banks:
+        age = plant.block_age(addr, "IR", base, count, now=now)
+        if age is not None and age <= max_age:
+            _logger.debug(
+                "refresh: skipping IR(%d,%d)@0x%02x — %.1fs ≤ %.1fs max_age",
+                base,
+                count,
+                addr,
+                age,
+                max_age,
+            )
+            continue
+        reqs.append(ReadInputRegistersRequest(base_register=base, register_count=count, device_address=addr))
+    return reqs
 
 
 class Client:
@@ -1070,6 +1136,7 @@ class Client:
         timeout: float = 2.0,
         retries: int = 1,
         retry_delay: float = 0.5,
+        max_age: float | None = None,
         ir0_max_age: float | None = None,
     ) -> Plant:
         """Read IR measurement blocks for all known devices.
@@ -1088,15 +1155,17 @@ class Client:
         though the device is responsive (#132). Pass a tighter budget if you own the
         bus exclusively and want genuine failures surfaced faster.
 
-        ``ir0_max_age`` (seconds) opts in to skip-if-fresh for the IR(0,60) live block
-        (#196): GivEnergy dongles fan out the responses to whoever is polling them (the
-        cloud, the app, another client), so the network consumer often already has a
-        recent IR(0,60) in cache without us asking. When set, if IR(0,60) was committed
-        within ``ir0_max_age`` seconds it is not re-solicited this cycle, sparing the
-        (often flaky) dongle a request. Defaults to ``None`` — always solicit, the
-        historic behaviour. Scoped to IR(0,60) only for now; broaden once soak-tested.
-        Note the fan-out only exists while something else is polling the unit; on a
-        cloud-disconnected dongle the block ages out and we solicit it as normal.
+        ``max_age`` (seconds) opts in to skip-if-fresh for any IR bank (#196, #207):
+        GivEnergy dongles fan out the responses to whoever is polling them (the cloud,
+        the app, another client), so the consumer often already has recent data in cache
+        without us asking. When set, any IR bank committed within ``max_age`` seconds
+        is not re-solicited this cycle. Defaults to ``None`` — always solicit, the
+        historic behaviour. Note the fan-out only exists while something else is polling
+        the unit; on a cloud-disconnected dongle the blocks age out and we solicit them.
+
+        ``ir0_max_age`` is deprecated — use ``max_age`` instead. It applied the same
+        logic to IR(0,60) only; ``max_age`` extends it to every bank. Will be removed
+        in 3.0.
         """
         caps = self.plant.capabilities
         if caps is None:
@@ -1104,60 +1173,22 @@ class Client:
                 "refresh() requires plant capabilities — call detect() once first, "
                 "or restore a persisted PlantCapabilities onto client.plant.capabilities."
             )
-        inverter = caps.inverter_address
-        reqs: list[TransparentRequest] = []
-        # EMS plant controllers don't expose IR(0,60) or IR(180,60) — see load_config() and #86.
-        if not caps.is_ems:
-            ir0_age = self.plant.block_age(inverter, "IR", 0, 60) if ir0_max_age is not None else None
-            if ir0_max_age is not None and ir0_age is not None and ir0_age <= ir0_max_age:
-                _logger.debug(
-                    "Skipping IR(0,60) solicit for device 0x%02x — fan-out kept it fresh (%.1fs <= %.1fs)",
-                    inverter,
-                    ir0_age,
-                    ir0_max_age,
-                )
-            else:
-                reqs.append(ReadInputRegistersRequest(base_register=0, register_count=60, device_address=inverter))
-            reqs.append(ReadInputRegistersRequest(base_register=180, register_count=60, device_address=inverter))
-        if caps.is_three_phase:
-            for base in range(1000, 1414, 60):
-                reqs.append(
-                    ReadInputRegistersRequest(
-                        base_register=base,
-                        register_count=min(60, 1414 - base),
-                        device_address=inverter,
-                    )
-                )
-        if caps.is_ems:
-            reqs.append(ReadInputRegistersRequest(base_register=2040, register_count=55, device_address=inverter))
-        if caps.is_gateway:
-            for base in range(1600, 1860, 60):
-                reqs.append(
-                    ReadInputRegistersRequest(
-                        base_register=base,
-                        register_count=min(60, 1860 - base),
-                        device_address=inverter,
-                    )
-                )
-        for addr in caps.lv_battery_addresses:
-            reqs.append(ReadInputRegistersRequest(base_register=60, register_count=60, device_address=addr))
-        if caps.lv_bcu_address is not None:
-            # LV BCU stack-level page (#241) — count 60 matches the field-validated probe shape.
-            reqs.append(
-                ReadInputRegistersRequest(base_register=60, register_count=60, device_address=caps.lv_bcu_address)
+        if ir0_max_age is not None:
+            warnings.warn(
+                "refresh(ir0_max_age=...) is deprecated; use max_age= instead "
+                "(applies to all banks, not just IR(0,60)). ir0_max_age will be "
+                "removed in 3.0.",
+                DeprecationWarning,
+                stacklevel=2,
             )
-        for addr in caps.meter_addresses:
-            reqs.append(ReadInputRegistersRequest(base_register=60, register_count=30, device_address=addr))
-        for offset, _ in caps.bcu_stacks:
-            reqs.append(ReadInputRegistersRequest(base_register=60, register_count=60, device_address=0x70 + offset))
-        # AIO per-module battery caches (#192) — each module answers at its own address.
-        for addr in caps.aio_battery_module_addresses:
-            reqs.append(ReadInputRegistersRequest(base_register=60, register_count=60, device_address=addr))
-        # HV BMU per-module per-cell caches (#265) — each module answers at its own 0x50+ address
-        # (installer-confirmed, not yet wire-confirmed). Empty until detect probes the band.
-        for addr in caps.hv_bmu_addresses:
-            reqs.append(ReadInputRegistersRequest(base_register=60, register_count=60, device_address=addr))
-        await self._execute_reads(reqs, timeout=timeout, retries=retries, retry_delay=retry_delay)
+            if max_age is None:
+                max_age = ir0_max_age
+        await self._execute_reads(
+            _refresh_ranges(caps, max_age, self.plant),
+            timeout=timeout,
+            retries=retries,
+            retry_delay=retry_delay,
+        )
         return self.plant
 
     async def refresh_plant(

--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -1136,8 +1136,9 @@ class Client:
         timeout: float = 2.0,
         retries: int = 1,
         retry_delay: float = 0.5,
-        max_age: float | None = None,
         ir0_max_age: float | None = None,
+        *,
+        max_age: float | None = None,
     ) -> Plant:
         """Read IR measurement blocks for all known devices.
 

--- a/tests/client/test_load_refresh.py
+++ b/tests/client/test_load_refresh.py
@@ -244,6 +244,30 @@ async def test_refresh_single_phase_no_peripherals():
     assert _reqs(mock_exec) == [_ir(0, 60), _ir(180, 60)]
 
 
+async def test_refresh_hybrid_with_peripherals_golden_sequence():
+    """Golden: HYBRID with meter + LV battery — full ordered sequence must not drift.
+
+    Pins the relative order of inverter blocks, battery, and meter reads so that
+    _refresh_ranges extraction in Slice 4 cannot accidentally reorder or drop a bank.
+    """
+    client = _client_with_caps(
+        Model.HYBRID,
+        meter_addresses=[0x01],
+        lv_battery_addresses=[0x33, 0x34],
+        lv_bcu_address=0x31,
+    )
+    with patch.object(client, "_execute_reads", new_callable=AsyncMock) as mock_exec:
+        await client.refresh()
+    assert _reqs(mock_exec) == [
+        _ir(0, 60),  # inverter live block
+        _ir(180, 60),  # inverter second block
+        _ir(60, 60, device=0x33),  # LV battery 1
+        _ir(60, 60, device=0x34),  # LV battery 2
+        _ir(60, 60, device=0x31),  # LV BCU
+        _ir(60, 30, device=0x01),  # meter
+    ]
+
+
 async def test_refresh_three_phase():
     """Three-phase adds IR 1000–1413 as seven reads."""
     client = _client_with_caps(Model.HYBRID_3PH)

--- a/tests/client/test_refresh_resilience.py
+++ b/tests/client/test_refresh_resilience.py
@@ -337,3 +337,112 @@ async def test_refresh_default_always_solicits_ir0():
 
     recorded = await _refresh_recording_requests(client, timeout=0.1, retries=0)
     assert _ir0_requested(recorded, inverter)
+
+
+# ---------------------------------------------------------------------------
+# _refresh_ranges — pure function unit tests (#268 slice 4)
+# ---------------------------------------------------------------------------
+
+
+def test_refresh_ranges_no_max_age_includes_all_banks():
+    """With max_age=None every bank for a HYBRID plant is included."""
+    from givenergy_modbus.client.client import _refresh_ranges
+
+    plant, caps = _client_with_caps(Model.HYBRID, lv_battery_addresses=[0x33]).plant, None
+    client = _client_with_caps(Model.HYBRID, lv_battery_addresses=[0x33])
+    plant = client.plant
+    caps = client.plant.capabilities
+    reqs = _refresh_ranges(caps, None, plant)
+    addrs = [(r.device_address, r.base_register) for r in reqs]
+    assert (caps.inverter_address, 0) in addrs  # IR(0,60)
+    assert (caps.inverter_address, 180) in addrs  # IR(180,60)
+    assert (0x33, 60) in addrs  # LV battery
+
+
+def test_refresh_ranges_max_age_skips_fresh_ir0():
+    """Fresh IR(0,60) is excluded when max_age is set and block is within budget."""
+    from datetime import UTC, datetime
+
+    from givenergy_modbus.client.client import _refresh_ranges
+
+    client = _client_with_caps(Model.HYBRID)
+    plant, caps = client.plant, client.plant.capabilities
+    inverter = caps.inverter_address
+    plant.register_block_updated_at[(inverter, "IR", 0, 60)] = datetime.now(UTC)
+
+    reqs = _refresh_ranges(caps, 30, plant)
+    assert not any(r.device_address == inverter and r.base_register == 0 for r in reqs)
+    assert any(r.device_address == inverter and r.base_register == 180 for r in reqs)
+
+
+def test_refresh_ranges_max_age_skips_fresh_battery_bank():
+    """Fresh battery IR(60,60) is excluded when max_age is set."""
+    from datetime import UTC, datetime
+
+    from givenergy_modbus.client.client import _refresh_ranges
+
+    client = _client_with_caps(Model.HYBRID, lv_battery_addresses=[0x33])
+    plant, caps = client.plant, client.plant.capabilities
+    plant.register_block_updated_at[(0x33, "IR", 60, 60)] = datetime.now(UTC)
+
+    reqs = _refresh_ranges(caps, 30, plant)
+    assert not any(r.device_address == 0x33 for r in reqs)
+
+
+def test_refresh_ranges_max_age_skips_fresh_meter_bank():
+    """Fresh meter IR(60,30) is excluded when max_age is set."""
+    from datetime import UTC, datetime
+
+    from givenergy_modbus.client.client import _refresh_ranges
+
+    client = _client_with_caps(Model.HYBRID, meter_addresses=[0x01])
+    plant, caps = client.plant, client.plant.capabilities
+    plant.register_block_updated_at[(0x01, "IR", 60, 30)] = datetime.now(UTC)
+
+    reqs = _refresh_ranges(caps, 30, plant)
+    assert not any(r.device_address == 0x01 for r in reqs)
+
+
+def test_refresh_ranges_solicits_stale_block():
+    """A block older than max_age is always included."""
+    from datetime import UTC, datetime, timedelta
+
+    from givenergy_modbus.client.client import _refresh_ranges
+
+    client = _client_with_caps(Model.HYBRID)
+    plant, caps = client.plant, client.plant.capabilities
+    inverter = caps.inverter_address
+    plant.register_block_updated_at[(inverter, "IR", 0, 60)] = datetime.now(UTC) - timedelta(seconds=120)
+
+    reqs = _refresh_ranges(caps, 30, plant)
+    assert any(r.device_address == inverter and r.base_register == 0 for r in reqs)
+
+
+def test_refresh_ranges_solicits_never_seen_block():
+    """A block with no timestamp (never ingested) is always included."""
+    from givenergy_modbus.client.client import _refresh_ranges
+
+    client = _client_with_caps(Model.HYBRID)
+    plant, caps = client.plant, client.plant.capabilities
+    inverter = caps.inverter_address
+
+    reqs = _refresh_ranges(caps, 30, plant)
+    assert any(r.device_address == inverter and r.base_register == 0 for r in reqs)
+
+
+@pytest.mark.asyncio
+async def test_refresh_ir0_max_age_emits_deprecation_warning():
+    """ir0_max_age= still works but emits DeprecationWarning; behaviour matches max_age=."""
+    import warnings
+    from datetime import UTC, datetime
+
+    client = _client_with_caps(Model.HYBRID)
+    inverter = client.plant.capabilities.inverter_address
+    client.plant.register_block_updated_at[(inverter, "IR", 0, 60)] = datetime.now(UTC)
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        recorded = await _refresh_recording_requests(client, ir0_max_age=30, timeout=0.1, retries=0)
+
+    assert any(issubclass(x.category, DeprecationWarning) and "ir0_max_age" in str(x.message) for x in w)
+    assert not _ir0_requested(recorded, inverter)

--- a/tests/client/test_refresh_resilience.py
+++ b/tests/client/test_refresh_resilience.py
@@ -348,7 +348,6 @@ def test_refresh_ranges_no_max_age_includes_all_banks():
     """With max_age=None every bank for a HYBRID plant is included."""
     from givenergy_modbus.client.client import _refresh_ranges
 
-    plant, caps = _client_with_caps(Model.HYBRID, lv_battery_addresses=[0x33]).plant, None
     client = _client_with_caps(Model.HYBRID, lv_battery_addresses=[0x33])
     plant = client.plant
     caps = client.plant.capabilities


### PR DESCRIPTION
## Summary

- Extracts `_refresh_banks()` and `_refresh_ranges()` from `refresh()` as testable pure functions, paralleling how `_derive_capabilities` was extracted from `detect()` in Slice 3
- `max_age=` parameter on `refresh()` generalises the existing `ir0_max_age=` skip-if-fresh gate from IR(0,60) alone to every IR bank, using the existing `Plant.block_age()` infrastructure (#196, #207)
- `ir0_max_age=` now emits `DeprecationWarning` and maps to `max_age=`; scheduled for removal in 3.0
- Default `refresh()` (no `max_age`) is bit-identical to today — enforced by a golden-sequence characterisation test

## Test plan
- [ ] `test_refresh_hybrid_with_peripherals_golden_sequence` — pins the default (no `max_age`) wire order for a multi-peripheral HYBRID topology
- [ ] 6 `_refresh_ranges` unit tests: no-max-age includes all banks; fresh IR(0,60)/battery/meter each excluded; stale and never-seen blocks always solicited
- [ ] `test_refresh_ir0_max_age_emits_deprecation_warning` — confirms old callers get the warning and the skip still works
- [ ] 1450 tests passing, tox py311–py314 green

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional freshness threshold for refreshes, so recently updated data can be skipped instead of re-read.
  * Refreshes now follow a more consistent order across inverter, battery, meter, and related device data.

* **Bug Fixes**
  * Improved detection logging and cache handling when devices are probed.
  * Kept the previous full-refresh behaviour when no freshness threshold is set.

* **Chores**
  * Added coverage for refresh ordering and freshness-based read skipping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->