### PR TITLE
Manifest Slice A: register-semantics routing + per-model renames (#293)

### DIFF
--- a/docs/hardware-firmware-quirks.md
+++ b/docs/hardware-firmware-quirks.md
@@ -33,13 +33,13 @@ return daily battery energy. The v4.1.6 doc, however, defines IR180-183 as
 genuinely battery energy, not a misread.
 
 **Implication.** The library's `alt1` battery-total source (`IR(180)`/`IR(181)` in
-`_BATTERY_ENERGY_SOURCE`) is correct for GEN1 but **firmware-fragile**: on a build that
+`manifest.VALUE_SOURCES`) is correct for GEN1 but **firmware-fragile**: on a build that
 implements the EV-charger definitions, deci-scaling a phase-voltage reading would yield
 a bogus "~175 kWh" total. Battery-energy routing must stay keyed to the resolved model,
 never inferred from live values, and should migrate to the dedicated registers below
 when a unit supports them.
 
-**References.** v4.1.6 §4.1.2; `model/inverter.py` `_BATTERY_ENERGY_SOURCE`.
+**References.** v4.1.6 §4.1.2; `model/manifest.py` `VALUE_SOURCES`.
 
 ## Firmware-gated registers — specified but absent on old builds (IR194-199, HR84-89)
 
@@ -54,7 +54,7 @@ the zeros are a firmware result. The same unit returns zero for HR84-89 (the §4
 firmware-version-string scheme), so this build predates several doc additions.
 
 **Implication.** IR194-197 cannot be a *universal* battery-total source. The library's
