### PR TITLE
feat: skip detect-confirmed-absent banks in refresh() (#268 slice 5)

### DIFF
--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -362,31 +362,33 @@ def _refresh_ranges(
     *,
     now: datetime | None = None,
 ) -> list[TransparentRequest]:
-    """Return the TransparentRequests for one refresh cycle, skipping fresh banks.
+    """Return the TransparentRequests for one refresh cycle, skipping absent and fresh banks.
 
-    When ``max_age`` is None every bank is included (bit-identical to the pre-#268
-    behaviour). When set, any bank whose ``plant.block_age()`` is not None and ≤
-    ``max_age`` seconds is omitted. No I/O.
+    A bank that detect marked ABSENT (``plant.block_present()`` is False) is skipped
+    unconditionally — the presence marker is a stronger, cheaper signal than a timeout,
+    so a known-absent device is never re-solicited (call ``detect()`` or
+    ``invalidate_presence()`` to recheck). Of the remaining banks, when ``max_age`` is
+    set any whose ``plant.block_age()`` is not None and ≤ ``max_age`` seconds is also
+    omitted. With ``max_age`` None and no absent banks every bank is included
+    (bit-identical to the pre-#268 behaviour). No I/O.
     """
-    banks = _refresh_banks(caps)
-    if max_age is None:
-        return [
-            ReadInputRegistersRequest(base_register=base, register_count=count, device_address=addr)
-            for addr, base, count in banks
-        ]
     reqs: list[TransparentRequest] = []
-    for addr, base, count in banks:
-        age = plant.block_age(addr, "IR", base, count, now=now)
-        if age is not None and age <= max_age:
-            _logger.debug(
-                "refresh: skipping IR(%d,%d)@0x%02x — %.1fs ≤ %.1fs max_age",
-                base,
-                count,
-                addr,
-                age,
-                max_age,
-            )
+    for addr, base, count in _refresh_banks(caps):
+        if plant.block_present(addr, "IR", base, count) is False:
+            _logger.debug("refresh: skipping IR(%d,%d)@0x%02x — detect marked it absent", base, count, addr)
             continue
+        if max_age is not None:
+            age = plant.block_age(addr, "IR", base, count, now=now)
+            if age is not None and age <= max_age:
+                _logger.debug(
+                    "refresh: skipping IR(%d,%d)@0x%02x — %.1fs ≤ %.1fs max_age",
+                    base,
+                    count,
+                    addr,
+                    age,
+                    max_age,
+                )
+                continue
         reqs.append(ReadInputRegistersRequest(base_register=base, register_count=count, device_address=addr))
     return reqs
 

--- a/tests/client/test_refresh_resilience.py
+++ b/tests/client/test_refresh_resilience.py
@@ -445,3 +445,57 @@ async def test_refresh_ir0_max_age_emits_deprecation_warning():
 
     assert any(issubclass(x.category, DeprecationWarning) and "ir0_max_age" in str(x.message) for x in w)
     assert not _ir0_requested(recorded, inverter)
+
+
+# ---------------------------------------------------------------------------
+# _refresh_ranges — ABSENT presence-marker skip (#268 slice 5)
+# ---------------------------------------------------------------------------
+
+
+def test_refresh_ranges_skips_absent_bank_even_without_max_age():
+    """A detect-marked-absent bank is skipped on the default (max_age=None) path; siblings still polled."""
+    from givenergy_modbus.client.client import _refresh_ranges
+
+    client = _client_with_caps(Model.HYBRID, lv_battery_addresses=[0x33, 0x34])
+    plant, caps = client.plant, client.plant.capabilities
+    plant.mark_absent(0x34, "IR", 60, 60)
+
+    reqs = _refresh_ranges(caps, None, plant)
+    assert any(r.device_address == 0x33 for r in reqs)
+    assert not any(r.device_address == 0x34 for r in reqs)
+
+
+def test_refresh_ranges_skips_absent_bank_regardless_of_freshness():
+    """The absent skip applies even with max_age set (presence beats freshness)."""
+    from givenergy_modbus.client.client import _refresh_ranges
+
+    client = _client_with_caps(Model.HYBRID, lv_battery_addresses=[0x34])
+    plant, caps = client.plant, client.plant.capabilities
+    plant.mark_absent(0x34, "IR", 60, 60)
+
+    reqs = _refresh_ranges(caps, 30, plant)
+    assert not any(r.device_address == 0x34 for r in reqs)
+
+
+def test_refresh_ranges_includes_present_bank():
+    """An explicitly-PRESENT bank is not over-skipped."""
+    from givenergy_modbus.client.client import _refresh_ranges
+
+    client = _client_with_caps(Model.HYBRID)
+    plant, caps = client.plant, client.plant.capabilities
+    inverter = caps.inverter_address
+    plant.register_block_present[(inverter, "IR", 0, 60)] = True
+
+    reqs = _refresh_ranges(caps, None, plant)
+    assert any(r.device_address == inverter and r.base_register == 0 for r in reqs)
+
+
+@pytest.mark.asyncio
+async def test_refresh_does_not_solicit_absent_device():
+    """End-to-end: refresh() never puts a marked-absent battery on the wire."""
+    client = _client_with_caps(Model.HYBRID, lv_battery_addresses=[0x33, 0x34])
+    client.plant.mark_absent(0x34, "IR", 60, 60)
+
+    recorded = await _refresh_recording_requests(client, timeout=0.1, retries=0)
+    assert not any(r.device_address == 0x34 for r in recorded)
+    assert any(r.device_address == 0x33 for r in recorded)


### PR DESCRIPTION
## Summary

Final slice of the #268 epic. `_refresh_ranges` now reads the tri-state presence marker that Slice 1 (#344) introduced: a bank that `detect()` marked ABSENT (`Plant.block_present()` returns `False`) is skipped **before** the `max_age` freshness gate, unconditionally. The presence marker is a stronger, cheaper signal than a 2s timeout — a known-absent device should never be re-solicited every poll cycle. Re-discovery stays `detect()`'s job (or `invalidate_presence()` → UNKNOWN); refresh polls what's known-present.

This closes the loop on the marker: `mark_absent` now has both a writer (every detect probe-failure site, Slice 1) and a reader (the refresh poll path).

The `max_age is None` fast path folds into one unified loop — output is **bit-identical for real topologies**, since `caps` never lists an absent bank in the normal flow (absent peripherals aren't in caps). The skip only fires when a caps bank and a `False` presence marker coexist — the capabilities-as-target direction (optimistic/restored caps vs live reality).

## Test plan
- [ ] `test_refresh_ranges_skips_absent_bank_even_without_max_age` — absent bank dropped on the default path; present sibling still polled
- [ ] `test_refresh_ranges_skips_absent_bank_regardless_of_freshness` — absent skip applies with `max_age` set too (presence beats freshness)
- [ ] `test_refresh_ranges_includes_present_bank` — explicitly-PRESENT bank not over-skipped
- [ ] `test_refresh_does_not_solicit_absent_device` — end-to-end: `refresh()` never puts the absent device on the wire
- [ ] Golden-sequence characterisation tests unchanged (no banks marked absent in those fixtures)
- [ ] 1454 tests passing, tox py311–py314 green

Completes #268.

🤖 Generated with [Claude Code](https://claude.com/claude-code)