### PR TITLE
fix: tolerate silence at 0x32 in the detect LV preamble (#358)

### DIFF
--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -901,24 +901,43 @@ class Client:
         non-contiguous and a transient BMS timeout on pack N must not drop pack N+1 onward.
         is_valid() gating and caps population are handled by _derive_capabilities.
         """
-        await self.send_request_and_await_response(
-            ReadInputRegistersRequest(base_register=60, register_count=60, device_address=0x32),
-            timeout=timeout,
-            retries=retries,
-        )
-        # #352/#289: since #352 a caps-absent 0x32 read routes through the battery getter, so its first
-        # preamble frame is held by the cold-start splice guard (the cache stays empty pending a
-        # corroborating re-read) exactly like 0x33+. detect() reads each address once, so without this
-        # confirming read the primary pack is dropped at the _derive_capabilities gate below and
-        # refresh() never re-polls it. One healthy re-read corroborates and commits; a flapping/spliced
-        # bank fails to corroborate and correctly stays out (#289 anti-poison intact).
-        if not self.plant.register_caches.get(0x32):
-            await self.send_request_and_await_response(
-                ReadInputRegistersRequest(base_register=60, register_count=60, device_address=0x32),
-                timeout=timeout,
-                retries=retries,
-            )
         batt_candidates = prior.lv_battery_addresses if prior is not None else _COLD_LV_BATTERY_RANGE
+        # The 0x32 preamble keeps the patient known-tier treatment (the primary pack matters — the
+        # #350 family), but silence is NOT fatal (#358): gateways keep battery data register-embedded
+        # in the rollup, and a hybrid with no pack attached is a valid AC/PV-only plant. Skipped
+        # entirely when prior capabilities carry no 0x32 (a hinted gateway reconnect would otherwise
+        # stall the full timeout on a read that can never answer, every reconnect).
+        if 0x32 in batt_candidates:
+            try:
+                await self.send_request_and_await_response(
+                    ReadInputRegistersRequest(base_register=60, register_count=60, device_address=0x32),
+                    timeout=timeout,
+                    retries=retries,
+                    warn_timeout=False,  # expected-absence probe semantics: don't pollute retry counters
+                )
+                # #352/#289: since #352 a caps-absent 0x32 read routes through the battery getter, so
+                # its first preamble frame is held by the cold-start splice guard (the cache stays empty
+                # pending a corroborating re-read) exactly like 0x33+. detect() reads each address once,
+                # so without this confirming read the primary pack is dropped at the _derive_capabilities
+                # gate below and refresh() never re-polls it. One healthy re-read corroborates and
+                # commits; a flapping/spliced bank fails to corroborate and correctly stays out (#289
+                # anti-poison intact).
+                if not self.plant.register_caches.get(0x32):
+                    await self.send_request_and_await_response(
+                        ReadInputRegistersRequest(base_register=60, register_count=60, device_address=0x32),
+                        timeout=timeout,
+                        retries=retries,
+                        warn_timeout=False,
+                    )
+            except ConnectionLost:
+                raise  # a dead connection is not an absent battery (#356 dual-base ordering)
+            except TimeoutError:
+                _logger.info("No LV battery answered at 0x32 — valid for gateways and battery-less plants (#358)")
+                self.plant.mark_absent(0x32, "IR", 60, 60)
+                self.plant.register_caches.pop(0x32, None)
+            else:
+                if not self.plant.register_caches.get(0x32):
+                    self.plant.mark_absent(0x32, "IR", 60, 60)
         for batt_addr in batt_candidates:
             if batt_addr > 0x32:
                 if not await self._probe(

--- a/tests/client/test_detect.py
+++ b/tests/client/test_detect.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from givenergy_modbus.client.client import Client
-from givenergy_modbus.exceptions import CommunicationError, PlantTopologyMismatch
+from givenergy_modbus.exceptions import CommunicationError, ConnectionLost, PlantTopologyMismatch
 from givenergy_modbus.model.inverter import Model
 from givenergy_modbus.model.plant import PlantCapabilities
 from givenergy_modbus.model.register import HR, IR
@@ -1436,7 +1436,7 @@ async def test_detect_primary_battery_survives_cold_start_hold():
     _prime_cache(client, 0x11, {HR(0): 0x2001, HR(21): 0})  # inverter/model only — 0x32 NOT pre-primed
     bank = _healthy_battery_bank()
 
-    async def _send_side_effect(request, *, timeout, retries):
+    async def _send_side_effect(request, *args, **kwargs):
         # Feed the healthy 0x32 bank through update() so the cold-start guard runs; detect issues this
         # twice (preamble + corroborating re-read), and the second commits the held baseline.
         if request.device_address == 0x32 and getattr(request, "base_register", None) == 60:
@@ -1647,3 +1647,85 @@ async def test_detect_success_leaves_connected():
 
     assert client.connected is True
     assert client.plant.capabilities is caps
+
+
+@pytest.mark.asyncio
+async def test_detect_completes_on_gateway_with_no_lv_battery_at_0x32():
+    """detect() must complete when nothing answers at 0x32 — gateways and battery-less hybrids (#358).
+
+    Field case: AberDino's Gen1 Gateway (hass#95) — identity resolves Model.GATEWAY, then the
+    mandatory 0x32 LV preamble times out against total silence and aborted the whole detect().
+    Silence at 0x32 is a valid topology: the pack is marked ABSENT and lv_battery_addresses
+    stays empty.
+    """
+    client = _make_client()
+    _prime_cache(client, 0x11, {HR(0): 0x7001, HR(21): 0})  # Gen1 Gateway identity
+
+    async def _send_side_effect(request, *args, **kwargs):
+        if getattr(request, "device_address", None) == 0x32:
+            raise TimeoutError()  # total silence at 0x32, full retries exhausted
+        return MagicMock()
+
+    async def _probe_side_effect(request, *, timeout, retries):
+        return False  # nothing else answers either
+
+    with (
+        patch.object(client, "send_request_and_await_response", side_effect=_send_side_effect),
+        patch.object(client, "_probe", side_effect=_probe_side_effect),
+    ):
+        caps = await client.detect()  # must NOT raise
+
+    assert caps.device_type is Model.GATEWAY
+    assert caps.lv_battery_addresses == []
+    assert client.plant.block_present(0x32, "IR", 60, 60) is False
+    assert 0x32 not in client.plant.register_caches
+
+
+@pytest.mark.asyncio
+async def test_detect_lv_preamble_does_not_swallow_connection_lost():
+    """A ConnectionLost from the 0x32 preamble must propagate, not be treated as pack-absent (#358).
+
+    ConnectionLost IS a TimeoutError (#356 compat dual-base), so the absence-tolerant except arm
+    must re-raise it first — a dead connection is not an absent battery.
+    """
+    client = _make_client()
+    _prime_cache(client, 0x11, {HR(0): 0x2001, HR(21): 0})
+
+    async def _send_side_effect(request, *args, **kwargs):
+        if getattr(request, "device_address", None) == 0x32:
+            raise ConnectionLost("drop mid-detect")
+        return MagicMock()
+
+    with (
+        patch.object(client, "send_request_and_await_response", side_effect=_send_side_effect),
+        patch.object(client, "_probe", side_effect=AsyncMock(return_value=False)),
+    ):
+        with pytest.raises(ConnectionLost):
+            await client.detect()
+
+
+@pytest.mark.asyncio
+async def test_detect_skips_lv_preamble_when_prior_has_no_0x32():
+    """Hinted re-detect on a plant whose prior caps carry no 0x32 must not read 0x32 at all (#358).
+
+    A gateway reconnect would otherwise stall the full known-tier timeout on a read that can
+    never answer, every single reconnect.
+    """
+    client = _make_client()
+    _prime_cache(client, 0x11, {HR(0): 0x7001, HR(21): 0})
+    prior = PlantCapabilities(device_type=Model.GATEWAY, lv_battery_addresses=[])
+
+    sent_addresses = []
+
+    async def _send_side_effect(request, *args, **kwargs):
+        sent_addresses.append(getattr(request, "device_address", None))
+        return MagicMock()
+
+    with (
+        patch.object(client, "send_request_and_await_response", side_effect=_send_side_effect),
+        patch.object(client, "_probe", side_effect=AsyncMock(return_value=False)),
+    ):
+        caps = await client.detect(prior=prior)
+
+    assert 0x32 not in sent_addresses
+    assert caps.lv_battery_addresses == []


### PR DESCRIPTION
Closes #358. `detect()` no longer aborts on plants where nothing answers at `0x32` — gateways (battery data register-embedded in the rollup) and battery-less hybrids (a valid AC/PV-only configuration).

## Problem
`_detect_lv_batteries` opened with an unconditional known-tier read of `IR(60,60)@0x32`; total silence exhausted the retries and the bare `TimeoutError` propagated out of `detect()`, so the consumer saw "cannot connect" despite a healthy connection and successful identification. Surfaced by the first live Gateway config-flow attempt (givenergy-hass#95, reproduced twice in the HA debug log). This was the last survivor of the mandatory-`0x32` assumption family that #352 retired on the routing side.

## Changes
- `batt_candidates` is computed first and the `0x32` preamble only runs when `0x32` is a candidate — a hinted gateway reconnect (prior `lv_battery_addresses=[]`) skips the dead read entirely instead of stalling the full known-tier timeout on every reconnect.
- Silence at `0x32` is a valid outcome: `except TimeoutError` → `mark_absent(0x32)` + drop the pre-seeded cache; an empty `lv_battery_addresses` then derives naturally. `except ConnectionLost: raise` is ordered above it — a dead connection is not an absent battery (the #356 dual-base ordering trap, regression-tested).
- The preamble keeps its patient known-tier treatment on battery plants (deliberate — the #350 family); `warn_timeout=False` so expected absence doesn't pollute the per-device retry counters, matching the `0x33+` probe semantics.

## Evidence & validation
The accompanying wire capture from the same Gateway (GivTCP polling it every 30 s) gave the GatewayV1 register map its first live-traffic validation: `HR(0)=0x7001 → Model.GATEWAY`, 46 fields decoding to coherent physics including an exact per-AIO energy split (per-AIO charge todays sum precisely to the battery total). A daylight capture is expected and will be folded into the fixture corpus separately.

## Tests
Field-abort repro (identity `0x7001` → `detect()` completes, `0x32` ABSENT, `lv_battery_addresses=[]`), `ConnectionLost` propagation through the new except arm, hinted-skip (no `0x32` request issued at all). Cold-mode wire sequence unchanged — detect characterisation goldens untouched. Full suite 1483 passed; tox matrix green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved low-voltage battery detection so missing or unresponsive primary-pack checks are handled more gracefully.
  * Detection now continues normally for supported plant types when the primary battery address does not respond.
  * Connection loss during battery detection is now surfaced correctly instead of being treated as a simple timeout.
  * When prior information shows no primary battery, detection skips that check entirely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->