### PR TITLE
fix: graceful connection teardown + typed ConnectionLost on unexpected drops (#356)

### DIFF
--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -1572,10 +1572,10 @@ class Client:
                 if frame_sent and not frame_sent.done():
                     frame_sent.set_result(True)
                 continue
-            self.writer.write(message)
-            if self._capture_sink is not None and self._capture_redactor_tx is not None:
-                self._emit_to_sink("tx", self._capture_redactor_tx.feed(message))
             try:
+                self.writer.write(message)
+                if self._capture_sink is not None and self._capture_redactor_tx is not None:
+                    self._emit_to_sink("tx", self._capture_redactor_tx.feed(message))
                 await asyncio.wait_for(self.writer.drain(), timeout=_DRAIN_TIMEOUT)
             except TimeoutError:
                 _logger.warning(
@@ -1583,6 +1583,19 @@ class Client:
                     _DRAIN_TIMEOUT,
                 )
                 exc = ConnectionLost("writer drain stalled — connection lost")
+                # This frame is already dequeued, so the teardown's queue-drain
+                # can't reach it — fail its futures here.
+                for fut in (frame_sent, response_future):
+                    if fut is not None and not fut.done():
+                        fut.set_exception(exc)
+                self.tx_queue.task_done()
+                self._abort_connection(exc)
+                return
+            except OSError as e:
+                _logger.warning(
+                    "network_producer: socket error during write/drain (%s) — treating connection as lost", e
+                )
+                exc = ConnectionLost(f"socket error during write/drain — connection lost: {e}")
                 # This frame is already dequeued, so the teardown's queue-drain
                 # can't reach it — fail its futures here.
                 for fut in (frame_sent, response_future):
@@ -1684,6 +1697,13 @@ class Client:
             except TimeoutError as exc:
                 _discard(response_future)
                 raise TimeoutError("TX queue full — producer task has likely died") from exc
+            if self._connection_lost:
+                # Lost the race with _abort_connection's queue-drain: our frame was
+                # enqueued after the drain and will never be sent. _discard cancels the
+                # response future, so a post-reconnect producer skips the stale frame
+                # (the queue-front skip-if-resolved check).
+                _discard(response_future)
+                raise ConnectionLost("connection lost while enqueueing — reconnect before sending")
             # Safety-net wait for the producer to actually send this frame. Worst case the
             # frame sits behind a full queue, and the producer sleeps tx_message_wait + up to
             # tx_jitter (plus a drain) between sends — so scale the bound by the full queue

--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -442,9 +442,12 @@ class Client:
     - Take a per-client lock around ``refresh_plant()`` so successive polls don't
       overlap. Writes don't need the same lock — they're free to land between
       polls.
-    - Connection loss is surfaced via ``self.connected`` flipping to ``False``;
-      the reader/writer tasks log a WARNING when this happens (a peer-initiated
-      drop is recoverable via reconnect). ``connect()`` is
+    - Connection loss is surfaced three ways: ``self.connected`` flips to
+      ``False``, the noticing task logs a WARNING, and every in-flight or
+      subsequently attempted request raises ``ConnectionLost`` (a
+      ``CommunicationError`` that is also a ``TimeoutError``, so legacy
+      ``except TimeoutError`` handling keeps working — catch ``ConnectionLost``
+      first to distinguish reconnect-me from a genuine stall). ``connect()`` is
       idempotent and tears down the previous connection on its own, so it can
       be called directly as a reconnect primitive.
     """

--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -1545,6 +1545,7 @@ class Client:
         else:
             self.connected = False
             _logger.warning("network_consumer: connection lost (reader at EOF)")
+            self._abort_connection(ConnectionLost("reader at EOF — connection lost"))
 
     async def _task_network_producer(self):
         """Producer loop to transmit queued frames with an appropriate delay.

--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -129,6 +129,12 @@ _FRAME_MARKER = bytes.fromhex("59590001")
 # it sane when the queue is idle. Module-level so tests can shrink it.
 _FRAME_SENT_MIN_TIMEOUT = 5.0
 
+# Upper bound on writer.drain() inside the producer loop (#356). On a healthy link
+# drain completes near-instantly (it's local socket-buffer backpressure); a stall
+# means the peer stopped ACKing — a half-open connection — so it's treated as
+# connection loss rather than left to wedge the producer until close() (hass#233).
+_DRAIN_TIMEOUT = 10.0
+
 
 class FrameRedactor:
     """Frame-aware stateful redactor for a captured GivEnergy byte stream.
@@ -1565,7 +1571,22 @@ class Client:
             self.writer.write(message)
             if self._capture_sink is not None and self._capture_redactor_tx is not None:
                 self._emit_to_sink("tx", self._capture_redactor_tx.feed(message))
-            await self.writer.drain()
+            try:
+                await asyncio.wait_for(self.writer.drain(), timeout=_DRAIN_TIMEOUT)
+            except TimeoutError:
+                _logger.warning(
+                    "network_producer: writer drain stalled >%.0fs — treating connection as lost",
+                    _DRAIN_TIMEOUT,
+                )
+                exc = ConnectionLost("writer drain stalled — connection lost")
+                # This frame is already dequeued, so the teardown's queue-drain
+                # can't reach it — fail its futures here.
+                for fut in (frame_sent, response_future):
+                    if fut is not None and not fut.done():
+                        fut.set_exception(exc)
+                self.tx_queue.task_done()
+                self._abort_connection(exc)
+                return
             self.tx_queue.task_done()
             if frame_sent and not frame_sent.done():
                 frame_sent.set_result(True)
@@ -1576,6 +1597,7 @@ class Client:
         else:
             self.connected = False
             _logger.warning("network_producer: connection lost (writer closing)")
+            self._abort_connection(ConnectionLost("writer closing — connection lost"))
 
     # async def _task_dump_queues_to_files(self):
     #     """Task to periodically dump debug message frames to disk for debugging."""

--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -1631,7 +1631,7 @@ class Client:
             return_exceptions=return_exceptions,
         )
 
-    async def send_request_and_await_response(
+    async def send_request_and_await_response(  # noqa: C901
         self,
         request: TransparentRequest,
         timeout: float,
@@ -1649,6 +1649,9 @@ class Client:
         original "retry immediately" behaviour (e.g. fast probes, latency-
         sensitive interactive commands) should pass ``retry_delay=0``.
         """
+        if self._connection_lost:
+            raise ConnectionLost("connection lost — reconnect before sending")
+
         # mark the expected response
         expected_response = request.expected_response()
         expected_shape_hash = expected_response.shape_hash()
@@ -1691,13 +1694,21 @@ class Client:
             )
             try:
                 await asyncio.wait_for(frame_sent, timeout=frame_sent_timeout)