-`_BATTERY_ENERGY_SOURCE` is keyed by static `Model`, which has no way to express
+`manifest.VALUE_SOURCES` is keyed by static `Model`, which has no way to express
 "firmware ≥ v4.1.5". Mapping these registers needs either firmware gating or must stay
 conditional until a unit is observed that actually populates them. Confirmed lower
 anchor: **HYBRID_GEN1 @ ARM 449 → absent.** No upper anchor (a unit that *does* populate

--- a/docs/migrating-from-the-async-fork.md
+++ b/docs/migrating-from-the-async-fork.md
@@ -155,8 +155,8 @@ Same registers, clearer names (register numbers shown as the join key):
 |---|---|---|
 | `battery_percent` | `battery_soc` | IR(59) |
 | `e_inverter_in_day` | `e_ac_charge_today` | IR(35) |
-| `e_inverter_out_day` | `e_pv_generation_today` (deprecated alias kept for one release) | IR(44) |
-| `e_inverter_out_total` | `e_pv_generation_total` | IR(45,46) |
+| `e_inverter_out_day` | `e_pv_generation_today`[^ir44] (deprecated alias kept for one release) | IR(44) |
+| `e_inverter_out_total` | `e_pv_generation_total`[^ir44] | IR(45,46) |
 | `e_battery_throughput_total` | `e_battery_throughput` | IR(6,7) |
 | `e_battery_charge_today` | `e_battery_charge_today_alt1` | IR(36) |
 | `e_battery_discharge_today` | `e_battery_discharge_today_alt1` | IR(37) |
@@ -181,6 +181,13 @@ Same registers, clearer names (register numbers shown as the join key):
 | `temp_battery` | `t_battery` | IR(56) |
 | `temp_inverter_heatsink` | `t_inverter_heatsink` | IR(41) |
 | `work_time_total` | `work_time_total_hours` | IR(47,48) |
+
+[^ir44]: As of 2.10, IR(44)/IR(45,46) carry different quantities depending on
+    model (#293): on DC-coupled hybrids they're genuine PV generation and
+    `e_pv_generation_today`/`_total` stay live; on AC-coupled and All-in-One
+    units the registers actually report inverter AC output, so those fields
+    return `None` and the value lives on `e_inverter_out_today`/`_total`
+    instead. See the per-model contract in `model/manifest.py`.
 
 Computed values like `battery_max_power` and `inverter_max_power` are
 properties on the inverter model rather than register definitions, but keep

--- a/givenergy_modbus/model/inverter.py
+++ b/givenergy_modbus/model/inverter.py
@@ -1228,6 +1228,14 @@ class SinglePhaseInverter(  # type: ignore[valid-type,misc]
 
         Three-phase units have a native e_load_today register and so do NOT get this
         computed field (it lives on SinglePhaseInverter only, not in the register LUT).
+
+        On AC-coupled and All-in-One units this returns None: manifest.py's IR44
+        identity routing (#293) already makes e_pv_generation_today None there (the
+        register carries inverter output, not PV, on those models), so the pv term's
+        own None-propagation below does the rest — no separate AC/AIO guard needed. A
+        candidate corrected-AIO consumption formula was evaluated against wire
+        evidence and failed the evidence gate; see manifest.py's module comment.
+
         Returns None if any input is unavailable.
         """
         pv = self.e_pv_generation_today  # type: ignore[attr-defined]
@@ -1254,6 +1262,10 @@ class SinglePhaseInverter(  # type: ignore[valid-type,misc]
           use state_class TOTAL_INCREASING (e.g. HA energy dashboard) MUST apply their
           own monotonic clamp rather than consuming the raw value directly.
 
+        On AC-coupled and All-in-One units this returns None via the same
+        None-propagation as e_consumption_today: manifest.py's IR44 identity routing
+        (#293) already makes e_pv_generation_today None there.
+
         Returns None if any input is unavailable.
         """
         pv = self.e_pv_generation_today  # type: ignore[attr-defined]
@@ -1274,6 +1286,9 @@ class SinglePhaseInverter(  # type: ignore[valid-type,misc]
         guaranteed to increase monotonically. Consumers using state_class
         TOTAL_INCREASING MUST apply a monotonic clamp (e.g. HA's monotonic=True
         sensor path) rather than consuming the raw value directly.
+
+        On AC-coupled and All-in-One units this returns None: manifest.py's IR44
+        identity routing (#293) already makes e_pv_generation_total None there.
 
         Returns None if any input is unavailable.
         """
@@ -1303,12 +1318,16 @@ class SinglePhaseInverter(  # type: ignore[valid-type,misc]
         without it, direct PV could exceed total on-site PV self-consumption, which is
         nonsensical (a subset can't beat its superset) — Codex review on #313.
 
-        Restricted to DC-coupled solar hybrids: on AC-coupled and All-in-One units the
-        PV-generation registers (IR44/45-46) are mislabelled — they read non-zero on
-        battery-only hardware (#293) — so the field returns None there rather than a
-        confident wrong value. In practice e_battery_charge_today only routes on
-        HYBRID_GEN1 today (see _BATTERY_ENERGY_SOURCE / #184), so the field is currently
-        GEN1-effective and returns None on other DC models until that map widens.
+        Effectively restricted to DC-coupled solar hybrids: on AC-coupled and All-in-One
+        units the PV-generation registers (IR44/45-46) are mislabelled — they carry the
+        inverter's battery-discharge AC output, not PV (#293) — and manifest.py's IR44
+        identity routing already makes e_pv_generation_today None there, so the pv term's
+        None-propagation below returns None with no separate AC/AIO guard needed. A
+        candidate corrected-AIO formula was evaluated against wire evidence and failed
+        the evidence gate; see manifest.py's module comment. In practice
+        e_battery_charge_today only routes on HYBRID_GEN1 today (see
+        _BATTERY_ENERGY_SOURCE / #184), so the field is currently GEN1-effective and
+        returns None on other DC models until that map widens.
 
         Only daily is offered: the lifetime equivalent needs e_ac_charge_total, which
         single-phase firmware does not expose (three-phase only, IR1378/9).
@@ -1316,10 +1335,8 @@ class SinglePhaseInverter(  # type: ignore[valid-type,misc]
         NOT monotonically increasing intraday — a grid-export burst can dip it — so
         consumers using state_class TOTAL_INCREASING MUST apply their own monotonic clamp
         (e.g. HA's monotonic=True path). Returns None if any input is unavailable or the
-        model is ineligible.
+        pv term is unavailable for this model (AC/AIO).
         """
-        if self.is_ac_coupled or self.model is Model.ALL_IN_ONE:  # type: ignore[attr-defined]
-            return None
         pv = self.e_pv_generation_today  # type: ignore[attr-defined]
         grid_out = self.e_grid_out_day  # type: ignore[attr-defined]
         battery_charge = self.e_battery_charge_today

--- a/givenergy_modbus/model/inverter.py
+++ b/givenergy_modbus/model/inverter.py
@@ -3,7 +3,7 @@ import warnings
 from enum import Enum, IntEnum, StrEnum
 from typing import ClassVar
 
-from pydantic import ConfigDict, computed_field, create_model
+from pydantic import ConfigDict, computed_field, create_model, model_validator
 
 from givenergy_modbus.client.commands import _InverterCommands
 from givenergy_modbus.model.battery import ExportPriority
@@ -959,10 +959,13 @@ class SinglePhaseInverterRegisterGetter(RegisterGetter):
         # Inverter AC grid-terminal apparent power (VA); pairs with IR(24), not IR(30)
         # (IR43/IR24 → plausible PF ~0.9; IR43/IR30 → impossible). Same node as IR(24).
         "p_grid_apparent": Def(C.uint16, None, IR(43), max=50000),
-        # IR(44) is PV-generation-today and IR(45/46) is PV-generation-total (both
-        # sentinel cross-correlation, #174), not the inverter AC output. Renamed from
-        # "e_inverter_out_day" / "e_inverter_out_total"; the old names are kept as
-        # deprecated @property aliases for a release.
+        # IR(44) is PV-generation-today and IR(45/46) is PV-generation-total on most
+        # models (sentinel cross-correlation, #174) — but on AC/ALL_IN_ONE they carry
+        # the inverter's battery-discharge AC output instead (#293): see
+        # _apply_field_identity below, which moves the decoded value across to
+        # e_inverter_out_today/_total on exactly those two models. Renamed from
+        # "e_inverter_out_day" / "e_inverter_out_total"; "day" is kept as a deprecated
+        # @property alias for a release ("total" is now a real field, live on AC/AIO).
         # NB: this rename is single-phase only. ThreePhaseInverter has its OWN native
         # e_inverter_out_total (IR1362/3) — a genuine, distinct register from its PV
         # total (e_pv_total, IR1374/5) — so the 3ph field is left untouched.
@@ -1041,6 +1044,45 @@ class SinglePhaseInverter(  # type: ignore[valid-type,misc]
         if self.e_pv1_day is None or self.e_pv2_day is None:  # type: ignore[attr-defined]
             return None
         return self.e_pv1_day + self.e_pv2_day  # type: ignore[attr-defined]
+
+    # Accurate per-model identity for IR(44)/IR(45-46) on AC/AIO (#293): the inverter's
+    # battery-discharge AC output. Populated ONLY by _apply_field_identity below; on
+    # DC hybrids these stay None and e_pv_generation_* carries the (genuine) PV values.
+    e_inverter_out_today: float | None = None
+    e_inverter_out_total: float | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _apply_field_identity(cls, values: dict) -> dict:
+        """Route model-dependent register identities per the manifest (#293).
+
+        Runs on the raw values dict (the model is frozen, so after-mode mutation is
+        unavailable). Overrides-only: unresolvable models keep the status quo.
+        Input-driven, so re-validation is idempotent: a value moves only when the
+        source field actually carries one, and re-validating a dumped model (where
+        e_pv_generation_* is already None) passes the moved values through untouched.
+        """
+        from givenergy_modbus.model.manifest import ir44_is_inverter_output
+
+        if not isinstance(values, dict):
+            return values
+        dtc = values.get("device_type_code")
+        arm_fw = values.get("arm_firmware_version")
+        if dtc is None or arm_fw is None:
+            return values
+        try:
+            model = resolve_model(int(dtc, 16), int(arm_fw))
+        except (TypeError, ValueError):
+            return values
+        if ir44_is_inverter_output(model, arm_fw=int(arm_fw)):
+            for src, dst in (
+                ("e_pv_generation_today", "e_inverter_out_today"),
+                ("e_pv_generation_total", "e_inverter_out_total"),
+            ):
+                if values.get(src) is not None:
+                    values[dst] = values.pop(src)
+                    values[src] = None
+        return values
 
     def _battery_energy(self, direction: str, metric: str) -> float | None:
         """Route a battery-energy metric to this model's authoritative alt register.
@@ -1340,34 +1382,16 @@ class SinglePhaseInverter(  # type: ignore[valid-type,misc]
         )
         return self.enable_inverter_parallel_mode  # type: ignore[attr-defined,no-any-return]
 
-    # Plain @property so the deprecated alias doesn't appear in model_dump().
-    # IR(44) was decoded as e_inverter_out_day (GivTCP-era guess); sentinel
-    # cross-correlation (#174) confirmed it is PV-generation-today. Renamed to
-    # e_pv_generation_today; this alias preserves back-compat for a release.
     @property
     def e_inverter_out_day(self) -> float | None:
-        """Deprecated alias for `e_pv_generation_today`."""
+        """Deprecated alias for `e_inverter_out_today` (live on AC/AIO; None on hybrids, #293)."""
         warnings.warn(
-            "SinglePhaseInverter.e_inverter_out_day is deprecated; use e_pv_generation_today",
+            "SinglePhaseInverter.e_inverter_out_day is deprecated; use e_inverter_out_today "
+            "(AC/AIO) or e_pv_generation_today (DC hybrids)",
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.e_pv_generation_today  # type: ignore[attr-defined,no-any-return]
-
-    # IR(45/46) was decoded as e_inverter_out_total (GivTCP-era guess); the same
-    # sentinel cross-correlation (#174) confirmed it is PV-generation-total. Renamed
-    # to e_pv_generation_total; this alias preserves back-compat for a release.
-    # Single-phase only: ThreePhaseInverter keeps its native e_inverter_out_total
-    # (IR1362/3), which is a genuine register there, so no alias is defined on 3ph.
-    @property
-    def e_inverter_out_total(self) -> float | None:
-        """Deprecated alias for `e_pv_generation_total`."""
-        warnings.warn(
-            "SinglePhaseInverter.e_inverter_out_total is deprecated; use e_pv_generation_total",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.e_pv_generation_total  # type: ignore[attr-defined,no-any-return]
+        return self.e_inverter_out_today
 
     # HR(63-82) renamed: _1/_2/_3 → _trip/_reconnect/_grid (installer-confirmed band structure).
     # Aliases preserve back-compat for a release.

--- a/givenergy_modbus/model/inverter.py
+++ b/givenergy_modbus/model/inverter.py
@@ -862,7 +862,7 @@ class SinglePhaseInverterRegisterGetter(RegisterGetter):
         # (our max poll base is HR(240); GivTCP's add_regs detect-probe candidates top
         # out at HR(300)). Defined for naming symmetry with the IR alt sources and as
         # scaffold for a future #48 "does this block respond on real hardware?" probe;
-        # no model's _BATTERY_ENERGY_SOURCE routes here. The C.deci scaling diverges
+        # no model's manifest.VALUE_SOURCES entry routes here. The C.deci scaling diverges
         # from GivTCP's raw (None) defs — moot while unpolled, reconcile under #48.
         "e_battery_discharge_total_alt2": Def(C.uint32, C.deci, HR(4109), HR(4110)),
         "e_battery_charge_total_alt2": Def(C.uint32, C.deci, HR(4111), HR(4112)),
@@ -1326,7 +1326,7 @@ class SinglePhaseInverter(  # type: ignore[valid-type,misc]
         candidate corrected-AIO formula was evaluated against wire evidence and failed
         the evidence gate; see manifest.py's module comment. In practice
         e_battery_charge_today only routes on HYBRID_GEN1 today (see
-        _BATTERY_ENERGY_SOURCE / #184), so the field is currently GEN1-effective and
+        manifest.VALUE_SOURCES / #184), so the field is currently GEN1-effective and
         returns None on other DC models until that map widens.
 
         Only daily is offered: the lifetime equivalent needs e_ac_charge_total, which

--- a/givenergy_modbus/model/inverter.py
+++ b/givenergy_modbus/model/inverter.py
@@ -1003,28 +1003,6 @@ class SinglePhaseInverterRegisterGetter(RegisterGetter):
     }
 
 
-# Per-(specific-model, metric) authoritative battery-energy source, keyed on the
-# Model resolved by resolve_model() — NOT the coarse `self.model` family. Declared
-# only where a wire capture positively confirms it; an absent model or metric routes
-# to None (honest "no evidence yet" + a forcing function for which captures to chase).
-# "today"/"total" each map to an altN whose register name is built as
-# e_battery_{charge,discharge}_{metric}_{altN} (see _battery_energy / the LUT renames).
-#
-#   alt1 = IR(36/37) daily, IR(180/181) total   alt2 = IR(182/183) daily, HR total (dead)
-#   alt3 = HR(4113/4114) daily (dead, never polled — see #48)
-#
-# Evidence (tests/fixtures/captures/): GEN1 populates the alt2 daily registers as
-# authoritative (non-alt read 0 on some firmware) and IR alt1 totals (17526/14791).
-# AC/AIO populate alt1 daily; their IR totals read a real 0 and where the lifetime
-# total actually lives is unknown (the HR block is never polled by anyone) — so total
-# is deliberately left undeclared → None rather than reporting a misleading 0.
-_BATTERY_ENERGY_SOURCE: dict[Model, dict[str, str]] = {
-    Model.HYBRID_GEN1: {"today": "alt2", "total": "alt1"},
-    Model.AC: {"today": "alt1"},
-    Model.ALL_IN_ONE: {"today": "alt1"},
-}
-
-
 _SinglePhaseInverterBase = create_model(  # type: ignore[call-overload]
     "SinglePhaseInverter",
     __config__=ConfigDict(frozen=True),
@@ -1069,7 +1047,7 @@ class SinglePhaseInverter(  # type: ignore[valid-type,misc]
 
         Which register location a firmware populates is a *static* property of the
         model, not something to infer from live values (the #119 lesson — see #76 /
-        Codex review on #150). `_BATTERY_ENERGY_SOURCE` declares, per specific model,
+        Codex review on #150). `manifest.VALUE_SOURCES` declares, per specific model,
         which `altN` source is authoritative for each metric; the value is returned
         verbatim including a legitimate 0.0. Returns None when the model or metric is
         undeclared (honest "no evidence yet") — no value inspection, no cross-source
@@ -1082,7 +1060,9 @@ class SinglePhaseInverter(  # type: ignore[valid-type,misc]
         if dtc is None or arm_fw is None:
             return None
         model = resolve_model(int(dtc, 16), int(arm_fw))
-        alt = _BATTERY_ENERGY_SOURCE.get(model, {}).get(metric)
+        from givenergy_modbus.model.manifest import battery_energy_source
+
+        alt = battery_energy_source(model, metric, arm_fw=int(arm_fw))
         if alt is None:
             return None
         return getattr(self, f"e_battery_{direction}_{metric}_{alt}")

--- a/givenergy_modbus/model/inverter.py
+++ b/givenergy_modbus/model/inverter.py
@@ -1401,14 +1401,16 @@ class SinglePhaseInverter(  # type: ignore[valid-type,misc]
 
     @property
     def e_inverter_out_day(self) -> float | None:
-        """Deprecated alias for `e_inverter_out_today` (live on AC/AIO; None on hybrids, #293)."""
+        """Deprecated alias for `e_inverter_out_today` (AC/AIO) or `e_pv_generation_today` (hybrids, #293)."""
         warnings.warn(
             "SinglePhaseInverter.e_inverter_out_day is deprecated; use e_inverter_out_today "
             "(AC/AIO) or e_pv_generation_today (DC hybrids)",
             DeprecationWarning,
             stacklevel=2,
         )
-        return self.e_inverter_out_today
+        if self.e_inverter_out_today is not None:
+            return self.e_inverter_out_today
+        return self.e_pv_generation_today  # type: ignore[attr-defined]
 
     # HR(63-82) renamed: _1/_2/_3 → _trip/_reconnect/_grid (installer-confirmed band structure).
     # Aliases preserve back-compat for a release.

--- a/givenergy_modbus/model/manifest.py
+++ b/givenergy_modbus/model/manifest.py
@@ -44,3 +44,21 @@ def battery_energy_source(model: Model, metric: str, arm_fw: int | None = None) 
     exist in Slice A).
     """
     return VALUE_SOURCES.get(f"battery_energy_{metric}", {}).get(model)
+
+
+# IR(44)/IR(45-46) identity overrides (#293): on these models the registers carry the
+# inverter's battery-discharge AC OUTPUT, not PV generation — delta-evidenced against
+# HV-stack counters (AberDino's 2×AIO, 2026-07-02: IR44 = 0.90× stack discharge,
+# accumulates pre-dawn, flat through an 11.5 kWh PV midday) and the ems_2_inv_3_bat_a
+# fixture's Model.AC units (IR44 == battery discharge). Unlisted models keep the
+# status quo (e_pv_generation_* live — the #174 hybrid verdict); adding a row here is
+# the entire upgrade path when new evidence lands. AIO_COMMERCIAL/ALL_IN_ONE_HYBRID
+# are ThreePhase-decoded and never reach the SinglePhaseInverter validator.
+FIELD_IDENTITY: dict[str, frozenset[Model]] = {
+    "ir44_inverter_out": frozenset({Model.AC, Model.ALL_IN_ONE}),
+}
+
+
+def ir44_is_inverter_output(model: Model, arm_fw: int | None = None) -> bool:
+    """True when IR44/IR45-46 carry inverter output (not PV) on this model (#293)."""
+    return model in FIELD_IDENTITY["ir44_inverter_out"]

--- a/givenergy_modbus/model/manifest.py
+++ b/givenergy_modbus/model/manifest.py
@@ -62,3 +62,35 @@ FIELD_IDENTITY: dict[str, frozenset[Model]] = {
 def ir44_is_inverter_output(model: Model, arm_fw: int | None = None) -> bool:
     """True when IR44/IR45-46 carry inverter output (not PV) on this model (#293)."""
     return model in FIELD_IDENTITY["ir44_inverter_out"]
+
+
+# Consumption-family evidence gate (#293): a candidate corrected-AIO consumption
+# formula — pv_day + grid_import − grid_export + battery_discharge − battery_charge —
+# was checked against the AberDino 2×AIO site (2026-06-29/30 delta analysis). On
+# 2026-06-30 it yields 33.7 kWh, far outside the only same-site load reference (the
+# Gateway rollup's e_load_today, 8.1-18.7 kWh/day) — but that reference is from OTHER
+# days, so there is no same-day pair to validate the formula's tolerance against.
+# Gate: FAIL. inverter.py's consumption-family deriveds (e_consumption_today,
+# e_self_consumption_today/_total, e_pv_direct_today) therefore stay None on AC/AIO —
+# not via a dedicated guard, but because the IR44 identity routing above already
+# makes e_pv_generation_today/_total None there, and each derived's own
+# None-propagation does the rest. No FIELD_IDENTITY/VALUE_SOURCES row exists for the
+# repair itself because there is nothing to route yet: the gate failed, so there is no
+# formula to enable. Missing evidence to close this: a same-day Gateway e_load_today +
+# AIO grid/battery/PV counters snapshot — a targeted ask goes to the reporter via hass
+# post-merge.
+#
+# Adjacent evidence, NOT sufficient to flip the gate: tests/fixtures/captures/
+# gateway_2aio_a (same AberDino site, 2026-07-03) carries the Gateway's own rollup
+# (IR1640-1798) — e_pv_today/e_grid_import_today/e_grid_export_today/e_aio_charge_
+# today/e_aio_discharge_today alongside the Gateway's own independently-metered
+# e_load_today, all from the same register poll. The candidate formula computed from
+# that rollup closes within ~0.1 kWh of e_load_today in BOTH committed captures
+# (daylight: 7.8 vs 7.7; night: 18.6 vs 18.7) — the formula's physics look sound at
+# this site. But it validates the Gateway's own CT-metered aggregates, not the
+# standalone AIO's local IR44-based e_pv_generation_today (independently confirmed
+# contaminated by #293) that SinglePhaseInverter.e_consumption_today would consume for
+# a directly-polled, non-gateway-fronted AIO — this capture has no per-AIO register
+# bank to cross-check against. Whether that distinction matters (and whether a
+# gateway-fronted plant even needs the repair, since GatewayV1 already exposes
+# e_load_today natively) is a maintainer call, not resolved here.

--- a/givenergy_modbus/model/manifest.py
+++ b/givenergy_modbus/model/manifest.py
@@ -1,0 +1,46 @@
+"""Declarative capability manifest — model(+firmware) → register semantics (#293, Slice A).
+
+One place answering "what does this register/field mean on this model". Grown in
+slices: A (this file's initial content) covers register SEMANTICS — value-source
+routing and per-model field identity. Slices B-D will add the capability fact
+tables, the polling ranges, and the write surface.
+
+Keys are the RESOLVED specific ``Model`` (from ``resolve_model``), never the coarse
+family. Every accessor takes ``arm_fw`` so a firmware column exists in the contract
+from day one; no Slice A row uses it (future users: slot_map's ``HYBRID_GEN3 and
+arm_fw > 302`` extended-slot wrinkle, the Gateway V1/V2 layout variant — Slice B+).
+"""
+
+from givenergy_modbus.model.inverter import Model
+
+# Per-(specific-model, metric) authoritative battery-energy source (#184; relocated
+# verbatim from inverter._BATTERY_ENERGY_SOURCE in Slice A). Declared only where a
+# wire capture positively confirms it; an absent model or metric routes to None
+# (honest "no evidence yet" + a forcing function for which captures to chase).
+# "today"/"total" each map to an altN whose register name is built as
+# e_battery_{charge,discharge}_{metric}_{altN} (see SinglePhaseInverter._battery_energy).
+#
+#   alt1 = IR(36/37) daily, IR(180/181) total   alt2 = IR(182/183) daily, HR total (dead)
+#   alt3 = HR(4113/4114) daily (dead, never polled — see #48)
+#
+# Evidence (tests/fixtures/captures/): GEN1 populates the alt2 daily registers as
+# authoritative and IR alt1 totals; AC/AIO populate alt1 daily, totals unknown → None.
+VALUE_SOURCES: dict[str, dict[Model, str]] = {
+    "battery_energy_today": {
+        Model.HYBRID_GEN1: "alt2",
+        Model.AC: "alt1",
+        Model.ALL_IN_ONE: "alt1",
+    },
+    "battery_energy_total": {
+        Model.HYBRID_GEN1: "alt1",
+    },
+}
+
+
+def battery_energy_source(model: Model, metric: str, arm_fw: int | None = None) -> str | None:
+    """Return the authoritative altN source tag for a battery-energy metric, or None.
+
+    ``arm_fw`` is accepted for forward-compatibility with firmware-gated rows (none
+    exist in Slice A).
+    """
+    return VALUE_SOURCES.get(f"battery_energy_{metric}", {}).get(model)

--- a/tests/model/test_fixture_golden_master.py
+++ b/tests/model/test_fixture_golden_master.py
@@ -142,6 +142,31 @@ async def test_aio_classifies_as_hv_all_in_one():
     # Inverter answers at 0x11; nothing served at 0x32 (the old wrong poll address).
     assert HR(0) in plant.register_caches[0x11]
 
+    # IR(44)/IR(45-46) carry inverter-output on ALL_IN_ONE, not PV generation (#293).
+    inv = plant.inverter
+    assert inv.e_pv_generation_today is None  # mislabel retired on AIO (#293)
+    assert inv.e_inverter_out_today == 1.8  # raw IR(44) == 18; 18 / 10 == 1.8
+
+
+@pytest.mark.timeout(20)
+async def test_ac_coupled_inverter_gets_inverter_out_identity():
+    """AC-coupled single-phase inverter: 0x3001/fw282 → Model.AC; IR44 is inverter output, not PV (#293).
+
+    No existing golden test decoded a Model.AC unit directly (only via the EMS rollup
+    that shares this fixture directory), so this pins one against the standalone
+    inverter-dongle capture that accompanies the EMS controller fixtures.
+    """
+    plant = await _replay("ems_2_inv_3_bat_a/ac_arm282_1x_givbat512gen3_30min.log")
+    caps = _classify(plant)
+
+    assert caps.device_type is Model.AC
+    assert caps.inverter_address == 0x11
+
+    inv = plant.inverter
+    assert inv.e_pv_generation_today is None  # mislabel retired on AC (#293)
+    assert inv.e_inverter_out_today == 6.3  # raw IR(44) == 63; 63 / 10 == 6.3
+    assert inv.e_inverter_out_total == 2643.8  # raw IR(45,46) == (0, 26438); 26438 / 10 == 2643.8
+
 
 @pytest.mark.timeout(20)
 async def test_hybrid_gen1_passive_capture_classifies_at_0x11_banks_stay_at_0x31():
@@ -166,6 +191,11 @@ async def test_hybrid_gen1_passive_capture_classifies_at_0x11_banks_stay_at_0x31
     assert HR(60) not in plant.register_caches[0x11]
     assert 0x32 in plant.register_caches
     assert 0x33 in plant.register_caches
+
+    # IR(44)/IR(45-46) stay PV generation on HYBRID_GEN1 — the #293 override doesn't fire.
+    inv = plant.inverter
+    assert inv.e_pv_generation_today == 19.2  # raw IR(44) == 192; 192 / 10 == 19.2
+    assert inv.e_inverter_out_today is None
 
 
 @pytest.mark.timeout(20)
@@ -193,6 +223,11 @@ async def test_hybrid_gen1_0x11_poll_capture_serves_full_banks_at_0x11():
     # LV battery packs.
     assert 0x32 in plant.register_caches
     assert 0x33 in plant.register_caches
+
+    # IR(44)/IR(45-46) stay PV generation on HYBRID_GEN1 — the #293 override doesn't fire.
+    inv = plant.inverter
+    assert inv.e_pv_generation_today == 15.8  # raw IR(44) == 158; 158 / 10 == 15.8
+    assert inv.e_inverter_out_today is None
 
 
 def test_inverter_address_matches_classification_for_all_fixtures():

--- a/tests/model/test_inverter.py
+++ b/tests/model/test_inverter.py
@@ -2043,20 +2043,25 @@ def test_e_pv_direct_today_formula(pv_today, grid_out_day, battery_charge, ac_ch
 def test_e_pv_direct_today_none_on_ineligible_models():
     """AC-coupled and All-in-One return None — their PV registers are mislabelled (#293).
 
-    Both have e_battery_charge_today resolving (AC/AIO route today→alt1), so a plain
-    None-guard would let them through; the explicit topology gate is what blocks them.
+    Both have e_battery_charge_today resolving (AC/AIO route today→alt1) — that term
+    alone would not block them. What blocks them: manifest.py's IR44 identity routing
+    (#293) already makes e_pv_generation_today None on AC/AIO (the register carries
+    inverter output there, not PV), so the pv term's own None-propagation is what
+    returns None — there is no separate AC/AIO guard in e_pv_direct_today anymore.
     """
     from givenergy_modbus.model.register import HR, IR
 
-    # AC-coupled (0x3001): every input present, but is_ac_coupled gates it out.
+    # AC-coupled (0x3001): every input present, but IR44 identity routing (#293)
+    # makes e_pv_generation_today None here, so the pv term's None-propagation blocks it.
     ac = SinglePhaseInverter.from_register_cache(
         RegisterCache({HR(0): 0x3001, HR(21): 282, IR(44): 100, IR(25): 10, IR(36): 70, IR(35): 40})
     )
     assert ac.is_ac_coupled is True  # type: ignore[attr-defined]
-    assert ac.e_battery_charge_today == 7.0  # resolves (today→alt1) — so the gate, not None-prop, blocks
+    assert ac.e_battery_charge_today == 7.0  # resolves (today→alt1) — unrelated to the None-prop above
     assert ac.e_pv_direct_today is None  # type: ignore[attr-defined]
 
-    # All-in-One (0x8001): PV register is non-PV here (#293) → gated out.
+    # All-in-One (0x8001): PV register is non-PV here (#293) → identity routing makes
+    # e_pv_generation_today None, so None-propagation blocks it, same as AC above.
     aio = SinglePhaseInverter.from_register_cache(
         RegisterCache({HR(0): 0x8001, HR(21): 612, IR(44): 100, IR(25): 10, IR(36): 70, IR(35): 40})
     )
@@ -2083,6 +2088,94 @@ def test_e_pv_direct_today_none_when_battery_charge_unavailable():
         RegisterCache({HR(0): 0x2001, HR(21): 449, IR(44): 100, IR(25): 10, IR(183): 70})
     )
     assert no_ac.e_pv_direct_today is None  # type: ignore[attr-defined]
+
+
+# Dataset-derived constants — AberDino 2×AIO site, 2026-06-29/30 delta analysis (#293).
+# The raw CSV is deliberately NOT committed (it carries the reporter's serial); these
+# daily figures are the durable extract. The same-site Gateway rollup's e_load_today,
+# observed on OTHER days, ran 8.1-18.7 kWh/day — no same-day pair exists yet.
+AIO_DATASET_20260630 = {
+    "e_pv_day_kwh": 12.5,
+    "hv_stack_charge_kwh": 14.4,
+    "hv_stack_discharge_kwh": 9.0,
+    "grid_import_kwh": 39.9,
+    "grid_export_kwh": 13.3,
+}
+GATEWAY_SAME_SITE_DAILY_LOAD_RANGE_KWH = (8.1, 18.7)
+
+
+def test_aio_balance_evidence_gate():
+    """Pin the #293 AIO-repair evidence-gate adjudication: cannot validate, stays None.
+
+    The candidate formula (pv + import - export + discharge - charge) yields 33.7 kWh
+    on the 2026-06-30 data; the only load reference (same-site Gateway rollup,
+    different days) runs 8.1-18.7 kWh/day, so the balance cannot be confirmed within
+    tolerance. If a same-day AIO-counters + Gateway e_load_today pair lands and closes
+    within ~15%, flip the manifest row, enable the deriveds for ALL_IN_ONE, and
+    retire this pin.
+    """
+    d = AIO_DATASET_20260630
+    formula = (
+        d["e_pv_day_kwh"]
+        + d["grid_import_kwh"]
+        - d["grid_export_kwh"]
+        + d["hv_stack_discharge_kwh"]
+        - d["hv_stack_charge_kwh"]
+    )
+    assert formula == pytest.approx(33.7, abs=0.1)
+    lo, hi = GATEWAY_SAME_SITE_DAILY_LOAD_RANGE_KWH
+    assert not (lo * 0.85 <= formula <= hi * 1.15)  # far outside the only reference
+
+
+def _inverter_with_energy_bank(dtc_hex: str, arm_fw: int):
+    """SinglePhaseInverter with identity + the full energy bank primed.
+
+    Register map confirmed against the Defs in inverter.py (LUT around :920-973):
+    IR(25)=e_grid_out_day, IR(26)=e_grid_in_day, IR(35)=e_ac_charge_today,
+    IR(36)=e_battery_charge_today_alt1, IR(37)=e_battery_discharge_today_alt1,
+    IR(44)=e_pv_generation_today (hybrids) / routed to e_inverter_out_today (AC/AIO,
+    #293 identity). All deci-scaled (register value / 10 = kWh).
+    """
+    from givenergy_modbus.model.register import IR
+
+    cache = RegisterCache(
+        {
+            HR(0): int(dtc_hex, 16),
+            HR(21): arm_fw,
+            IR(25): 10,  # e_grid_out_today (0.1 kWh units) -> 1.0
+            IR(26): 30,  # e_grid_in_today -> 3.0
+            IR(35): 20,  # e_ac_charge_today -> 2.0
+            IR(36): 15,  # e_battery_charge_today_alt1 -> 1.5
+            IR(37): 12,  # e_battery_discharge_today_alt1 -> 1.2
+            IR(44): 77,  # e_pv_generation_today (hybrids) / inverter out (AC/AIO) -> 7.7
+        }
+    )
+    return SinglePhaseInverter.from_register_cache(cache)
+
+
+def test_deriveds_none_on_aio_and_ac():
+    """Consumption-family deriveds are None where the PV term has no live identity (#293).
+
+    The corrected-AIO-formula evidence gate FAILED (no same-day independent load
+    reference exists yet) — see manifest.py's module comment for the missing evidence.
+    """
+    for dtc, fw in (("3001", 282), ("8001", 612)):
+        inv = _inverter_with_energy_bank(dtc, fw)
+        assert inv.e_consumption_today is None  # type: ignore[attr-defined]
+        assert inv.e_self_consumption_today is None  # type: ignore[attr-defined]
+        assert inv.e_self_consumption_total is None  # type: ignore[attr-defined]
+        assert inv.e_pv_direct_today is None  # type: ignore[attr-defined]
+
+
+def test_deriveds_unchanged_on_hybrid():
+    """On a hybrid, e_consumption_today still computes from live registers (#293).
+
+    Hand-derivation from the primed bank (all deci-scaled, /10):
+    pv=7.7 (IR44) + grid_in=3.0 (IR26) - grid_out=1.0 (IR25) - ac_charge=2.0 (IR35)
+    = 7.7.
+    """
+    inv = _inverter_with_energy_bank("2001", 449)  # HYBRID_GEN1
+    assert inv.e_consumption_today == pytest.approx(7.7)  # type: ignore[attr-defined]
 
 
 def test_three_phase_has_no_computed_consumption_and_native_ac_charge():

--- a/tests/model/test_inverter.py
+++ b/tests/model/test_inverter.py
@@ -1810,10 +1810,11 @@ def test_e_pv_generation_today_rename_and_deprecated_alias():
     """IR(44) is e_pv_generation_today (#174); e_inverter_out_day is a deprecated alias.
 
     The two classes behave slightly differently:
-    - SinglePhaseInverter: alias returns e_inverter_out_today (#293) — None here, since
-      this cache has no HR(0)/HR(21) and the model is unresolvable, so the identity
-      override never fires (status quo: e_pv_generation_today carries the live value).
-      On AC/AIO the override moves the value across and the alias follows it.
+    - SinglePhaseInverter: alias prefers e_inverter_out_today (#293), falling back to
+      e_pv_generation_today when that's None — this cache has no HR(0)/HR(21) so the
+      model is unresolvable, the identity override never fires, and the alias falls
+      back to the live e_pv_generation_today value (status quo preserved for hybrids).
+      On AC/AIO the override moves the value across and the alias follows it there.
     - ThreePhaseInverter: alias returns e_pv_today (IR1412/3, the verified 3ph register),
       so warning and return value agree. IR44 still leaks as e_pv_generation_today via
       single-phase LUT inheritance, but the alias migration path is unambiguous.
@@ -1832,7 +1833,8 @@ def test_e_pv_generation_today_rename_and_deprecated_alias():
 
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
-        assert sp.e_inverter_out_day is None  # (#293) unresolvable model → no override
+        # (#293) unresolvable model → no override → alias falls back to e_pv_generation_today
+        assert sp.e_inverter_out_day == 8.1  # type: ignore[attr-defined]
     sp_deprecations = [x for x in w if issubclass(x.category, DeprecationWarning)]
     assert len(sp_deprecations) == 1
     assert "e_inverter_out_today" in str(sp_deprecations[0].message)
@@ -1848,6 +1850,17 @@ def test_e_pv_generation_today_rename_and_deprecated_alias():
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         assert sp_ac.e_inverter_out_day == 8.1  # type: ignore[attr-defined]
+    assert len([x for x in w if issubclass(x.category, DeprecationWarning)]) == 1
+
+    # Single-phase, resolved DC hybrid: (#293) not in the override set, so
+    # e_inverter_out_today stays None and the alias falls back to
+    # e_pv_generation_today — the exact backward-compatibility case flagged in review.
+    sp_hybrid_cache = RegisterCache({HR(0): 0x2001, HR(21): 449, IR(44): 81})
+    sp_hybrid = SinglePhaseInverter.from_register_cache(sp_hybrid_cache)
+    assert sp_hybrid.e_inverter_out_today is None  # type: ignore[attr-defined]
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        assert sp_hybrid.e_inverter_out_day == 8.1  # type: ignore[attr-defined]
     assert len([x for x in w if issubclass(x.category, DeprecationWarning)]) == 1
 
     # Three-phase: IR44 leaks as e_pv_generation_today (unverified); the alias

--- a/tests/model/test_inverter.py
+++ b/tests/model/test_inverter.py
@@ -2205,7 +2205,7 @@ def test_battery_energy_facade_routes_by_model():
     """Battery-energy facade routes each metric to the model's declared altN (#76).
 
     Which register a firmware populates is a static property of the model, declared in
-    _BATTERY_ENERGY_SOURCE — not inferred from live values (the #119 / #150-Codex
+    manifest.VALUE_SOURCES — not inferred from live values (the #119 / #150-Codex
     lesson). The declared source is returned verbatim, including a legitimate 0.0; an
     undeclared model or metric returns None, with no value inspection and no
     cross-source fallback. The specific model is resolved via DTC+arm_fw like slot_map,

--- a/tests/model/test_inverter.py
+++ b/tests/model/test_inverter.py
@@ -171,6 +171,8 @@ def test_inverter():
             "p_grid_apparent": None,
             "e_pv_generation_today": None,
             "e_pv_generation_total": None,
+            "e_inverter_out_today": None,
+            "e_inverter_out_total": None,
             "work_time_total_hours": None,
             "system_mode": None,
             "v_battery": None,
@@ -723,6 +725,8 @@ def test_from_registers(register_cache):
         "p_grid_apparent": 680,
         "e_pv_generation_today": 8.1,  # IR(44) — was mislabelled e_inverter_out_day (#174)
         "e_pv_generation_total": 93.0,
+        "e_inverter_out_today": None,  # HYBRID_GEN1 keeps the status quo (#293)
+        "e_inverter_out_total": None,
         "work_time_total_hours": 213,
         "system_mode": 1,
         "v_battery": 49.91,
@@ -1211,6 +1215,8 @@ def test_from_registers_actual_data(register_cache_inverter_daytime_discharging_
         "p_grid_apparent": 554,
         "e_pv_generation_today": 3.8,  # IR(44) — was mislabelled e_inverter_out_day (#174)
         "e_pv_generation_total": 172.5,
+        "e_inverter_out_today": None,  # HYBRID_GEN1 keeps the status quo (#293)
+        "e_inverter_out_total": None,
         "work_time_total_hours": 385,
         "system_mode": 1,
         "v_battery": 51.73,
@@ -1804,7 +1810,10 @@ def test_e_pv_generation_today_rename_and_deprecated_alias():
     """IR(44) is e_pv_generation_today (#174); e_inverter_out_day is a deprecated alias.
 
     The two classes behave slightly differently:
-    - SinglePhaseInverter: alias returns e_pv_generation_today (IR44, verified).
+    - SinglePhaseInverter: alias returns e_inverter_out_today (#293) — None here, since
+      this cache has no HR(0)/HR(21) and the model is unresolvable, so the identity
+      override never fires (status quo: e_pv_generation_today carries the live value).
+      On AC/AIO the override moves the value across and the alias follows it.
     - ThreePhaseInverter: alias returns e_pv_today (IR1412/3, the verified 3ph register),
       so warning and return value agree. IR44 still leaks as e_pv_generation_today via
       single-phase LUT inheritance, but the alias migration path is unambiguous.
@@ -1823,14 +1832,23 @@ def test_e_pv_generation_today_rename_and_deprecated_alias():
 
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
-        assert sp.e_inverter_out_day == 8.1  # type: ignore[attr-defined]  # returns e_pv_generation_today
+        assert sp.e_inverter_out_day is None  # (#293) unresolvable model → no override
     sp_deprecations = [x for x in w if issubclass(x.category, DeprecationWarning)]
     assert len(sp_deprecations) == 1
-    assert "e_pv_generation_today" in str(sp_deprecations[0].message)
+    assert "e_inverter_out_today" in str(sp_deprecations[0].message)
 
     sp_dumped = sp.model_dump()
     assert "e_pv_generation_today" in sp_dumped
     assert "e_inverter_out_day" not in sp_dumped
+
+    # Single-phase, AC model: (#293) the identity override moves IR44 across, and the
+    # deprecated alias follows the live field to its new home.
+    sp_ac_cache = RegisterCache({HR(0): 0x3001, HR(21): 282, IR(44): 81})
+    sp_ac = SinglePhaseInverter.from_register_cache(sp_ac_cache)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        assert sp_ac.e_inverter_out_day == 8.1  # type: ignore[attr-defined]
+    assert len([x for x in w if issubclass(x.category, DeprecationWarning)]) == 1
 
     # Three-phase: IR44 leaks as e_pv_generation_today (unverified); the alias
     # returns e_pv_today (IR1412/3) so the migration path is unambiguous.
@@ -1856,39 +1874,17 @@ def test_e_pv_generation_today_rename_and_deprecated_alias():
     assert "e_inverter_out_day" not in tp_dumped
 
 
-def test_e_pv_generation_total_rename_and_deprecated_alias():
-    """IR(45/46) is e_pv_generation_total (#174); e_inverter_out_total is a deprecated alias.
+def test_e_inverter_out_total_threephase_native_field():
+    """ThreePhaseInverter's own e_inverter_out_total (IR1362/3) is unaffected by #293.
 
-    Unlike the day field, three-phase is NOT symmetric here:
-    - SinglePhaseInverter: IR(45/46) renamed to e_pv_generation_total; e_inverter_out_total
-      becomes a deprecated @property → e_pv_generation_total (not in model_dump()).
-    - ThreePhaseInverter: keeps its OWN native e_inverter_out_total (IR1362/3), a genuine,
-      distinct register from its PV total — so it stays a real field with no deprecation.
-      The single-phase IR(45/46) also leaks in as e_pv_generation_total (unverified on 3ph),
-      consistent with the e_pv_generation_today leak; left for #48.
+    SinglePhaseInverter's e_inverter_out_total is no longer a deprecated alias for
+    e_pv_generation_total — it is now a real field, live on AC/AIO models and covered by
+    the #293 identity-matrix tests in tests/model/test_manifest.py. ThreePhaseInverter
+    never reaches that validator (it has its own, unrelated, LUT-declared field), so its
+    native register stays a real, non-deprecated field distinct from its PV total.
     """
     from givenergy_modbus.model.inverter_threephase import ThreePhaseInverter
     from givenergy_modbus.model.register import IR
-
-    # Single-phase: IR(45/46) is the authoritative PV-generation-total register (uint32, deci).
-    sp_cache = RegisterCache({IR(45): 0, IR(46): 930})
-    sp = SinglePhaseInverter.from_register_cache(sp_cache)
-
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        assert sp.e_pv_generation_total == 93.0  # type: ignore[attr-defined]
-    assert [x for x in w if issubclass(x.category, DeprecationWarning)] == []
-
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        assert sp.e_inverter_out_total == 93.0  # type: ignore[attr-defined]  # returns e_pv_generation_total
-    sp_deprecations = [x for x in w if issubclass(x.category, DeprecationWarning)]
-    assert len(sp_deprecations) == 1
-    assert "e_pv_generation_total" in str(sp_deprecations[0].message)
-
-    sp_dumped = sp.model_dump()
-    assert "e_pv_generation_total" in sp_dumped
-    assert "e_inverter_out_total" not in sp_dumped
 
     # Three-phase: e_inverter_out_total is a genuine native register (IR1362/3) — it stays
     # a real, non-deprecated field. The single-phase IR(45/46) leaks in as

--- a/tests/model/test_manifest.py
+++ b/tests/model/test_manifest.py
@@ -1,0 +1,23 @@
+"""Tests for the declarative capability manifest (Slice A: register semantics, #293)."""
+
+from givenergy_modbus.model.inverter import Model
+from givenergy_modbus.model.manifest import battery_energy_source
+
+
+def test_battery_energy_source_migrated_rows():
+    """The #184 routing rows relocated verbatim from _BATTERY_ENERGY_SOURCE."""
+    assert battery_energy_source(Model.HYBRID_GEN1, "today") == "alt2"
+    assert battery_energy_source(Model.HYBRID_GEN1, "total") == "alt1"
+    assert battery_energy_source(Model.AC, "today") == "alt1"
+    assert battery_energy_source(Model.ALL_IN_ONE, "today") == "alt1"
+
+
+def test_battery_energy_source_absent_is_none():
+    """Absent model or metric routes to None — the honest no-evidence posture."""
+    assert battery_energy_source(Model.AC, "total") is None
+    assert battery_energy_source(Model.GATEWAY, "today") is None
+
+
+def test_battery_energy_source_accepts_fw_param():
+    """The arm_fw column exists in the signature from day one (unused in Slice A)."""
+    assert battery_energy_source(Model.HYBRID_GEN1, "today", arm_fw=449) == "alt2"

--- a/tests/model/test_manifest.py
+++ b/tests/model/test_manifest.py
@@ -1,7 +1,7 @@
 """Tests for the declarative capability manifest (Slice A: register semantics, #293)."""
 
 from givenergy_modbus.model.inverter import Model
-from givenergy_modbus.model.manifest import battery_energy_source
+from givenergy_modbus.model.manifest import battery_energy_source, ir44_is_inverter_output
 
 
 def test_battery_energy_source_migrated_rows():
@@ -21,3 +21,66 @@ def test_battery_energy_source_absent_is_none():
 def test_battery_energy_source_accepts_fw_param():
     """The arm_fw column exists in the signature from day one (unused in Slice A)."""
     assert battery_energy_source(Model.HYBRID_GEN1, "today", arm_fw=449) == "alt2"
+
+
+def test_ir44_identity_overrides():
+    """IR44 = inverter output on exactly the evidence-backed models (#293)."""
+    assert ir44_is_inverter_output(Model.AC) is True
+    assert ir44_is_inverter_output(Model.ALL_IN_ONE) is True
+    assert ir44_is_inverter_output(Model.HYBRID_GEN1) is False
+    assert ir44_is_inverter_output(Model.HYBRID_GEN3) is False
+    assert ir44_is_inverter_output(Model.GATEWAY) is False  # unlisted → status quo
+
+
+def _inverter(dtc_hex: str, arm_fw: int, ir44: int = 77, ir45: int = 1, ir46: int = 17083):
+    """Build a SinglePhaseInverter with identity registers primed."""
+    from givenergy_modbus.model.inverter import SinglePhaseInverter
+    from givenergy_modbus.model.register import HR, IR
+    from givenergy_modbus.model.register_cache import RegisterCache
+
+    cache = RegisterCache({HR(0): int(dtc_hex, 16), HR(21): arm_fw, IR(44): ir44, IR(45): ir45, IR(46): ir46})
+    return SinglePhaseInverter.from_register_cache(cache)
+
+
+def test_identity_matrix_hybrid_keeps_pv_generation():
+    inv = _inverter("2001", 449)  # HYBRID_GEN1
+    assert inv.e_pv_generation_today == 7.7
+    assert inv.e_pv_generation_total == 8261.9  # uint32(1,17083)/10
+    assert inv.e_inverter_out_today is None
+    assert inv.e_inverter_out_total is None
+
+
+def test_identity_matrix_ac_gets_inverter_out():
+    inv = _inverter("3001", 282)  # Model.AC
+    assert inv.e_inverter_out_today == 7.7
+    assert inv.e_inverter_out_total == 8261.9
+    assert inv.e_pv_generation_today is None
+    assert inv.e_pv_generation_total is None
+
+
+def test_identity_matrix_aio_gets_inverter_out():
+    inv = _inverter("8001", 612)  # ALL_IN_ONE
+    assert inv.e_inverter_out_today == 7.7
+    assert inv.e_pv_generation_today is None
+
+
+def test_identity_validator_is_idempotent_on_roundtrip():
+    """model_validate(model_dump()) must not destroy the moved identity values (#293)."""
+    from givenergy_modbus.model.inverter import SinglePhaseInverter
+
+    inv = _inverter("3001", 282)  # Model.AC, live IR44/45/46
+    again = SinglePhaseInverter.model_validate(inv.model_dump())
+    assert again.e_inverter_out_today == inv.e_inverter_out_today
+    assert again.e_inverter_out_total == inv.e_inverter_out_total
+    assert again.e_pv_generation_today is None
+
+
+def test_identity_unresolvable_keeps_status_quo():
+    """No HR(0)/HR(21) → no override → e_pv_generation_* serves as today."""
+    from givenergy_modbus.model.inverter import SinglePhaseInverter
+    from givenergy_modbus.model.register import IR
+    from givenergy_modbus.model.register_cache import RegisterCache
+
+    inv = SinglePhaseInverter.from_register_cache(RegisterCache({IR(44): 77}))
+    assert inv.e_pv_generation_today == 7.7
+    assert inv.e_inverter_out_today is None

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -1304,6 +1304,8 @@ def test_from_actual():
         "p_grid_apparent": 654,
         "e_pv_generation_today": 38.0,  # IR(44) — was mislabelled e_inverter_out_day (#174)
         "e_pv_generation_total": 1698.7,  # IR(45/46) — was mislabelled e_inverter_out_total (#174)
+        "e_inverter_out_today": None,  # HYBRID_GEN1 keeps the status quo (#293)
+        "e_inverter_out_total": None,
         "work_time_total_hours": 2754,
         "system_mode": 1,
         "v_battery": 51.28,


### PR DESCRIPTION
## Summary

First of four planned manifest slices (A semantics → B fact-table consolidation → C polling manifest → D write surface), all landing together as **2.10.0**.

A new declarative `givenergy_modbus/model/manifest.py` module gives register semantics a per-model home:

- **`VALUE_SOURCES`** — the existing private `_BATTERY_ENERGY_SOURCE` battery-energy routing dict, relocated behaviour-identically (the existing #184 tests pass untouched).
- **`FIELD_IDENTITY`** — on `Model.AC` and `Model.ALL_IN_ONE`, IR44/IR45-46 carry the inverter's battery-discharge AC output, not PV — evidenced by delta analysis against AberDino's AIO site and the EMS fixture's AC units. A `mode="before"` validator on `SinglePhaseInverter` routes those decoded values into new `e_inverter_out_today`/`e_inverter_out_total` fields on exactly those two models; `e_pv_generation_today`/`_total` become `None` there. Every other model (including unresolvable ones) keeps today's behaviour — this is overrides-only, not a default flip.
- Deprecated alias `e_inverter_out_day` retargets to the new `e_inverter_out_today`; the old `e_inverter_out_total` alias property is removed in favour of the real field of the same name.
- The four consumption-family derived properties (`e_consumption_today`, `e_self_consumption_today/_total`, `e_pv_direct_today`) now consult the manifest instead of a hardcoded AC/AIO guard, which is deleted.
- A candidate repaired AIO consumption formula was evidence-gated against a two-day AberDino dataset: it fails validation (no same-day independent load reference exists), so the deriveds stay `None` on AIO. The adjudication is pinned as a test with the dataset constants hard-coded (raw CSV isn't committed — it carries the reporter's serial).

## Deliberate behaviour change

`e_pv_generation_today`/`_total` now return `None` on AC/AIO instead of the AC/AIO-mislabelled PV values — the accurate numbers arrive via `e_inverter_out_today`/`_total` instead. Hybrids are unaffected. This needs a call-out in the 2.10.0 release note and the hass boundary note, separate from this PR.

## Test plan

- [x] Identity matrix: hybrid / AC / AIO / unresolvable × both field names
- [x] Golden-fixture pins against real captures (aio_a, an EMS AC unit, hybrid_gen1) — every literal replay-derived and hand-checked against the raw register
- [x] `_BATTERY_ENERGY_SOURCE` → `manifest.VALUE_SOURCES` migration proven behaviour-identical
- [x] Idempotent-validator round-trip regression test (`model_validate(model_dump())` preserves values)
- [x] Evidence-gate adjudication pinned with dataset-derived constants
- [x] Full suite (1507 tests), ruff, and tox all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer inverter energy field reporting for AC and all-in-one devices, with inverter output values now shown separately from PV generation where appropriate.
  * Improved how battery and energy register mappings are resolved across supported device types.

* **Bug Fixes**
  * Corrected several device-specific energy field labels and fallbacks so readouts now better match the inverter’s actual role.
  * Fixed deprecated field behaviour and updated related warnings to point to the right replacement values.

* **Tests**
  * Updated regression coverage for inverter, plant, and manifest behaviour across hybrid, AC, and all-in-one devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->