### PR TITLE
fix: route caps-absent 0x32 reads to the battery guard (#352)

### DIFF
--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -850,6 +850,18 @@ class Client:
             timeout=timeout,
             retries=retries,
         )
+        # #352/#289: since #352 a caps-absent 0x32 read routes through the battery getter, so its first
+        # preamble frame is held by the cold-start splice guard (the cache stays empty pending a
+        # corroborating re-read) exactly like 0x33+. detect() reads each address once, so without this
+        # confirming read the primary pack is dropped at the _derive_capabilities gate below and
+        # refresh() never re-polls it. One healthy re-read corroborates and commits; a flapping/spliced
+        # bank fails to corroborate and correctly stays out (#289 anti-poison intact).
+        if not self.plant.register_caches.get(0x32):
+            await self.send_request_and_await_response(
+                ReadInputRegistersRequest(base_register=60, register_count=60, device_address=0x32),
+                timeout=timeout,
+                retries=retries,
+            )
         batt_candidates = prior.lv_battery_addresses if prior is not None else _COLD_LV_BATTERY_RANGE
         for batt_addr in batt_candidates:
             if batt_addr > 0x32:

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -214,7 +214,7 @@ class PlantCapabilities(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     device_type: Model
-    inverter_address: int = 0x32
+    inverter_address: int = 0x11  # 0x11 since #189; _derive_inverter_address overwrites per model (#352)
     meter_addresses: list[int] = Field(default_factory=list)
     lv_battery_addresses: list[int] = Field(default_factory=list)
     # Each entry is (bcu_offset, num_modules) where the BCU device address is 0x70 + bcu_offset.
@@ -901,11 +901,13 @@ class Plant(GivEnergyBaseModel):
         With capabilities the inverter lives at ``capabilities.inverter_address``
         (0x11 since #189; 0x31 may persist from pre-#189 state and the AC/
         HYBRID_GEN1 hardware facade still answers there) and 0x32 is LV battery
-        pack #1. Without capabilities we fall back to the legacy mapping where
-        the inverter was cached at 0x32, and also treat 0x11/0x31 as inverter so
-        replay/debug tooling (which feeds PDUs to a bare Plant) keeps validating
-        inverter banks at either wire address — including passive captures of
-        other consumers still polling the 0x31 facade.
+        pack #1. Without capabilities the separation is unconditional (#352): only
+        0x11/0x31 are the inverter and 0x32–0x37 are LV battery packs. This means a
+        0x32 read issued before detect() sets capabilities still routes through the
+        battery splice guard rather than the inverter getter — closing the #350
+        seeding window. (The pre-#189 layout where 0x32 carried inverter data is no
+        longer aliased here, consistent with a persisted 0x32 surfacing as a
+        PlantTopologyMismatch; live use always has capabilities after detect().)
         """
         if self.capabilities is not None:
             if device_address == self.capabilities.inverter_address:
@@ -919,9 +921,9 @@ class Plant(GivEnergyBaseModel):
             if 0x32 <= device_address <= 0x37:
                 return BatteryRegisterGetter
         else:
-            if device_address in (0x11, 0x31, 0x32):
+            if device_address in (0x11, 0x31):
                 return SinglePhaseInverterRegisterGetter
-            if 0x33 <= device_address <= 0x37:
+            if 0x32 <= device_address <= 0x37:
                 return BatteryRegisterGetter
         if 0x01 <= device_address <= 0x08:
             return MeterRegisterGetter
@@ -1791,12 +1793,14 @@ class Plant(GivEnergyBaseModel):
         capability may still point at 0x31, which detect() doesn't populate (it reads
         identity at 0x11), so this would otherwise KeyError between detect() and the
         first poll. Returns an empty-cache model in that window, matching the
-        .ems / .gateway accessors. (#119, #189)
+        .ems / .gateway accessors. Without capabilities the inverter is read at its
+        canonical address 0x11 (#352) — not 0x32, which is LV battery pack #1 — via
+        ``.get`` since 0x11 is not pre-allocated on a bare Plant. (#119, #189)
         """
         if self.capabilities:
             cache = self.register_caches.get(self.capabilities.inverter_address, RegisterCache())
             return select_inverter(self.capabilities.device_type, cache)
-        return SinglePhaseInverter.from_register_cache(self.register_caches[0x32])
+        return SinglePhaseInverter.from_register_cache(self.register_caches.get(0x11, RegisterCache()))
 
     @property
     def inverter_serial(self) -> str:

--- a/tests/client/test_detect.py
+++ b/tests/client/test_detect.py
@@ -9,6 +9,7 @@ from givenergy_modbus.exceptions import CommunicationError, PlantTopologyMismatc
 from givenergy_modbus.model.inverter import Model
 from givenergy_modbus.model.plant import PlantCapabilities
 from givenergy_modbus.model.register import HR, IR
+from givenergy_modbus.pdu import ReadInputRegistersResponse
 
 
 def _make_client() -> Client:
@@ -1394,6 +1395,66 @@ async def test_detect_lv_batteries_invalid_slot_skipped_not_aborted():
     assert 0x32 in caps.lv_battery_addresses
     assert 0x33 not in caps.lv_battery_addresses  # ghost — skipped
     assert 0x34 in caps.lv_battery_addresses
+
+
+def _healthy_battery_bank() -> dict[int, int]:
+    """A coherent LV battery bank (IR60–119) with a valid serial — commits through the splice guard."""
+    bank: dict[int, int] = {60 + i: 3300 for i in range(16)}  # 16 cells @ 3.300 V
+    bank.update({76 + i: 250 for i in range(4)})  # cell-mass temps @ 25.0 °C
+    bank.update({80: 52800, 97: 16, 98: 3005, 100: 55})  # v_sum, num_cells, bms_fw, soc
+    # valid serial "SA1234A567" at IR(110–114), matching _prime_battery_serial
+    bank.update({110: 0x5341, 111: 0x3132, 112: 0x3334, 113: 0x4135, 114: 0x3637})
+    return bank
+
+
+def _battery_ir_response(device_address: int, bank: dict[int, int]) -> MagicMock:
+    """A minimal ReadInputRegistersResponse mock that update() commits via the battery getter."""
+    pdu = MagicMock(spec=ReadInputRegistersResponse)
+    pdu.device_address = device_address
+    pdu.base_register = 60
+    pdu.register_count = 60
+    pdu.error = False
+    pdu.crc_failed = False
+    pdu.inverter_serial_number = ""
+    pdu.data_adapter_serial_number = ""
+    pdu.to_dict.return_value = bank
+    pdu.is_suspicious.return_value = False
+    return pdu
+
+
+@pytest.mark.asyncio
+async def test_detect_primary_battery_survives_cold_start_hold():
+    """The primary 0x32 LV battery is still detected when its first frame is cold-start-held (#352).
+
+    Since #352 a caps-absent 0x32 read routes through the battery getter, so the detect() preamble
+    frame is held by the cold-start splice guard (#289) — the cache stays empty pending corroboration.
+    Without a confirming re-read the primary pack is dropped from lv_battery_addresses and refresh()
+    never re-polls it. This feeds a healthy 0x32 bank through the real plant.update() path (exercising
+    the guard rather than pre-priming the cache) and asserts the corroborating re-read commits it.
+    """
+    client = _make_client()
+    _prime_cache(client, 0x11, {HR(0): 0x2001, HR(21): 0})  # inverter/model only — 0x32 NOT pre-primed
+    bank = _healthy_battery_bank()
+
+    async def _send_side_effect(request, *, timeout, retries):
+        # Feed the healthy 0x32 bank through update() so the cold-start guard runs; detect issues this
+        # twice (preamble + corroborating re-read), and the second commits the held baseline.
+        if request.device_address == 0x32 and getattr(request, "base_register", None) == 60:
+            client.plant.update(_battery_ir_response(0x32, bank))
+        return MagicMock()
+
+    async def _probe_side_effect(request, *, timeout, retries):
+        return False  # no additional packs at 0x33+
+
+    with (
+        patch.object(client, "send_request_and_await_response", side_effect=_send_side_effect),
+        patch.object(client, "_probe", side_effect=_probe_side_effect),
+    ):
+        caps = await client.detect()
+
+    assert 0x32 in caps.lv_battery_addresses  # the corroborating re-read committed the held frame
+    assert client.plant.cold_start_held_count.get(0x32, 0) >= 1  # proves the guard actually engaged
+    assert client.plant.register_caches[0x32][IR(60)] == 3300  # healthy data committed
 
 
 # ---------------------------------------------------------------------------

--- a/tests/client/test_detect_characterisation.py
+++ b/tests/client/test_detect_characterisation.py
@@ -15,7 +15,7 @@ from the unchanged `detect()` over each MockPlant fixture.
 Coverage — the three identity-complete fixtures that drive a live detect over MockPlant
 deterministically (the same set `test_offline_from_caches.py` uses, for the same reason):
   - hybrid_gen1: Step 1 (identity), Step 3 (meter sweep), Step 4 (LV batteries — incl. the cold-start
-    re-read at 0x33, #233/#289), Step 4b (LV BCU).
+    re-read at 0x32 (#352) and 0x33 (#233/#289)), Step 4b (LV BCU).
   - aio:         Step 1, Step 2 (BMS@0xA0 + BCU@0x70), Step 2b (AIO modules 0x50–0x53), Step 3.
   - ems:         Step 1, Step 3, Step 5 (EMS rollup IR(2040,55) — a known-tier read).
 The non-AIO HV BMU path (Step 2c) has no live-drivable fixture (three_phase_hv_a is a passive refresh
@@ -39,9 +39,9 @@ _DETECT = dict(timeout=1.0, retries=0, probe_timeout=0.1, probe_retries=0)
 # Golden outbound sequences as (reg_type, device_address, base_register, register_count) — literal
 # recordings from the unchanged detect(). Order is significant.
 _GOLDEN: dict[str, list[tuple[str, int, int, int]]] = {
-    # HYBRID_GEN1 — meters (Step 3) precede the LV battery sweep (Step 4); 0x32 is read once via the
-    # known-tier preamble, 0x33 twice (the cold-start corroborating re-read), 0x34–0x37 once each
-    # (absent → mark_absent), then the LV BCU at 0x31 (Step 4b).
+    # HYBRID_GEN1 — meters (Step 3) precede the LV battery sweep (Step 4); 0x32 and 0x33 are each read
+    # twice (the cold-start corroborating re-read — for 0x32 since #352 routes it through the battery
+    # getter too), 0x34–0x37 once each (absent → mark_absent), then the LV BCU at 0x31 (Step 4b).
     "hybrid_2_bat_a/hybrid_gen1_arm449_0x11_poll_10min.log": [
         ("HR", 0x11, 0, 60),
         ("IR", 0x01, 60, 30),
@@ -52,6 +52,7 @@ _GOLDEN: dict[str, list[tuple[str, int, int, int]]] = {
         ("IR", 0x06, 60, 30),
         ("IR", 0x07, 60, 30),
         ("IR", 0x08, 60, 30),
+        ("IR", 0x32, 60, 60),
         ("IR", 0x32, 60, 60),
         ("IR", 0x33, 60, 60),
         ("IR", 0x33, 60, 60),

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -984,9 +984,9 @@ def test_from_actual():
         ),
     }
 
-    # 0x11 decodes the inverter identity (#352); 0x32 stays LV battery pack #1 — both
-    # from the same real capture, which historically sat at a single 0x32 address.
-    register_caches[0x11] = register_caches[0x32]
+    # 0x11 decodes the inverter identity (#352); 0x32 stays LV battery pack #1 — an
+    # independent copy of the same real capture, which historically sat at one 0x32 address.
+    register_caches[0x11] = RegisterCache(register_caches[0x32])
 
     p = Plant(register_caches=register_caches)
     i = p.inverter

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -82,8 +82,10 @@ def test_plant(
         "register_caches": {0x32: {}},
     }
 
-    # inject register values
-    plant.register_caches[0x32].update(register_cache_inverter_daytime_discharging_with_solar_generation)
+    # inject register values: inverter identity at 0x11, LV battery pack #1 at 0x32 (#352)
+    plant.register_caches.setdefault(0x11, RegisterCache()).update(
+        register_cache_inverter_daytime_discharging_with_solar_generation
+    )
     plant.register_caches[0x32].update(register_cache_battery_daytime_discharging)
 
     assert plant.model_dump() == {
@@ -982,6 +984,10 @@ def test_from_actual():
         ),
     }
 
+    # 0x11 decodes the inverter identity (#352); 0x32 stays LV battery pack #1 — both
+    # from the same real capture, which historically sat at a single 0x32 address.
+    register_caches[0x11] = register_caches[0x32]
+
     p = Plant(register_caches=register_caches)
     i = p.inverter
     assert i.model_dump() == {
@@ -1712,6 +1718,19 @@ def test_getter_for_device_address_with_capabilities():
     assert plant._getter_for_device_address(0x32).__name__ == "BatteryRegisterGetter"
     assert plant._getter_for_device_address(0x05).__name__ == "MeterRegisterGetter"
     assert plant._getter_for_device_address(0x99) is None
+
+
+def test_getter_for_device_address_without_capabilities():
+    """Without capabilities, 0x32-0x37 are batteries and only 0x11/0x31 are the inverter (#352).
+
+    Retires the pre-#189 fallback that aliased a bare Plant's 0x32 to the inverter getter — the gap
+    that let a caps-None 0x32 read bypass the battery splice guard (#350).
+    """
+    plant = Plant()  # no capabilities
+    assert plant._getter_for_device_address(0x11).__name__ == "SinglePhaseInverterRegisterGetter"
+    assert plant._getter_for_device_address(0x31).__name__ == "SinglePhaseInverterRegisterGetter"
+    assert plant._getter_for_device_address(0x32).__name__ == "BatteryRegisterGetter"
+    assert plant._getter_for_device_address(0x33).__name__ == "BatteryRegisterGetter"
 
 
 def test_getter_for_device_address_lv_bcu():
@@ -2760,9 +2779,9 @@ def test_register_age_keeps_freshest_when_older_window_seen_later(plant: Plant):
 #
 # Tests that the splice guard correctly rejects or escrows LV battery banks
 # carrying physics-impossible register deltas, even when CRC, bounds, and
-# serial-coherence checks pass. All tests target device 0x33: on a bare
-# Plant, 0x32 → SinglePhaseInverterRegisterGetter and 0x33–0x37 →
-# BatteryRegisterGetter, so only 0x33+ is guarded.
+# serial-coherence checks pass. All tests target device 0x33: since #352
+# every 0x32–0x37 address routes to BatteryRegisterGetter, and 0x33 is used
+# as a clean, non-pre-seeded battery address for these guard tests.
 # ---------------------------------------------------------------------------
 
 
@@ -2805,7 +2824,7 @@ def _coherent_battery_bank(overrides: dict[int, int] | None = None) -> dict[int,
     return bank
 
 
-_BATT = 0x33  # battery pack #1 on bare Plant; 0x32 → inverter getter on bare Plant
+_BATT = 0x33  # an LV battery address (0x32–0x37 all route to the battery getter, #352)
 
 
 def _establish_baseline(
@@ -3051,19 +3070,38 @@ def test_splice_impossible_frame_refused_at_commit_battery_getter(plant: Plant):
 
 
 def test_splice_impossible_frame_refused_at_commit_when_caps_absent(plant: Plant, caplog):
-    """The modbus#350 seeding path: an impossible 0x32 frame is refused even with capabilities absent.
+    """The modbus#350 impossible-frame refusal holds with capabilities absent.
 
-    A 0x32 read during a capabilities-None window (a fresh Plant mid-reconnect) misroutes to the
-    inverter getter and bypasses the battery splice guard — so the getter-agnostic _commit_bank guard
-    is the one that must refuse it, or it seeds the poisoned baseline the guard later defends.
+    Since #352 a caps-None 0x32 read routes to the battery getter, so the splice guard now engages —
+    but the getter-agnostic _commit_bank impossible-guard still fires first, refusing an all-cells-zero
+    frame before it can seed a baseline regardless of getter routing.
     """
     import logging
 
-    assert plant.capabilities is None  # bare plant: 0x32 routes to the inverter getter, not battery
+    assert plant.capabilities is None  # bare plant: 0x32 → battery getter (#352); impossible frame refused either way
     with caplog.at_level(logging.WARNING, logger="givenergy_modbus.model.plant"):
         _feed_bank(plant, _impossible_zero_cell_bank(), device_address=0x32, received_at=_T0)
     assert IR(60) not in plant.register_caches[0x32], "impossible frame must never seed the cache"
     assert any("internally-impossible" in r.message for r in caplog.records)
+
+
+def test_caps_none_0x32_bank_splice_guarded_and_cold_start_held(caplog):
+    """A bare-Plant 0x32 bank now gets the full splice guard — cold-start-held, not committed unchecked.
+
+    Since #352 a caps-None 0x32 read routes to the battery getter, so a healthy first frame is held for
+    cold-start corroboration (it would have committed silently via the inverter getter before) and a
+    second corroborating read commits it — closing the #350 seeding window for every corruption shape.
+    """
+    import logging
+
+    plant = Plant()  # no capabilities
+    healthy = _coherent_battery_bank()
+    with caplog.at_level(logging.INFO, logger="givenergy_modbus.model.plant"):
+        _feed_bank(plant, healthy, device_address=0x32, received_at=_T0)
+        assert IR(60) not in plant.register_caches[0x32], "first frame must be held pending corroboration"
+        _feed_bank(plant, healthy, device_address=0x32, received_at=_T0 + timedelta(seconds=30))
+    assert plant.register_caches[0x32][IR(60)] == 3300, "corroborated frame commits"
+    assert any("cold-start" in r.message for r in caplog.records)
 
 
 def test_splice_temp_cohort_zeros_rejected(plant: Plant, caplog):
@@ -3525,18 +3563,22 @@ def test_splice_short_read_refuses_temp_zero_cohort(plant: Plant, caplog):
 
 
 def test_splice_non_battery_device_skips_guard(plant: Plant, caplog):
-    """On a bare Plant, 0x32 → inverter getter; the splice guard is not applied there."""
+    """On a bare Plant, 0x11 → inverter getter; the splice guard is not applied there (#352).
+
+    Since #352 every 0x32–0x37 address routes to the battery getter, so the inverter
+    address 0x11 is the natural non-battery device that bypasses the splice guard.
+    """
     import logging
 
-    # Seed 0x32 with a battery-shaped bank (committed under the inverter getter).
-    _feed_bank(plant, _coherent_battery_bank(), device_address=0x32, received_at=_T0)
-    # Two battery-physics trips — would be rejected on 0x33, but 0x32 is not BatteryRegisterGetter.
+    # Seed 0x11 (the inverter) with a battery-shaped bank — committed under the inverter getter.
+    _feed_bank(plant, _coherent_battery_bank(), device_address=0x11, received_at=_T0)
+    # Two battery-physics trips — would be rejected on a battery address, but 0x11 is not BatteryRegisterGetter.
     wild = _coherent_battery_bank({60: 3700, 76: 0})
     with caplog.at_level(logging.WARNING, logger="givenergy_modbus.model.plant"):
-        _feed_bank(plant, wild, device_address=0x32, received_at=_T0 + timedelta(seconds=30))
+        _feed_bank(plant, wild, device_address=0x11, received_at=_T0 + timedelta(seconds=30))
     warns = [r for r in caplog.records if "splice" in r.message.lower() or "Held battery bank" in r.message]
     assert not warns
-    assert plant.register_caches[0x32][IR(60)] == 3700  # committed
+    assert plant.register_caches[0x11][IR(60)] == 3700  # committed
 
 
 def test_splice_escrow_isolated_per_device(plant: Plant):

--- a/tests/model/test_plant_accessors.py
+++ b/tests/model/test_plant_accessors.py
@@ -7,7 +7,7 @@ from givenergy_modbus.model.inverter import Model
 from givenergy_modbus.model.inverter_threephase import ThreePhaseInverter
 from givenergy_modbus.model.meter import Meter
 from givenergy_modbus.model.plant import Plant, PlantCapabilities
-from givenergy_modbus.model.register import IR
+from givenergy_modbus.model.register import HR, IR
 from givenergy_modbus.model.register_cache import RegisterCache
 
 
@@ -28,12 +28,17 @@ def _prime(plant: Plant, device_addr: int, registers: dict) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_inverter_falls_back_without_capabilities():
-    plant = Plant()
-    # No capabilities: returns SinglePhaseInverter from 0x32 cache as before.
+def test_inverter_falls_back_to_0x11_without_capabilities():
+    """Without capabilities, .inverter reads the inverter identity at 0x11, not battery pack 1 at 0x32 (#352)."""
     from givenergy_modbus.model.inverter import SinglePhaseInverter
 
+    plant = Plant()
+    # Empty bare Plant: still an empty SinglePhaseInverter, no KeyError (0x11 is not pre-allocated).
     assert isinstance(plant.inverter, SinglePhaseInverter)
+    # Inverter serial (HR13-17 → "SA1234G567") lives at 0x11; battery cell data sits at 0x32.
+    _prime(plant, 0x11, {HR(13): 0x5341, HR(14): 0x3132, HR(15): 0x3334, HR(16): 0x4735, HR(17): 0x3637})
+    _prime(plant, 0x32, {IR(60): 3300})  # battery cell — must not surface through .inverter
+    assert plant.inverter.serial_number == "SA1234G567"  # decoded from 0x11, not the 0x32 battery cache
 
 
 def test_inverter_returns_threephase_for_threephase_model():


### PR DESCRIPTION
Closes #352. Finishes the #119/#189 addressing migration by making the inverter/battery address separation unconditional, closing the structural window behind #350.

## Background
#350 (fixed in 2.9.3) was a silent primary-battery loss. On a fresh `Plant` mid-reconnect, `capabilities` is `None`, and an `IR(60,60)@0x32` battery preamble read *before* capabilities are set fell through the legacy fallback to the **inverter** getter — bypassing the battery splice guard (gated on `BatteryRegisterGetter`), so a corrupt frame could seed a poisoned baseline. 2.9.3 refused the catastrophic all-cells-zero shape getter-agnostically and added a self-heal, but the addressing muddle remained and other splice shapes were still unguarded in that window.

## Change
Without capabilities, only `0x11`/`0x31` are the inverter and `0x32–0x37` are LV battery packs. A caps-absent `0x32` read now gets the full splice guard + cold-start hold from the first frame, for every corruption shape.

- `_getter_for_device_address` — caps-None branch routes `0x32` to the battery getter.
- `Plant.inverter` — caps-None reads the inverter at its canonical `0x11` (via `.get`, since `0x11` isn't pre-allocated on a bare `Plant`).
- `PlantCapabilities.inverter_address` default `0x32 → 0x11` (a stale vestige; `_derive_inverter_address` already overwrites it per model).

The only behaviour retired is replaying a pre-#189 capture (inverter at `0x32`) into a bare `Plant` — no fixture does this and live use always has capabilities after `detect()`; consistent with a persisted `0x32` already surfacing as `PlantTopologyMismatch`.

## Tests
- New caps-None routing test + a cold-start-engages test proving the window is guarded for all shapes (not just the impossible one).
- The two bare-Plant `.inverter` golden tests and the non-battery-device splice test move to `0x11`; the #350 caps-absent test comment is updated.
- Builds on #353, which moved the mechanical `0x32 → 0x11` cache-mechanics churn out of the way.

## Verification
- Full suite green (1463 passed); `tox` (py311–py314 + lint/mypy) green.
- On my own HA, I'll watch the next reconnect to confirm the `0x32` preamble now emits a cold-start hold line instead of committing silently — I'll report back once I've seen it.

Likely a patch (2.9.4): no intended public API change; the only altered default was a stale inverter address that was always overwritten in practice.