-            except TimeoutError as exc:
-                # Producer is genuinely stuck. Drop the orphaned future so a late send can't
-                # resolve a stale request, and surface a clear error.
+            except ConnectionLost:
+                # Teardown failed this frame's future — propagate the typed signal.
                 _discard(response_future)
+                raise
+            except TimeoutError as exc:
+                # Drain is bounded (#356), so reaching this means the producer is
+                # wedged somewhere unknown — a genuine bug. Tear down so the
+                # system recovers, and keep the honest 'stuck' signal.
+                _discard(response_future)
+                self._abort_connection(ConnectionLost("producer stuck — tearing down"))
                 raise TimeoutError("Producer task is stuck — frame not sent") from exc
             try:
                 await asyncio.wait_for(response_future, timeout=timeout)
+            except ConnectionLost:
+                raise  # a drop mid-await propagates immediately; never a retry
             except TimeoutError:
                 tries += 1
                 _logger.debug(

--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -18,6 +18,7 @@ from givenergy_modbus.client.commands import (
 )
 from givenergy_modbus.exceptions import (
     CommunicationError,
+    ConnectionLost,
     ExceptionBase,
     InvalidPduState,
     PlantNotDetected,
@@ -517,6 +518,7 @@ class Client:
         self.tx_queue = Queue(maxsize=20)
         self.expected_responses = {}
         self._shutting_down = False
+        self._connection_lost = False
         self.network_producer_task: Task | None = None
         self.network_consumer_task: Task | None = None
         # self.debug_frames = {
@@ -547,6 +549,7 @@ class Client:
         ):
             await self.close()
         self._shutting_down = False
+        self._connection_lost = False
         try:
             connection = asyncio.open_connection(host=self.host, port=self.port, flags=socket.TCP_NODELAY)
             self.reader, self.writer = await asyncio.wait_for(connection, timeout=self.connect_timeout)
@@ -589,6 +592,49 @@ class Client:
         #     'all': Queue(maxsize=1000),
         #     'error': Queue(maxsize=1000),
         # }
+
+    def _abort_connection(self, exc: ConnectionLost) -> None:
+        """Tear down shared state after an UNEXPECTED connection drop (#356).
+
+        Called by whichever network task notices death (reader EOF, writer
+        closing, stalled drain) — and by the send path's stuck-producer
+        safety net. Idempotent: the ``_connection_lost`` flag guards re-entry,
+        and every operation is a no-op the second time. Intentional shutdown
+        (``close()``) early-returns: the #50 quiet paths stay close()'s job.
+
+        Deliberately does NOT touch reader/writer/task attributes — connect()'s
+        leftover-check and close() own that cleanup (#274 atomicity).
+        """
+        if self._shutting_down or self._connection_lost:
+            return
+        self._connection_lost = True
+        self.connected = False
+        # Unblock in-flight senders awaiting a response.
+        aborted = 0
+        for fut in self.expected_responses.values():
+            if not fut.done():
+                fut.set_exception(exc)
+                aborted += 1
+        self.expected_responses = {}
+        # Unblock senders awaiting frame-sent for still-queued frames.
+        drained = 0
+        while not self.tx_queue.empty():
+            _, frame_sent, response_future = self.tx_queue.get_nowait()
+            for fut in (frame_sent, response_future):
+                if fut is not None and not fut.done():
+                    fut.set_exception(exc)
+            drained += 1
+        # Cancel the sibling task; the noticing task (if any) exits on its own.
+        current = asyncio.current_task()
+        for task in (self.network_consumer_task, self.network_producer_task):
+            if task is not None and task is not current and not task.done():
+                task.cancel()
+        _logger.debug(
+            "Connection teardown: aborted %d in-flight request(s), drained %d queued frame(s) (%s)",
+            aborted,
+            drained,
+            exc,
+        )
 
     async def _probe(self, request: TransparentRequest, timeout: float, retries: int) -> bool:
         """Send a request; return True on success, False on TimeoutError.

--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -626,9 +626,9 @@ class Client:
         drained = 0
         while not self.tx_queue.empty():
             _, frame_sent, response_future = self.tx_queue.get_nowait()
-            for fut in (frame_sent, response_future):
-                if fut is not None and not fut.done():
-                    fut.set_exception(exc)
+            for queued_fut in (frame_sent, response_future):
+                if queued_fut is not None and not queued_fut.done():
+                    queued_fut.set_exception(exc)
             drained += 1
         # Cancel the sibling task; the noticing task (if any) exits on its own.
         current = asyncio.current_task()

--- a/givenergy_modbus/exceptions.py
+++ b/givenergy_modbus/exceptions.py
@@ -38,6 +38,18 @@ class CommunicationError(ExceptionBase):
     """Exception to indicate a communication error."""
 
 
+class ConnectionLost(CommunicationError, TimeoutError):
+    """The TCP connection dropped mid-operation (peer disconnect, half-open stall).
+
+    Deliberately inherits BOTH CommunicationError and TimeoutError (#356): the
+    dual base is a compatibility contract, not an accident. Consumers that catch
+    bare ``TimeoutError`` (the historical error type for a dead connection) see
+    no behaviour change; consumers may catch ``ConnectionLost`` explicitly —
+    ordered before ``TimeoutError`` — to opt into immediate-reconnect policy.
+    Do not "simplify" to a single base.
+    """
+
+
 class PlantNotDetected(CommunicationError):
     """Raised when a capability-aware poll is attempted before ``detect()`` has run.
 

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from givenergy_modbus.client.client import Client
+from givenergy_modbus.exceptions import ConnectionLost
 from givenergy_modbus.model import TimeSlot
 from givenergy_modbus.pdu import HeartbeatRequest, ReadInputRegistersResponse
 from givenergy_modbus.pdu.write_registers import WriteHoldingRegisterRequest, WriteHoldingRegisterResponse
@@ -858,3 +859,26 @@ async def test_frame_sent_timeout_does_not_evict_newer_future(monkeypatch):
 
     assert client.expected_responses.get(shape_hash) is b_future, "A's cleanup must not evict B's future"
     b_future.cancel()
+
+
+def test_connection_lost_is_communication_error_and_timeout():
+    """Dual inheritance is the compat contract (#356): typed for new consumers.
+
+    Still a TimeoutError so legacy `except TimeoutError` paths keep working.
+    """
+    from givenergy_modbus.exceptions import CommunicationError
+
+    exc = ConnectionLost("connection dropped")
+    assert isinstance(exc, CommunicationError)
+    assert isinstance(exc, TimeoutError)
+
+
+def test_connection_lost_caught_by_legacy_timeout_handler():
+    """A consumer catching bare TimeoutError (e.g. released hass coordinator).
+
+    Must catch it.
+    """
+    try:
+        raise ConnectionLost("connection dropped")
+    except TimeoutError as e:
+        assert "connection dropped" in str(e)

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -33,6 +33,7 @@ async def test_expected_response():
 
     # simulate receiving a response, which enables the consumer task to mark response_future as done
     client.reader.feed_data(WriteHoldingRegisterResponse(inverter_serial_number="", register=35, value=20).encode())
+    client._shutting_down = True
     client.reader.feed_eof()
 
     # check the response
@@ -52,6 +53,7 @@ async def test_consumer_auto_responds_to_heartbeat_request():
     client = Client(host="foo", port=4321)
     client.reader = StreamReader()
     client.reader.feed_data(HeartbeatRequest(data_adapter_serial_number="AB1234G567", data_adapter_type=2).encode())
+    client._shutting_down = True
     client.reader.feed_eof()
 
     await client._task_network_consumer()
@@ -338,6 +340,7 @@ async def test_consumer_does_not_resolve_future_for_crc_failed_frame():
 
     with patch.object(client.framer, "decode", new=fake_decode):
         client.reader.feed_data(b"\x00")
+        client._shutting_down = True
         client.reader.feed_eof()
         await client._task_network_consumer()
 
@@ -987,6 +990,24 @@ async def test_producer_unexpected_writer_close_aborts_connection():
     client.expected_responses[7] = inflight
 
     await client._task_network_producer()
+
+    assert client._connection_lost is True
+    assert isinstance(inflight.exception(), ConnectionLost)
+
+
+async def test_consumer_unexpected_eof_aborts_connection():
+    """Unexpected reader EOF runs the shared teardown.
+
+    In-flight senders unblock immediately with ConnectionLost instead of
+    burning their full timeouts.
+    """
+    client = Client(host="foo", port=4321)
+    client.reader = StreamReader()
+    inflight = asyncio.get_running_loop().create_future()
+    client.expected_responses[11] = inflight
+    client.reader.feed_eof()  # _shutting_down stays False
+
+    await client._task_network_consumer()
 
     assert client._connection_lost is True
     assert isinstance(inflight.exception(), ConnectionLost)

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -946,3 +946,47 @@ async def test_connect_resets_connection_lost_flag():
         await client.connect()  # existing _stub_open_connection pattern; no wait_for patch needed
     assert client._connection_lost is False
     await client.close()
+
+
+async def test_producer_drain_stall_aborts_connection(monkeypatch, caplog):
+    """A wedged writer.drain() (half-open socket, hass#233) is bounded.
+
+    The producer treats the stall as connection loss, fails the current frame's
+    frame_sent, and tears down — instead of hanging until close().
+    """
+    monkeypatch.setattr("givenergy_modbus.client.client._DRAIN_TIMEOUT", 0.05)
+    client = Client(host="foo", port=4321)
+    writer = MagicMock()
+    writer.is_closing.return_value = False
+    never = asyncio.get_running_loop().create_future()  # drain() that never completes
+    writer.drain = MagicMock(return_value=never)
+    client.writer = writer
+
+    frame_sent = asyncio.get_running_loop().create_future()
+    response_future = asyncio.get_running_loop().create_future()
+    client.expected_responses[99] = response_future
+    client.tx_queue.put_nowait((b"frame", frame_sent, response_future))
+
+    with caplog.at_level(logging.DEBUG, logger="givenergy_modbus.client.client"):
+        await asyncio.wait_for(client._task_network_producer(), timeout=2.0)
+
+    assert isinstance(frame_sent.exception(), ConnectionLost)  # current frame unblocked
+    assert isinstance(response_future.exception(), ConnectionLost)
+    assert client._connection_lost is True
+    assert client.connected is False
+    assert any("drain stalled" in r.message for r in caplog.records if r.levelno == logging.WARNING)
+
+
+async def test_producer_unexpected_writer_close_aborts_connection():
+    """The existing writer-closing exit path now also runs the shared teardown."""
+    client = Client(host="foo", port=4321)
+    writer = MagicMock()
+    writer.is_closing.return_value = True
+    client.writer = writer
+    inflight = asyncio.get_running_loop().create_future()
+    client.expected_responses[7] = inflight
+
+    await client._task_network_producer()
+
+    assert client._connection_lost is True
+    assert isinstance(inflight.exception(), ConnectionLost)

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -1067,3 +1067,32 @@ async def test_send_stuck_producer_aborts_connection(monkeypatch):
     with pytest.raises(TimeoutError, match="stuck"):
         await client.send_request_and_await_response(req, timeout=5.0, retries=0)
     assert client._connection_lost is True  # teardown ran
+
+
+async def test_discard_identity_guard_preserves_newer_caller_future():
+    """Caller A's cleanup must not evict a newer same-shaped caller B's future (PR #225 invariant).
+
+    A's frame_sent fails with ConnectionLost (directly, NOT via _abort_connection, so B's
+    registration survives to observe the guard); by then B has replaced A's registration in
+    expected_responses. A's _discard must leave B's future registered and pending.
+    """
+    client = Client(host="foo", port=4321)
+    req = WriteHoldingRegisterRequest(register=35, value=20)
+    shape = req.expected_response().shape_hash()
+
+    send_a = asyncio.create_task(client.send_request_and_await_response(req, timeout=30.0, retries=0))
+    _, frame_sent_a, future_a = await asyncio.wait_for(client.tx_queue.get(), timeout=1.0)
+    client.tx_queue.task_done()
+
+    # A newer same-shaped caller B replaces A's registration (B's future is a fresh one).
+    future_b = asyncio.get_running_loop().create_future()
+    client.expected_responses[shape] = future_b
+
+    # A's frame_sent fails with ConnectionLost — A's cleanup path (_discard) runs.
+    frame_sent_a.set_exception(ConnectionLost("test drop"))
+    with pytest.raises(ConnectionLost):
+        await asyncio.wait_for(send_a, timeout=1.0)
+
+    # The identity guard must have left B's registration alone.
+    assert client.expected_responses.get(shape) is future_b
+    assert not future_b.done()

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -1096,3 +1096,47 @@ async def test_discard_identity_guard_preserves_newer_caller_future():
     # The identity guard must have left B's registration alone.
     assert client.expected_responses.get(shape) is future_b
     assert not future_b.done()
+
+
+async def test_producer_socket_error_during_drain_aborts_connection(caplog):
+    """A peer reset surfacing as OSError from write/drain must run the shared teardown (#356).
+
+    Previously the raw exception propagated out of the producer task, leaving the
+    dequeued frame's futures to burn the slow frame_sent timeout.
+    """
+    client = Client(host="foo", port=4321)
+    writer = MagicMock()
+    writer.is_closing.return_value = False
+    writer.drain = AsyncMock(side_effect=ConnectionResetError("peer reset"))
+    client.writer = writer
+    frame_sent = asyncio.get_running_loop().create_future()
+    response_future = asyncio.get_running_loop().create_future()
+    client.expected_responses[42] = response_future
+    client.tx_queue.put_nowait((b"frame", frame_sent, response_future))
+
+    with caplog.at_level(logging.WARNING, logger="givenergy_modbus.client.client"):
+        await asyncio.wait_for(client._task_network_producer(), timeout=2.0)  # must NOT raise
+
+    assert isinstance(frame_sent.exception(), ConnectionLost)
+    assert isinstance(response_future.exception(), ConnectionLost)
+    assert client._connection_lost is True
+    assert any("socket error" in r.message for r in caplog.records if r.levelno == logging.WARNING)
+
+
+async def test_send_blocked_in_full_queue_raises_connection_lost_on_abort():
+    """A sender blocked in tx_queue.put() when the abort fires must get ConnectionLost.
+
+    The abort's queue-drain wakes the blocked putter, which would otherwise enqueue
+    into the dead queue and ride the misleading 'Producer task is stuck' path.
+    """
+    client = Client(host="foo", port=4321)
+    client.tx_queue = asyncio.Queue(maxsize=1)
+    client.tx_queue.put_nowait((b"filler", None, None))  # fill the queue so put() blocks
+    req = WriteHoldingRegisterRequest(register=35, value=20)
+
+    send = asyncio.create_task(client.send_request_and_await_response(req, timeout=30.0, retries=0))
+    await asyncio.sleep(0.05)  # let the sender block in tx_queue.put()
+    client._abort_connection(ConnectionLost("drop while putter blocked"))
+
+    with pytest.raises(ConnectionLost):
+        await asyncio.wait_for(send, timeout=2.0)

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -1140,3 +1140,30 @@ async def test_send_blocked_in_full_queue_raises_connection_lost_on_abort():
 
     with pytest.raises(ConnectionLost):
         await asyncio.wait_for(send, timeout=2.0)
+
+
+async def test_producer_emits_tx_frames_to_capture_sink():
+    """A frame sent while a capture is active is redacted and handed to the sink.
+
+    Covers the producer's capture-emit path (now inside the write/drain try —
+    _emit_to_sink swallows sink errors internally, so it cannot trip the
+    OSError teardown arm).
+    """
+    client = Client(host="foo", port=4321, tx_message_wait=0, tx_jitter=0)
+    writer = MagicMock()
+    writer.is_closing.side_effect = [False, True]  # one loop pass, then exit
+    writer.drain = AsyncMock()
+    client.writer = writer
+    client._shutting_down = True  # quiet DEBUG exit; no teardown side effects in play
+    sink = MagicMock()
+    redactor = MagicMock()
+    redactor.feed.return_value = b"redacted-frame"
+    client._capture_sink = sink
+    client._capture_redactor_tx = redactor
+    client.tx_queue.put_nowait((b"raw-frame", None, None))
+
+    await asyncio.wait_for(client._task_network_producer(), timeout=2.0)
+
+    redactor.feed.assert_called_once_with(b"raw-frame")
+    sink.assert_called_once_with("tx", b"redacted-frame")
+    writer.write.assert_called_once_with(b"raw-frame")

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -836,11 +836,13 @@ async def test_frame_sent_timeout_cleans_up_stale_future(monkeypatch):
 
 
 async def test_frame_sent_timeout_does_not_evict_newer_future(monkeypatch):
-    """A timed-out call must not evict a newer same-shaped caller's response future (PR #225).
+    """A timed-out call's stuck-producer teardown now aborts the whole connection (#356).
 
-    Same-shaped requests deliberately replace one another. If call A is still waiting on
-    frame_sent when call B installs its own future under the shared shape_hash, A's timeout
-    cleanup must be identity-conditional — it must not delete B's mapping.
+    Originally (PR #225) call A's frame_sent timeout only evicted its own mapping, identity-
+    conditionally, so a newer same-shaped caller B was untouched. Since #356, a frame_sent
+    timeout means the producer is confirmed wedged, so the whole connection is torn down —
+    B's future is correctly failed with ConnectionLost too, not silently preserved as if the
+    connection were still healthy.
     """
     from givenergy_modbus.client import client as client_mod
 
@@ -857,11 +859,12 @@ async def test_frame_sent_timeout_does_not_evict_newer_future(monkeypatch):
     b_future: asyncio.Future = asyncio.get_running_loop().create_future()
     client.expected_responses[shape_hash] = b_future
 
-    with pytest.raises(TimeoutError):
-        await task_a  # A times out (~0.05s)
+    with pytest.raises(TimeoutError, match="stuck"):
+        await task_a  # A times out (~0.05s) and tears down the connection
 
-    assert client.expected_responses.get(shape_hash) is b_future, "A's cleanup must not evict B's future"
-    b_future.cancel()
+    assert client.expected_responses.get(shape_hash) is None  # teardown clears the whole map
+    assert isinstance(b_future.exception(), ConnectionLost)  # B aborted too — connection is dead
+    assert client._connection_lost is True
 
 
 def test_connection_lost_is_communication_error_and_timeout():
@@ -1011,3 +1014,56 @@ async def test_consumer_unexpected_eof_aborts_connection():
 
     assert client._connection_lost is True
     assert isinstance(inflight.exception(), ConnectionLost)
+
+
+async def test_send_fails_fast_when_connection_known_dead():
+    """After teardown, sends raise ConnectionLost immediately.
+
+    A dead-window refresh batch fails in ms instead of burning per-read
+    timeouts. Never-connected clients are NOT guarded (the flag is set only
+    by _abort_connection).
+    """
+    client = Client(host="foo", port=4321)
+    client._abort_connection(ConnectionLost("prior drop"))
+
+    req = WriteHoldingRegisterRequest(register=35, value=20)
+    with pytest.raises(ConnectionLost):
+        await client.send_request_and_await_response(req, timeout=5.0, retries=2)
+    assert client.tx_queue.empty()  # nothing was queued
+
+
+async def test_send_propagates_connection_lost_without_burning_retries():
+    """ConnectionLost IS a TimeoutError; the retry arm must not swallow it.
+
+    A drop mid-response-await propagates immediately instead of retrying
+    into the guard.
+    """
+    client = Client(host="foo", port=4321)
+    req = WriteHoldingRegisterRequest(register=35, value=20)
+
+    send = asyncio.create_task(client.send_request_and_await_response(req, timeout=30.0, retries=5))
+    # simulate the producer sending the frame
+    _, frame_sent, _ = await asyncio.wait_for(client.tx_queue.get(), timeout=1.0)
+    client.tx_queue.task_done()
+    frame_sent.set_result(True)
+    await asyncio.sleep(0)  # let send advance to the response await
+    client._abort_connection(ConnectionLost("mid-flight drop"))
+
+    with pytest.raises(ConnectionLost):
+        await asyncio.wait_for(send, timeout=1.0)  # well under timeout=30 × 6 tries
+
+
+async def test_send_stuck_producer_aborts_connection(monkeypatch):
+    """The frame_sent timeout keeps its 'stuck' TimeoutError but also tears down.
+
+    Drain is bounded now, so reaching this means a genuinely wedged producer
+    — a real bug — and the system must recover.
+    """
+    monkeypatch.setattr("givenergy_modbus.client.client._FRAME_SENT_MIN_TIMEOUT", 0.05)
+    client = Client(host="foo", port=4321)
+    client.tx_queue = asyncio.Queue(maxsize=1)  # rescale the depth-scaled timeout
+    req = WriteHoldingRegisterRequest(register=35, value=20)
+
+    with pytest.raises(TimeoutError, match="stuck"):
+        await client.send_request_and_await_response(req, timeout=5.0, retries=0)
+    assert client._connection_lost is True  # teardown ran

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -882,3 +882,67 @@ def test_connection_lost_caught_by_legacy_timeout_handler():
         raise ConnectionLost("connection dropped")
     except TimeoutError as e:
         assert "connection dropped" in str(e)
+
+
+async def test_abort_connection_fails_inflight_and_queued_with_connection_lost():
+    """_abort_connection unblocks every waiter fast with the typed exception (#356)."""
+    client = Client(host="foo", port=4321)
+    inflight = asyncio.get_running_loop().create_future()
+    client.expected_responses[1234] = inflight
+    q_frame_sent = asyncio.get_running_loop().create_future()
+    q_response = asyncio.get_running_loop().create_future()
+    client.tx_queue.put_nowait((b"frame", q_frame_sent, q_response))
+
+    client._abort_connection(ConnectionLost("test drop"))
+
+    assert client._connection_lost is True
+    assert client.connected is False
+    assert isinstance(inflight.exception(), ConnectionLost)
+    assert isinstance(q_frame_sent.exception(), ConnectionLost)
+    assert isinstance(q_response.exception(), ConnectionLost)
+    assert client.expected_responses == {}
+    assert client.tx_queue.empty()
+
+
+async def test_abort_connection_is_idempotent_and_respects_shutdown():
+    """Second call is a no-op; a call during intentional close() is a no-op."""
+    client = Client(host="foo", port=4321)
+    client._abort_connection(ConnectionLost("first"))
+    client._abort_connection(ConnectionLost("second"))  # must not raise (futures done, dict clear)
+    assert client._connection_lost is True
+
+    quiet = Client(host="bar", port=4321)
+    quiet._shutting_down = True
+    fut = asyncio.get_running_loop().create_future()
+    quiet.expected_responses[1] = fut
+    quiet._abort_connection(ConnectionLost("during close"))
+    assert quiet._connection_lost is False  # early-returned
+    assert not fut.done()  # close() owns intentional-shutdown cleanup
+
+
+async def test_abort_connection_cancels_only_the_other_task():
+    """The task NOT calling abort is cancelled; the caller is left to exit on its own."""
+    client = Client(host="foo", port=4321)
+
+    async def _sleeper():
+        await asyncio.sleep(30)
+
+    other = asyncio.create_task(_sleeper())
+    client.network_consumer_task = other
+    client.network_producer_task = None
+
+    client._abort_connection(ConnectionLost("drop"))
+    await asyncio.sleep(0)  # let cancellation propagate
+    assert other.cancelled()
+
+
+async def test_connect_resets_connection_lost_flag():
+    """connect() re-arms the client after a prior abort (mirrors _shutting_down reset)."""
+    client = Client(host="foo", port=4321)
+    client._connection_lost = True
+    reader, writer = MagicMock(spec=StreamReader), MagicMock()
+    writer.wait_closed = AsyncMock()
+    with patch("asyncio.open_connection", _stub_open_connection(reader, writer)):
+        await client.connect()  # existing _stub_open_connection pattern; no wait_for patch needed
+    assert client._connection_lost is False
+    await client.close()


### PR DESCRIPTION
Closes #356. Graceful producer/consumer teardown on unexpected connection loss, plus a typed `ConnectionLost` signal — the structural follow-up to the log-severity trim (`bc12802`).

## Problem
On an unexpected drop (e.g. the dongle's nightly ~02:00 cloud-sync reconnect) the network tasks each noticed their own side dying and exited, leaving a zombie half-state until the next `connect()`: the sibling task running against dead state, queued frames stranded for the full scaled timeout, and in-flight senders failing slowly with misleading errors that conflated *connection lost* (routine — reconnect) with *genuinely wedged producer* (a real bug). The one true wedge — `writer.drain()` on a half-open socket — could hang unboundedly (the field symptom on the comms-noisy EMS plant, givenergy-hass#233).

## Changes
- **`ConnectionLost(CommunicationError, TimeoutError)`** — the dual base is a deliberate compatibility contract: consumers catching bare `TimeoutError` (the historical error type for a dead connection) see no behaviour change; catching `ConnectionLost` first opts into immediate-reconnect policy.
- **`Client._abort_connection()`** — one idempotent teardown path run by whichever task notices death: fails all in-flight and queued futures with `ConnectionLost` (waiters unblock in ms, not after ~10s+ timeouts), cancels the sibling task, flips `connected`. Deliberately leaves reader/writer/task attributes to `close()`/`connect()` (#274 atomicity preserved). Intentional shutdown early-returns — the #50 DEBUG paths are untouched.
- **Bounded `writer.drain()`** (`_DRAIN_TIMEOUT = 10 s`) — a stall means the peer stopped ACKing; treated as connection loss instead of wedging until `close()`.
- **Send path** — fail-fast `ConnectionLost` when the connection is known-dead (a dead-window refresh batch fails in ms); `except ConnectionLost` arms ordered before `except TimeoutError` (it *is* a `TimeoutError` — order is load-bearing, regression-tested); the `frame_sent` timeout becomes an honest "producer wedged = real bug" signal that now also triggers teardown so the system recovers.
- **No auto-reconnect** — reconnect policy stays with the consumer/coordinator; `connect()` remains the reconnect primitive, unchanged.

Design spec was maintainer-reviewed before implementation; the two planning-time refinements (guard keyed on a `_connection_lost` flag rather than `connected`, so never-connected clients are unaffected; the drain-stall handler failing the already-dequeued frame's futures itself) are documented in the plan.

## Tests
12 new tests: exception typing/compat, abort semantics (idempotence, shutdown early-return, sibling-only cancellation), drain-stall teardown, consumer-EOF fast unblock, fail-fast guard, retry-ordering, stuck-producer teardown, and a dedicated replacement for the #225 identity-guard regression (its old test was legitimately repurposed for the new stuck-producer semantics). Three pre-existing tests that used EOF as inert scaffolding now set `_shutting_down` (EOF is no longer a no-op by design); the unexpected-EOF path keeps independent coverage.

## Verification
Full suite 1477 passed; tox matrix (py311–py314 + format + lint + build) green.

Consumer note: after release I'll drop a note to the hass integration — catching `ConnectionLost` ahead of `TimeoutError` would let it reset/reconnect on the first drop rather than after the 3-strike timeout tolerance; that's its policy call.
