### PR TITLE
fix: coalesce identical splice-reject WARNINGs during sustained bursts (#355)

### DIFF
--- a/givenergy_modbus/model/battery_splice.py
+++ b/givenergy_modbus/model/battery_splice.py
@@ -129,6 +129,11 @@ SCALAR_IMMUT_HEAL_POLLS: int = 10
 #: so the two want independent tuning. Same degenerate-cadence-floor role as its sibling.
 SPLICE_REJECT_HEAL_POLLS: int = 10
 
+#: Re-warn interval for a sustained same-signature reject burst (#355): the onset logs at
+#: WARNING, identical repeats drop to DEBUG (splice_reject_count keeps the tally), and a burst
+#: still ongoing after this many seconds re-emits a WARNING so a stuck condition can't go quiet.
+SPLICE_REJECT_REWARN_SECONDS: float = 300.0
+
 #: Absolute raw-unit bounds (mirrored from the ``Battery`` model) for the voltage/capacity classes a
 #: #299 heal may adopt. The KEYS are also the *only* trip classes a heal is eligible for: every
 #: corruption signature in the corpus is a temp-zero cohort (cell-mass IR76-79, mosfet IR81,

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -1163,11 +1163,16 @@ class Plant(GivEnergyBaseModel):
         if getter_cls is BatteryRegisterGetter:
             if not self._splice_guard(device_address, incoming, register_count, now=received_at):
                 return False
-            # A committing battery bank closes out any coalesced reject burst (#355).
-            commit_ts = received_at if received_at is not None else datetime.now(UTC)
-            if commit_ts.tzinfo is None:
-                commit_ts = commit_ts.replace(tzinfo=UTC)
-            self._splice_burst_note_commit(device_address, commit_ts)
+            # A committing FULL battery bank closes out any coalesced reject burst (#355).
+            # Short reads (register_count < 60) pass the guard unevaluated — mirroring the
+            # guard's own gate — so a count=1 fan-out commit between corrupt full banks
+            # must not pop the burst (it would log a misleading 'cleared' and re-spam
+            # fresh onsets).
+            if register_count >= 60:
+                commit_ts = received_at if received_at is not None else datetime.now(UTC)
+                if commit_ts.tzinfo is None:
+                    commit_ts = commit_ts.replace(tzinfo=UTC)
+                self._splice_burst_note_commit(device_address, commit_ts)
         self.register_caches[device_address].update(incoming)
         return True
 

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -1336,12 +1336,20 @@ class Plant(GivEnergyBaseModel):
             self._splice_reject_streak.pop(device_address, None)
             self._bump(self.splice_reject_count, device_address)
             warn_now, suffix = self._splice_burst_note_reject(device_address, phys, now_ts)
+            # "Please report if seen" solicits UNcharacterised shapes only (#355): the corpus's
+            # sole corruption signature is the temperature family (cell-mass IR76-79/103-104 +
+            # mosfet IR81 — the temp-zero cohort and its partial variants), characterised to
+            # death, so reporting it adds nothing. Any trip OUTSIDE the temp family is a novel
+            # shape — exactly the evidence the corpus model and the #299 heal question still want.
+            _TEMP_FAMILY = ("cell_temp_deci", "mosfet_temp_deci")
+            plea = "" if all(name in _TEMP_FAMILY for _ir, name, _o, _n in phys) else " Please report if seen."
             (_logger.warning if warn_now else _logger.debug)(
                 "Rejected battery bank for device 0x%02x — sub-bus splice (>=2 physics-impossible "
-                "deltas); keeping last-good. Trips: %s%s. Please report if seen.",
+                "deltas); keeping last-good. Trips: %s%s.%s",
                 device_address,
                 self._format_splice_trips(phys),
                 suffix,
+                plea,
             )
             return False
 

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -16,6 +16,7 @@ from givenergy_modbus.model.battery_splice import (
     IMMUTABLE_SERIAL,
     SCALAR_IMMUT_HEAL_POLLS,
     SPLICE_REJECT_HEAL_POLLS,
+    SPLICE_REJECT_REWARN_SECONDS,
     STALE_BYPASS_SECONDS,
     THRESHOLD_BY_CLASS,
     classify_transition,
@@ -846,6 +847,13 @@ class Plant(GivEnergyBaseModel):
     # adopted as the new baseline. Ephemeral; not serialised.
     _splice_reject_streak: dict[int, tuple[list[int], datetime, int]] = PrivateAttr(default_factory=dict)
 
+    # Per-device coalescing state for sustained same-signature reject bursts (#355):
+    # device -> (trip signature = frozenset of (register, rule-name), burst start, rejection
+    # count, last WARNING-emitted at). Onset warns with full detail, identical repeats drop to
+    # DEBUG, an over-interval burst re-warns, and the first successful commit afterwards logs a
+    # single clearing WARNING with the tally. Ephemeral; not serialised.
+    _splice_reject_burst: dict[int, tuple[frozenset, datetime, int, datetime]] = PrivateAttr(default_factory=dict)
+
     # Direct-inverter register caches injected by add_direct_source() for multi-Client
     # reconciliation (#106 Phase 3). Stored separately from register_caches to avoid the
     # Modbus address collision (both EMS controller and direct inverter live at 0x11).
@@ -1152,10 +1160,14 @@ class Plant(GivEnergyBaseModel):
         # all the checks above wave through. Runs last so the existing serial gate owns serial
         # corruption (quietly) and the bounds pass runs first; it must see last-good, so it sits
         # before the update below. Gated to battery banks via the getter identity.
-        if getter_cls is BatteryRegisterGetter and not self._splice_guard(
-            device_address, incoming, register_count, now=received_at
-        ):
-            return False
+        if getter_cls is BatteryRegisterGetter:
+            if not self._splice_guard(device_address, incoming, register_count, now=received_at):
+                return False
+            # A committing battery bank closes out any coalesced reject burst (#355).
+            commit_ts = received_at if received_at is not None else datetime.now(UTC)
+            if commit_ts.tzinfo is None:
+                commit_ts = commit_ts.replace(tzinfo=UTC)
+            self._splice_burst_note_commit(device_address, commit_ts)
         self.register_caches[device_address].update(incoming)
         return True
 
@@ -1295,11 +1307,13 @@ class Plant(GivEnergyBaseModel):
             self._splice_immut_streak.pop(device_address, None)
             self._splice_reject_streak.pop(device_address, None)
             self._bump(self.splice_reject_count, device_address)
-            _logger.warning(
+            warn_now, suffix = self._splice_burst_note_reject(device_address, serial_immut + phys, now_ts)
+            (_logger.warning if warn_now else _logger.debug)(
                 "Rejected battery bank for device 0x%02x — sub-bus splice (serial-block change); "
-                "keeping last-good. Trips: %s. Please report if seen.",
+                "keeping last-good. Trips: %s%s. Please report if seen.",
                 device_address,
                 self._format_splice_trips(serial_immut + phys),
+                suffix,
             )
             return False
 
@@ -1316,11 +1330,13 @@ class Plant(GivEnergyBaseModel):
                 return self._handle_reject_streak(device_address, new, present, phys, now_ts)
             self._splice_reject_streak.pop(device_address, None)
             self._bump(self.splice_reject_count, device_address)
-            _logger.warning(
+            warn_now, suffix = self._splice_burst_note_reject(device_address, phys, now_ts)
+            (_logger.warning if warn_now else _logger.debug)(
                 "Rejected battery bank for device 0x%02x — sub-bus splice (>=2 physics-impossible "
-                "deltas); keeping last-good. Trips: %s. Please report if seen.",
+                "deltas); keeping last-good. Trips: %s%s. Please report if seen.",
                 device_address,
                 self._format_splice_trips(phys),
+                suffix,
             )
             return False
 
@@ -1583,6 +1599,44 @@ class Plant(GivEnergyBaseModel):
     def _fmt_scalar_sig(scalar_immut: list[tuple[int, str, int, int]]) -> str:
         """Render scalar-immutable trips compactly for the INFO logs, e.g. ``IR(98) 3005->3010``."""
         return ", ".join(f"IR({ir_no}) {old}->{new}" for ir_no, _name, old, new in scalar_immut)
+
+    def _splice_burst_note_reject(
+        self, device_address: int, trips: list[tuple[int, str, int, int]], now_ts: datetime
+    ) -> tuple[bool, str]:
+        """Track a hard reject in the per-device burst state; decide WARNING vs DEBUG (#355).
+
+        Returns ``(warn_now, suffix)``: ``warn_now`` is True for a burst onset, a changed trip
+        signature, or an over-interval escalation re-warn; the suffix carries the running tally on
+        escalations. The signature is the SET of tripped (register, rule) pairs — value-agnostic,
+        so jittering corrupt values don't defeat the coalescing.
+        """
+        sig = frozenset((ir, name) for ir, name, _old, _new in trips)
+        burst = self._splice_reject_burst.get(device_address)
+        if burst is None or burst[0] != sig:
+            self._splice_reject_burst[device_address] = (sig, now_ts, 1, now_ts)
+            return True, ""
+        _, start, count, last_warn = burst
+        count += 1
+        if (now_ts - last_warn).total_seconds() >= SPLICE_REJECT_REWARN_SECONDS:
+            self._splice_reject_burst[device_address] = (sig, start, count, now_ts)
+            return True, f" (ongoing burst: {count} rejections over {(now_ts - start).total_seconds():.0f}s)"
+        self._splice_reject_burst[device_address] = (sig, start, count, last_warn)
+        return False, ""
+
+    def _splice_burst_note_commit(self, device_address: int, now_ts: datetime) -> None:
+        """Close out a reject burst on a successful commit; log the tally once (#355).
+
+        Singleton rejections skip the clearing line — their onset WARNING already told the story.
+        """
+        burst = self._splice_reject_burst.pop(device_address, None)
+        if burst is not None and burst[2] > 1:
+            _logger.warning(
+                "Battery bank for device 0x%02x: splice burst cleared after %d rejections over %.0fs "
+                "— last-good was held throughout.",
+                device_address,
+                burst[2],
+                (now_ts - burst[1]).total_seconds(),
+            )
 
     @staticmethod
     def _format_splice_trips(trips: list[tuple[int, str, int, int]]) -> str:

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -3892,7 +3892,7 @@ def test_splice_burst_short_read_does_not_clear(plant: Plant, caplog):
 
 
 def test_splice_reject_report_plea_gated_on_novel_signature(plant: Plant, caplog):
-    """ "Please report if seen" only solicits shapes we haven't characterised (#355).
+    """The report plea only solicits shapes we haven't characterised (#355).
 
     The temp-zero cohort is corpus-characterised to death — a report adds nothing, so its
     onset drops the plea. A novel ≥2-physics shape (voltage-class trips) keeps it: that is

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -3889,3 +3889,29 @@ def test_splice_burst_short_read_does_not_clear(plant: Plant, caplog):
         _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0 + timedelta(seconds=40))
     clears = [r for r in caplog.records if "splice burst cleared" in r.message]
     assert len(clears) == 1 and "3 rejection" in clears[0].message
+
+
+def test_splice_reject_report_plea_gated_on_novel_signature(plant: Plant, caplog):
+    """ "Please report if seen" only solicits shapes we haven't characterised (#355).
+
+    The temp-zero cohort is corpus-characterised to death — a report adds nothing, so its
+    onset drops the plea. A novel ≥2-physics shape (voltage-class trips) keeps it: that is
+    exactly the evidence the corpus model and the #299 heal question hinge on.
+    """
+    import logging
+
+    _establish_baseline(plant, device_address=_BATT, received_at=_T0)
+    with caplog.at_level(logging.WARNING, logger="givenergy_modbus.model.plant"):
+        _feed_bank(plant, _corrupt_tempzero_bank(), device_address=_BATT, received_at=_T0 + timedelta(seconds=10))
+    known = [r for r in caplog.records if "sub-bus splice" in r.message]
+    assert len(known) == 1 and "Please report if seen" not in known[0].message
+
+    caplog.clear()
+    _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0 + timedelta(seconds=20))
+    with caplog.at_level(logging.WARNING, logger="givenergy_modbus.model.plant"):
+        # two cell-voltage physics trips, temps intact — NOT the known cohort
+        _feed_bank(
+            plant, _coherent_battery_bank({60: 0, 61: 0}), device_address=_BATT, received_at=_T0 + timedelta(seconds=30)
+        )
+    novel = [r for r in caplog.records if "sub-bus splice" in r.message]
+    assert len(novel) == 1 and "Please report if seen" in novel[0].message

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -2977,8 +2977,12 @@ def test_splice_serial_block_change_always_rejected(plant: Plant, caplog):
         for n in range(1, 25):  # 24 polls @ 15 s = 360 s; observation clock refreshes so bypass never fires
             _feed_bank(plant, swapped, device_address=_BATT, received_at=_T0 + timedelta(seconds=15 * n))
     assert plant.register_caches[_BATT][IR(110)] == 0x4247  # last-good serial held forever
+    # Every poll was rejected (the counter is the tally); the WARNINGs coalesce (#355):
+    # onset at t=15s + one escalation re-warn at t=315s (>=300s interval) = exactly 2.
+    assert plant.splice_reject_count == {_BATT: 24}
     serial_rejects = [r for r in caplog.records if "serial-block change" in r.message and "0x33" in r.message]
-    assert len(serial_rejects) == 24
+    assert len(serial_rejects) == 2
+    assert "ongoing burst" in serial_rejects[1].message
     assert not [r for r in caplog.records if "adopting as new baseline" in r.message]  # never healed
 
 
@@ -3679,9 +3683,12 @@ def test_splice_sustained_corruption_never_bypassed(plant: Plant, caplog):
     assert plant.register_caches[_BATT][IR(76)] == 250
     # The bypass must never have fired (it would have adopted a corrupt bank).
     assert not [r for r in caplog.records if "stale baseline" in r.message]
-    # Every corrupt poll was rejected.
+    # Every corrupt poll was rejected (counter tally); WARNINGs coalesce (#355):
+    # onset at t=30s + one escalation re-warn at t=330s (>=300s interval) = exactly 2.
+    assert plant.splice_reject_count == {_BATT: 20}
     rejects = [r for r in caplog.records if "Rejected battery bank" in r.message and "0x33" in r.message]
-    assert len(rejects) == 20
+    assert len(rejects) == 2
+    assert "ongoing burst" in rejects[1].message
 
 
 def test_splice_bypass_only_after_genuine_gap_not_rejection_streak(plant: Plant, caplog):
@@ -3750,3 +3757,110 @@ def test_splice_guard_defaults_now_when_received_at_missing(plant: Plant):
     # Second bank moments later: gap ~0 s (no bypass), single in-threshold change commits.
     _feed_bank(plant, _coherent_battery_bank({60: 3350}), device_address=_BATT)
     assert plant.register_caches[_BATT][IR(60)] == 3350
+
+
+# ---------------------------------------------------------------------------
+# Splice-reject WARNING coalescing during sustained bursts (#355)
+# ---------------------------------------------------------------------------
+
+
+def _corrupt_tempzero_bank() -> dict[int, int]:
+    """A ≥2-physics temp-zero-cohort bank (the 2026-07-01 field-burst shape)."""
+    return _coherent_battery_bank({76: 560, 78: 0, 81: 0})
+
+
+def test_splice_burst_first_reject_warns_repeats_debug(plant: Plant, caplog):
+    """Onset of a burst logs the full-detail WARNING; identical-signature repeats drop to DEBUG.
+
+    The counter keeps the per-rejection tally — nothing quantitative is lost (#284/#355).
+    """
+    import logging
+
+    _establish_baseline(plant, device_address=_BATT, received_at=_T0)
+    with caplog.at_level(logging.DEBUG, logger="givenergy_modbus.model.plant"):
+        for i in range(1, 6):
+            _feed_bank(
+                plant, _corrupt_tempzero_bank(), device_address=_BATT, received_at=_T0 + timedelta(seconds=10 * i)
+            )
+    warns = [r for r in caplog.records if r.levelno == logging.WARNING and "sub-bus splice" in r.message]
+    debugs = [r for r in caplog.records if r.levelno == logging.DEBUG and "sub-bus splice" in r.message]
+    assert len(warns) == 1, "only the burst onset may WARN"
+    assert len(debugs) == 4, "repeats stay visible at DEBUG"
+    assert plant.splice_reject_count == {_BATT: 5}  # tally unaffected
+
+
+def test_splice_burst_clear_warns_once_with_stats(plant: Plant, caplog):
+    """A successful commit after a multi-rejection burst logs one clearing WARNING with stats."""
+    import logging
+
+    _establish_baseline(plant, device_address=_BATT, received_at=_T0)
+    for i in range(1, 4):
+        _feed_bank(plant, _corrupt_tempzero_bank(), device_address=_BATT, received_at=_T0 + timedelta(seconds=10 * i))
+    with caplog.at_level(logging.WARNING, logger="givenergy_modbus.model.plant"):
+        _feed_bank(
+            plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0 + timedelta(seconds=40)
+        )  # healthy again → commits
+    clears = [r for r in caplog.records if "splice burst cleared" in r.message]
+    assert len(clears) == 1
+    assert "3 rejection" in clears[0].message
+    assert plant.register_caches[_BATT][IR(60)] == 3300  # recovery committed
+
+
+def test_splice_burst_singleton_reject_no_clear_line(plant: Plant, caplog):
+    """A single rejection followed by recovery logs no 'cleared' line — onset already told the story."""
+    import logging
+
+    _establish_baseline(plant, device_address=_BATT, received_at=_T0)
+    _feed_bank(plant, _corrupt_tempzero_bank(), device_address=_BATT, received_at=_T0 + timedelta(seconds=10))
+    with caplog.at_level(logging.WARNING, logger="givenergy_modbus.model.plant"):
+        _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0 + timedelta(seconds=20))
+    assert not [r for r in caplog.records if "splice burst cleared" in r.message]
+
+
+def test_splice_burst_signature_change_warns_again(plant: Plant, caplog):
+    """A different trip signature mid-burst is a new onset — full-detail WARNING again."""
+    import logging
+
+    _establish_baseline(plant, device_address=_BATT, received_at=_T0)
+    with caplog.at_level(logging.WARNING, logger="givenergy_modbus.model.plant"):
+        _feed_bank(plant, _corrupt_tempzero_bank(), device_address=_BATT, received_at=_T0 + timedelta(seconds=10))
+        # different registers trip: cell-voltage + capacity class instead of temps
+        _feed_bank(
+            plant,
+            _coherent_battery_bank({60: 0, 61: 0, 77: 0, 79: 0}),
+            device_address=_BATT,
+            received_at=_T0 + timedelta(seconds=20),
+        )
+    warns = [r for r in caplog.records if r.levelno == logging.WARNING and "sub-bus splice" in r.message]
+    assert len(warns) == 2, "changed signature must re-warn with full detail"
+
+
+def test_splice_burst_escalation_rewarns_after_interval(plant: Plant, caplog):
+    """A burst outliving the re-warn interval re-emits at WARNING so a stuck condition can't go silent."""
+    import logging
+
+    _establish_baseline(plant, device_address=_BATT, received_at=_T0)
+    with caplog.at_level(logging.WARNING, logger="givenergy_modbus.model.plant"):
+        _feed_bank(plant, _corrupt_tempzero_bank(), device_address=_BATT, received_at=_T0 + timedelta(seconds=10))
+        _feed_bank(
+            plant, _corrupt_tempzero_bank(), device_address=_BATT, received_at=_T0 + timedelta(seconds=40)
+        )  # inside interval → suppressed
+        _feed_bank(
+            plant, _corrupt_tempzero_bank(), device_address=_BATT, received_at=_T0 + timedelta(seconds=10 + 301)
+        )  # past the 300s re-warn interval
+    warns = [r for r in caplog.records if r.levelno == logging.WARNING and "sub-bus splice" in r.message]
+    assert len(warns) == 2, "escalation re-warn expected after the interval"
+    assert "ongoing" in warns[1].message
+
+
+def test_splice_burst_isolated_per_device(plant: Plant, caplog):
+    """Bursts on different devices coalesce independently — each gets its own onset WARNING."""
+    import logging
+
+    _establish_baseline(plant, device_address=0x33, received_at=_T0)
+    _establish_baseline(plant, device_address=0x34, received_at=_T0)
+    with caplog.at_level(logging.WARNING, logger="givenergy_modbus.model.plant"):
+        _feed_bank(plant, _corrupt_tempzero_bank(), device_address=0x33, received_at=_T0 + timedelta(seconds=10))
+        _feed_bank(plant, _corrupt_tempzero_bank(), device_address=0x34, received_at=_T0 + timedelta(seconds=11))
+    warns = [r for r in caplog.records if r.levelno == logging.WARNING and "sub-bus splice" in r.message]
+    assert len(warns) == 2

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -3864,3 +3864,28 @@ def test_splice_burst_isolated_per_device(plant: Plant, caplog):
         _feed_bank(plant, _corrupt_tempzero_bank(), device_address=0x34, received_at=_T0 + timedelta(seconds=11))
     warns = [r for r in caplog.records if r.levelno == logging.WARNING and "sub-bus splice" in r.message]
     assert len(warns) == 2
+
+
+def test_splice_burst_short_read_does_not_clear(plant: Plant, caplog):
+    """A short battery read (unguarded, register_count<60) must not close a reject burst (#364 review).
+
+    Only an accepted FULL bank is a burst-ending observation — a count=1 fan-out commit between
+    corrupt full banks would otherwise log a misleading 'cleared' and re-spam fresh onsets.
+    """
+    import logging
+
+    _establish_baseline(plant, device_address=_BATT, received_at=_T0)
+    with caplog.at_level(logging.DEBUG, logger="givenergy_modbus.model.plant"):
+        _feed_bank(plant, _corrupt_tempzero_bank(), device_address=_BATT, received_at=_T0 + timedelta(seconds=10))
+        _feed_bank(plant, _corrupt_tempzero_bank(), device_address=_BATT, received_at=_T0 + timedelta(seconds=20))
+        # a legitimate single-register fan-out read commits via the unguarded short-read path
+        _feed_bank(plant, {100: 56}, device_address=_BATT, count=1, received_at=_T0 + timedelta(seconds=25))
+        _feed_bank(plant, _corrupt_tempzero_bank(), device_address=_BATT, received_at=_T0 + timedelta(seconds=30))
+    assert not [r for r in caplog.records if "splice burst cleared" in r.message]
+    warns = [r for r in caplog.records if r.levelno == logging.WARNING and "sub-bus splice" in r.message]
+    assert len(warns) == 1, "burst must survive the short read — no fresh onset"
+    # the eventual full-bank recovery still closes it out with the full tally
+    with caplog.at_level(logging.WARNING, logger="givenergy_modbus.model.plant"):
+        _feed_bank(plant, _coherent_battery_bank(), device_address=_BATT, received_at=_T0 + timedelta(seconds=40))
+    clears = [r for r in caplog.records if "splice burst cleared" in r.message]
+    assert len(clears) == 1 and "3 rejection" in clears[0].message


### PR DESCRIPTION
Closes #355. Sustained same-signature reject bursts now log onset (full detail, unchanged wording) → DEBUG repeats (`splice_reject_count` keeps the tally) → a 300 s escalation re-warn with the running count → one clearing WARNING with stats when a commit finally succeeds (singletons skip it).

The signature is the **set of tripped (register, rule) pairs** — value-agnostic, so jittering corrupt values can't defeat the coalescing. Both hard-reject sites (serial-block change, ≥2-physics) route through it; the scalar-immutable and escrow paths were already INFO-level holds and are untouched.

On the 2026-07-01 field burst this turns ~13 identical WARNINGs into 1 (plus a clearing line); an hour-long burst goes from ~1,400 lines to onset + ~11 escalations + resolution.

Tests: 6 new (onset/repeat, clear-with-stats, singleton-no-clear, signature-change re-warns, escalation, per-device isolation). Two sustained-burst regression tests updated — their substantive protections are unchanged; they now assert the counter tally + the coalesced onset+escalation pattern (timing-deterministic: exactly 2 WARNINGs each).

Full suite 1492 passed; tox matrix green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced repeated warning spam during sustained battery splice-reject bursts.
  * Repeated identical reject patterns are now logged more quietly, with re-warnings only after a configurable interval, when the pattern changes, or when the burst escalates.
  * Recovery now emits a single consolidated “splice burst cleared” summary including rejection counts.
  * Logging coalescing is applied per device, and short reads no longer clear an active burst.
* **Tests**
  * Updated and extended burst scenario coverage to verify warning coalescing, escalation, and clearing behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->