### PR TITLE
Manifest Slice B: fact-table consolidation (#293)

### DIFF
--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -1079,7 +1079,13 @@ class Client:
             ", ".join(f"0x{a:02x}" for a in final_caps.hv_bmu_addresses),
         )
 
-        if prior is not None and prior != final_caps:
+        # arm_firmware_version is informational, not part of the topology contract — a
+        # firmware upgrade on otherwise-unchanged hardware must not raise a mismatch
+        # here (#293 Slice B added the field; excluding it from this comparison keeps
+        # PlantTopologyMismatch scoped to genuine address/device-type/count changes).
+        if prior is not None and prior.model_dump(exclude={"arm_firmware_version"}) != final_caps.model_dump(
+            exclude={"arm_firmware_version"}
+        ):
             self.plant.capabilities = None
             raise PlantTopologyMismatch(
                 f"detect: plant topology does not match prior — prior={prior!r}, actual={final_caps!r}",

--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -1001,7 +1001,7 @@ class Client:
                 "detect: HR(0) not populated after reading device 0x11 — cannot determine device type"
             )
         arm_fw = cache.get(HR(21)) or 0
-        caps = PlantCapabilities(device_type=resolve_model(raw_dtc, arm_fw))
+        caps = PlantCapabilities(device_type=resolve_model(raw_dtc, arm_fw), arm_firmware_version=arm_fw or None)
         _logger.info("detect: device_type=Model.%s", caps.device_type.name)
 
         if prior is not None and prior.device_type != caps.device_type:

--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -1001,6 +1001,10 @@ class Client:
                 "detect: HR(0) not populated after reading device 0x11 — cannot determine device type"
             )
         arm_fw = cache.get(HR(21)) or 0
+        # arm_firmware_version here is consistency-only: this intermediate `caps` only
+        # feeds the probing steps below (is_hv, device_type), none of which read
+        # firmware. The object detect() actually returns is built separately in
+        # _derive_capabilities() (#293 Slice B), which populates the field for real.
         caps = PlantCapabilities(device_type=resolve_model(raw_dtc, arm_fw), arm_firmware_version=arm_fw or None)
         _logger.info("detect: device_type=Model.%s", caps.device_type.name)
 

--- a/givenergy_modbus/model/inverter.py
+++ b/givenergy_modbus/model/inverter.py
@@ -88,13 +88,6 @@ _DTC_PREFIX_TO_MODEL: dict[str, Model] = {
     "83": Model.HYBRID_GEN4,
 }
 
-# AC-coupled inverters: no integrated DC battery, so they expose dedicated AC
-# charge/discharge limit registers (HR313/314) that DC-coupled models don't.
-# Both are coarse families with no specific sub-variants, so the set is complete
-# (an AC DTC like 0x3001 resolves to Model.AC via Model._missing_). Consumers gate
-# AC-only controls on this rather than re-deriving the model set themselves.
-AC_COUPLED_MODELS: frozenset[Model] = frozenset({Model.AC, Model.AC_3PH})
-
 # Rated AC output power in watts, keyed by 4-char hex device type code.
 # Original entries from britkat1980/giv_tcp:dev3. Entries marked "(app v4.0.7)" were added from
 # the GivEnergy app's authoritative HR(0) model-code table (#320): all 36 codes that overlapped the
@@ -1168,14 +1161,14 @@ class SinglePhaseInverter(  # type: ignore[valid-type,misc]
     @property
     def slot_map(self) -> SlotMap:
         """Register address pairs for the charge/discharge time slots on this model."""
+        from givenergy_modbus.model.manifest import has_extended_slots
+
         dtc = self.device_type_code  # type: ignore[attr-defined]
         arm_fw = self.arm_firmware_version  # type: ignore[attr-defined]
         if dtc is None or arm_fw is None:
             return SINGLE_PHASE_SLOTS
         model = resolve_model(int(dtc, 16), int(arm_fw))
-        if model in (Model.ALL_IN_ONE, Model.HYBRID_GEN4, Model.HYBRID_HV_GEN3):
-            return EXTENDED_SLOTS
-        if model is Model.HYBRID_GEN3 and int(arm_fw) > 302:
+        if has_extended_slots(model, int(arm_fw)):
             return EXTENDED_SLOTS
         return SINGLE_PHASE_SLOTS
 
@@ -1208,7 +1201,9 @@ class SinglePhaseInverter(  # type: ignore[valid-type,misc]
         Model.AC_3PH and neither has specific sub-variants. False when the model is
         unknown (DTC unread).
         """
-        return self.model in AC_COUPLED_MODELS  # type: ignore[attr-defined]
+        from givenergy_modbus.model.manifest import has_capability
+
+        return has_capability("is_ac_coupled", self.model)  # type: ignore[attr-defined]
 
     @computed_field  # type: ignore[prop-decorator]
     @property
@@ -1617,6 +1612,11 @@ class SinglePhaseInverter(  # type: ignore[valid-type,misc]
 
 
 def __getattr__(name: str):
+    """PEP 562 module attribute deprecation shim.
+
+    AC_COUPLED_MODELS moved to manifest.CAPABILITIES["is_ac_coupled"] (#293 Slice B);
+    kept accessible here for backward compatibility until the 3.0 deprecation horizon.
+    """
     if name == "Inverter":
         warnings.warn(
             "Inverter has been renamed to SinglePhaseInverter and the alias will be removed in a future release. "
@@ -1625,4 +1625,14 @@ def __getattr__(name: str):
             stacklevel=2,
         )
         return SinglePhaseInverter
+    if name == "AC_COUPLED_MODELS":
+        warnings.warn(
+            "givenergy_modbus.model.inverter.AC_COUPLED_MODELS is deprecated; "
+            "use givenergy_modbus.model.manifest.has_capability('is_ac_coupled', model)",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        from givenergy_modbus.model.manifest import CAPABILITIES
+
+        return CAPABILITIES["is_ac_coupled"]
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/givenergy_modbus/model/inverter.py
+++ b/givenergy_modbus/model/inverter.py
@@ -1614,8 +1614,12 @@ class SinglePhaseInverter(  # type: ignore[valid-type,misc]
 def __getattr__(name: str):
     """PEP 562 module attribute deprecation shim.
 
-    AC_COUPLED_MODELS moved to manifest.CAPABILITIES["is_ac_coupled"] (#293 Slice B);
-    kept accessible here for backward compatibility until the 3.0 deprecation horizon.
+    Serves two deprecated names — the pre-existing `Inverter` rename alias, and
+    AC_COUPLED_MODELS (moved to manifest.CAPABILITIES["is_ac_coupled"], #293 Slice B).
+    Both are kept accessible here for backward compatibility until the 3.0
+    deprecation horizon. Deliberately a single `__getattr__`: Python only honours the
+    last one defined at module scope, so a second definition would silently shadow
+    this one rather than raising or merging.
     """
     if name == "Inverter":
         warnings.warn(

--- a/givenergy_modbus/model/inverter_threephase.py
+++ b/givenergy_modbus/model/inverter_threephase.py
@@ -9,7 +9,6 @@ from givenergy_modbus.client.commands import _InverterCommands, _ThreePhaseComma
 from givenergy_modbus.model.battery import BatteryMaintenance
 from givenergy_modbus.model.inverter import (
     _DTC_RATED_POWER,
-    AC_COUPLED_MODELS,
     BatteryType,
     Model,
     PowerFactorFunctionModel,
@@ -612,7 +611,9 @@ class ThreePhaseInverter(  # type: ignore[valid-type,misc]
         Mirrors the field on SinglePhaseInverter (not inherited — the two inverter
         classes are parallel, like battery_max_power / inverter_max_power above).
         """
-        return self.model in AC_COUPLED_MODELS  # type: ignore[attr-defined]
+        from givenergy_modbus.model.manifest import has_capability
+
+        return has_capability("is_ac_coupled", self.model)  # type: ignore[attr-defined]
 
     @computed_field  # type: ignore[prop-decorator]
     @property
@@ -950,24 +951,6 @@ class ThreePhaseInverter(  # type: ignore[valid-type,misc]
         return self.time_grid_high_freq_limit_reconnect  # type: ignore[attr-defined,no-any-return]
 
 
-# Models that decode via the three-phase / 1000-range register layout. The residential
-# ALL_IN_ONE (DTC family "8", e.g. 0x8001) is deliberately absent: it is HV but single-
-# phase, and decoding it as ThreePhaseInverter shadows ~30 live fields (battery_soc, v_ac1,
-# f_ac1, firmware, charge slots, status…) to IR/HR(1000+) addresses it doesn't expose,
-# zeroing them. It carries its data in the single-phase IR(0)/IR(180) banks and so decodes
-# correctly as SinglePhaseInverter. Verified against real AIO register dumps (#105). HV
-# battery voltage, extended slots and is_hv stay model-keyed at the capabilities layer.
-THREE_PHASE_MODELS: frozenset[Model] = frozenset(
-    {
-        Model.HYBRID_3PH,
-        Model.AC_3PH,
-        Model.AIO_COMMERCIAL,
-        Model.HYBRID_HV_GEN3,
-        Model.ALL_IN_ONE_HYBRID,
-    }
-)
-
-
 def _removed_per_phase_power_property(old: str, new: str) -> property:
     """Build a hard-failing property for a per-phase active-power field renamed in #185."""
 
@@ -992,8 +975,30 @@ def select_inverter(model: Model, register_cache) -> "SinglePhaseInverter | Thre
 
     Genuinely three-phase and HV-hybrid units use the 1000-range register address layout;
     everything else — including the residential single-phase ALL_IN_ONE — uses the
-    single-phase layout (see THREE_PHASE_MODELS for why the AIO is excluded).
+    single-phase layout (see manifest.CAPABILITIES["is_three_phase"] for why the AIO is
+    excluded).
     """
-    if model in THREE_PHASE_MODELS:
+    from givenergy_modbus.model.manifest import has_capability
+
+    if has_capability("is_three_phase", model):
         return ThreePhaseInverter.from_register_cache(register_cache)
     return SinglePhaseInverter.from_register_cache(register_cache)
+
+
+def __getattr__(name: str) -> object:
+    """PEP 562 module attribute deprecation shim (#293 Slice B).
+
+    THREE_PHASE_MODELS moved to manifest.CAPABILITIES["is_three_phase"]; kept
+    accessible here for backward compatibility until the 3.0 deprecation horizon.
+    """
+    if name == "THREE_PHASE_MODELS":
+        warnings.warn(
+            "givenergy_modbus.model.inverter_threephase.THREE_PHASE_MODELS is deprecated; "
+            "use givenergy_modbus.model.manifest.has_capability('is_three_phase', model)",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        from givenergy_modbus.model.manifest import CAPABILITIES
+
+        return CAPABILITIES["is_three_phase"]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/givenergy_modbus/model/manifest.py
+++ b/givenergy_modbus/model/manifest.py
@@ -2,8 +2,8 @@
 
 One place answering "what does this register/field mean on this model". Grown in
 slices: A (this file's initial content) covers register SEMANTICS — value-source
-routing and per-model field identity. Slices B-D will add the capability fact
-tables, the polling ranges, and the write surface.
+routing and per-model field identity. Slice B added the capability fact tables
+(`CAPABILITIES`, `has_extended_slots`); slices C-D will add the polling ranges and the write surface.
 
 Keys are the RESOLVED specific ``Model`` (from ``resolve_model``), never the coarse
 family. Every accessor takes ``arm_fw`` so a firmware column exists in the contract
@@ -94,3 +94,89 @@ def ir44_is_inverter_output(model: Model, arm_fw: int | None = None) -> bool:
 # bank to cross-check against. Whether that distinction matters (and whether a
 # gateway-fronted plant even needs the repair, since GatewayV1 already exposes
 # e_load_today natively) is a maintainer call, not resolved here.
+
+# Per-model capability facts, one frozenset per named fact. Relocated from six
+# independently-defined module constants (#293 Slice B): plant.py's _HV_MODELS,
+# _THREE_PHASE_MODELS, _AC_CONFIG_BLOCK_MODELS, _SMART_LOAD_CAPABLE_MODELS,
+# _HV_CABINET_MODELS, _PEAK_SHAVING_MODELS, and inverter.py's AC_COUPLED_MODELS.
+# _THREE_PHASE_MODELS was independently duplicated in inverter_threephase.py under
+# the public name THREE_PHASE_MODELS — same membership, two copies, nothing stopped
+# them drifting apart. Both public names (AC_COUPLED_MODELS, THREE_PHASE_MODELS) are
+# kept as deprecated __getattr__ shims in their original modules.
+CAPABILITIES: dict[str, frozenset[Model]] = {
+    # Models whose battery architecture is HV (BCU/BMU stacks rather than LV packs).
+    "is_hv": frozenset(
+        {
+            Model.HYBRID_3PH,
+            Model.AC_3PH,
+            Model.ALL_IN_ONE,
+            Model.HYBRID_HV_GEN3,
+            Model.ALL_IN_ONE_HYBRID,
+        }
+    ),
+    # Models with registers in the 1000-range (HR 1000-1124, IR 1000-1413), i.e.
+    # genuinely three-phase units that expose the per-phase bank. The residential
+    # ALL_IN_ONE (DTC family "8") is HV but SINGLE-phase — it error-responds to
+    # 1000-range reads and decodes via the single-phase IR(0)/IR(180) banks instead.
+    # Verified against real AIO hardware and the GE spec sheet (3.6 kW/16 A). See #105.
+    "is_three_phase": frozenset(
+        {
+            Model.HYBRID_3PH,
+            Model.AC_3PH,
+            Model.AIO_COMMERCIAL,
+            Model.ALL_IN_ONE_HYBRID,
+            Model.HYBRID_HV_GEN3,
+        }
+    ),
+    # AC-coupled inverters — no integrated DC battery.
+    "is_ac_coupled": frozenset({Model.AC, Model.AC_3PH}),
+    # Models that expose the HR(300-359) AC-output config block: export_priority
+    # (HR311), battery_*_limit_ac (HR313/314), enable_eps (HR317), pause mode/slot
+    # (HR318-320). Present on AC-coupled inverters AND the All-in-One. DC-coupled/
+    # hybrid inverters lack the block and time out when polled for it (#162).
+    "has_ac_config_block": frozenset({Model.AC, Model.AC_3PH, Model.ALL_IN_ONE}),
+    # Models with a *readable* Smart Load slot block at HR(540-599). Deliberately
+    # empty — no model has been confirmed to return data on real hardware; HYBRID_GEN1
+    # is confirmed to time out on the read (#179). Gate off until a capture confirms.
+    "has_smart_load_block": frozenset(),
+    # Models with a readable HV cabinet topology block at HR(499-510). Deliberately
+    # empty — no model confirmed on real hardware yet (#265).
+    "has_hv_cabinet_block": frozenset(),
+    # Models with a readable peak-shaving block at HR(20000-20051). Deliberately
+    # empty — no model confirmed on real hardware yet.
+    "has_peak_shaving_block": frozenset(),
+}
+
+
+def has_capability(name: str, model: Model, arm_fw: int | None = None) -> bool:
+    """Return True if `model` has the named capability fact.
+
+    `name` must be a key in `CAPABILITIES` — an unknown name raises `KeyError` rather
+    than silently returning False, since every call site is our own static-string
+    code and a typo should fail loudly. `arm_fw` is accepted for signature consistency
+    with every other manifest accessor; none of these facts are firmware-conditional.
+    """
+    return model in CAPABILITIES[name]
+
+
+# Models using the extended 10-slot map (HR 240-299 for slots 3-10). Relocated from
+# plant.py's _EXTENDED_SLOT_MODELS (#293 Slice B) — that copy listed HYBRID_GEN3
+# unconditionally, which disagreed with the register-layout decision actually made by
+# SinglePhaseInverter.slot_map (inverter.py), which only treats HYBRID_GEN3 as
+# extended above firmware 302. slot_map.py's own EXTENDED_SLOTS comment already
+# stated the correct rule; this fixes plant.py's copy to match it. ALL_IN_ONE_HYBRID
+# is three-phase-decoded and always uses THREE_PHASE_SLOTS (never the literal
+# EXTENDED_SLOTS object) — but THREE_PHASE_SLOTS genuinely has 10 slot pairs too, so
+# it belongs in this CAPABILITY set regardless of which SlotMap object serves it.
+_EXTENDED_SLOT_MODELS: frozenset[Model] = frozenset(
+    {Model.HYBRID_GEN4, Model.ALL_IN_ONE, Model.ALL_IN_ONE_HYBRID, Model.HYBRID_HV_GEN3}
+)
+_EXTENDED_SLOT_FIRMWARE_GATE: dict[Model, int] = {Model.HYBRID_GEN3: 302}
+
+
+def has_extended_slots(model: Model, arm_fw: int | None = None) -> bool:
+    """True if `model` (at this firmware) uses the extended 10-slot map (HR 240-299)."""
+    if model in _EXTENDED_SLOT_MODELS:
+        return True
+    threshold = _EXTENDED_SLOT_FIRMWARE_GATE.get(model)
+    return threshold is not None and arm_fw is not None and arm_fw > threshold

--- a/givenergy_modbus/model/manifest.py
+++ b/givenergy_modbus/model/manifest.py
@@ -148,9 +148,12 @@ CAPABILITIES: dict[str, frozenset[Model]] = {
 }
 
 
-def has_capability(name: str, model: Model, arm_fw: int | None = None) -> bool:
+def has_capability(name: str, model: Model | None, arm_fw: int | None = None) -> bool:
     """Return True if `model` has the named capability fact.
 
+    `model` accepts `None` because callers pass `self.model`, which is `None` when
+    the device type code hasn't been read yet — `None in CAPABILITIES[name]` is a
+    safe, honest `False` rather than forcing every call site to guard first.
     `name` must be a key in `CAPABILITIES` — an unknown name raises `KeyError` rather
     than silently returning False, since every call site is our own static-string
     code and a typo should fail loudly. `arm_fw` is accepted for signature consistency

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -164,6 +164,7 @@ class PlantCapabilities(BaseModel):
         aio_battery_module_addresses: list[int] | None = None,
         lv_bcu_address: int | None = None,
         hv_bmu_addresses: list[int] | None = None,
+        arm_firmware_version: int | None = None,
         **kwargs: Any,
     ) -> None:
         # Custom __init__ for two reasons:
@@ -190,6 +191,8 @@ class PlantCapabilities(BaseModel):
             kwargs["lv_bcu_address"] = lv_bcu_address
         if hv_bmu_addresses is not None:
             kwargs["hv_bmu_addresses"] = hv_bmu_addresses
+        if arm_firmware_version is not None:
+            kwargs["arm_firmware_version"] = arm_firmware_version
         _map_legacy_aliases(kwargs, stacklevel=3)
         super().__init__(**kwargs)
 

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -7,7 +7,7 @@ from typing import Any, ClassVar, cast
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, model_validator
 
 from givenergy_modbus.exceptions import CommunicationError
-from givenergy_modbus.model import GivEnergyBaseModel
+from givenergy_modbus.model import GivEnergyBaseModel, manifest
 from givenergy_modbus.model.aio_battery import AioBatteryModule
 from givenergy_modbus.model.battery import Battery, BatteryRegisterGetter
 from givenergy_modbus.model.battery_splice import (
@@ -30,7 +30,6 @@ from givenergy_modbus.model.ems import Ems
 from givenergy_modbus.model.gateway import GatewayV1, GatewayV2, select_gateway
 from givenergy_modbus.model.hv_bcu import Bcu, BcuRegisterGetter, Bmu, BmuRegisterGetter, HvStack
 from givenergy_modbus.model.inverter import (
-    AC_COUPLED_MODELS,
     Model,
     SinglePhaseInverter,
     SinglePhaseInverterRegisterGetter,
@@ -53,36 +52,6 @@ from givenergy_modbus.pdu import (
 
 _logger = logging.getLogger(__name__)
 
-# Models whose battery architecture is HV (BCU/BMU stacks rather than LV packs).
-# Coarse families "4" (HYBRID_3PH), "6" (AC_3PH) and "8" (ALL_IN_ONE and variants)
-# are all HV; specific sub-variants are included explicitly.
-_HV_MODELS: frozenset[Model] = frozenset(
-    {
-        Model.HYBRID_3PH,
-        Model.AC_3PH,
-        Model.ALL_IN_ONE,
-        Model.HYBRID_HV_GEN3,
-        Model.ALL_IN_ONE_HYBRID,
-    }
-)
-
-# Models with registers in the 1000-range (HR 1000–1124, IR 1000–1413), i.e. genuinely
-# three-phase units that expose the per-phase bank. NB: the residential ALL_IN_ONE (DTC
-# family "8", e.g. 0x8001) is HV but SINGLE-phase — it has no 1000-range bank (it error-
-# responds to those reads) and its data lives in the single-phase IR(0)/IR(180) banks. It
-# is intentionally excluded here (and from the decode-layout set in inverter_threephase.py)
-# while remaining in _HV_MODELS / _EXTENDED_SLOT_MODELS. Confirmed against real AIO hardware
-# (HR(0)=0x8001, owner-confirmed 1-phase) and the GE spec sheet (3.6 kW/16 A). See #105.
-_THREE_PHASE_MODELS: frozenset[Model] = frozenset(
-    {
-        Model.HYBRID_3PH,
-        Model.AC_3PH,
-        Model.AIO_COMMERCIAL,
-        Model.ALL_IN_ONE_HYBRID,
-        Model.HYBRID_HV_GEN3,
-    }
-)
-
 # Models that use the extended 10-slot map (HR 240–299 for slots 3–10).
 _EXTENDED_SLOT_MODELS: frozenset[Model] = frozenset(
     {
@@ -93,45 +62,6 @@ _EXTENDED_SLOT_MODELS: frozenset[Model] = frozenset(
         Model.HYBRID_HV_GEN3,
     }
 )
-
-# Models that expose the HR(300–359) AC-output config block: export_priority (HR311),
-# battery_*_limit_ac (HR313/314), enable_eps (HR317), pause mode/slot (HR318–320).
-# Present on AC-coupled inverters AND the All-in-One (which has an AC output stage with
-# the same export/EPS/AC-limit controls). DC-coupled/hybrid inverters lack the block and
-# time out when polled for it (#162). Evidence: Model.AC fixtures answer HR(300,60); the
-# AIO fixture answers HR(300,21) and a live AIO populates export_priority/enable_eps/
-# battery_*_limit_ac (#105). NB this is deliberately a separate set from AC_COUPLED_MODELS
-# (the is_ac_coupled predicate, which hass uses to scope AC controls) — whether the AIO is
-# "AC-coupled" for that purpose is a separate consumer decision; here we only care which
-# models carry this register block.
-_AC_CONFIG_BLOCK_MODELS: frozenset[Model] = frozenset(
-    {
-        Model.AC,
-        Model.AC_3PH,
-        Model.ALL_IN_ONE,
-    }
-)
-
-# Models with a *readable* Smart Load slot block at HR(540-599). Deliberately empty:
-# the block was added speculatively from the GivEnergy app's Direct Control catalogue
-# (which only proves the writable surface, not that a live read answers), and no model
-# has yet been confirmed to return data on real hardware. HYBRID_GEN1 is confirmed to
-# *time out* on the read (#179, two independent reports). device_type here is the
-# firmware-resolved variant (resolve_model), so members may be gen-specific once any
-# model is confirmed. Until then the bulk read is gated off everywhere; the
-# smart_load_slot_* decode Defs and set_smart_load_slot_* write helpers are unaffected.
-_SMART_LOAD_CAPABLE_MODELS: frozenset[Model] = frozenset()
-
-# Models with a readable HV cabinet topology block at HR(499-510). Deliberately empty:
-# no model has been confirmed to return data on real hardware. Gate off until a capture
-# confirms the block responds; the hv_* decode Defs are unaffected.
-_HV_CABINET_MODELS: frozenset[Model] = frozenset()
-
-# Models with a readable peak-shaving block at HR(20000-20051). Deliberately empty:
-# no model has been confirmed to return data on real hardware. Gate off until a capture
-# confirms the block responds; the peak_shaving_* decode Defs are unaffected.
-_PEAK_SHAVING_MODELS: frozenset[Model] = frozenset()
-
 
 _CAPABILITIES_LEGACY_ALIASES = {
     "inverter_slave": "inverter_address",
@@ -367,7 +297,7 @@ class PlantCapabilities(BaseModel):
     @property
     def is_hv(self) -> bool:
         """Return True if this system uses HV battery stacks (BCU/BMU) rather than LV packs."""
-        return self.device_type in _HV_MODELS
+        return manifest.has_capability("is_hv", self.device_type)
 
     SCHEMA_VERSION: ClassVar[int] = 1
 
@@ -476,12 +406,12 @@ class PlantCapabilities(BaseModel):
     @property
     def is_three_phase(self) -> bool:
         """Return True if this system uses three-phase registers (HR/IR 1000-range)."""
-        return self.device_type in _THREE_PHASE_MODELS
+        return manifest.has_capability("is_three_phase", self.device_type)
 
     @property
     def is_ac_coupled(self) -> bool:
         """Return True if this system is AC-coupled (no integrated DC battery)."""
-        return self.device_type in AC_COUPLED_MODELS
+        return manifest.has_capability("is_ac_coupled", self.device_type)
 
     @property
     def has_extended_slots(self) -> bool:
@@ -490,41 +420,41 @@ class PlantCapabilities(BaseModel):
 
     @property
     def has_ac_config_block(self) -> bool:
-        """Return True if this system exposes the HR(300–359) AC-output config block.
+        """Return True if this system exposes the HR(300-359) AC-output config block.
 
         Covers export priority, EPS enable, AC charge/discharge limits and pause mode —
         present on AC-coupled inverters and the All-in-One, absent (times out) on
-        DC-coupled/hybrid models. See `_AC_CONFIG_BLOCK_MODELS` (#162).
+        DC-coupled/hybrid models. See `manifest.CAPABILITIES["has_ac_config_block"]` (#162).
         """
-        return self.device_type in _AC_CONFIG_BLOCK_MODELS
+        return manifest.has_capability("has_ac_config_block", self.device_type)
 
     @property
     def has_smart_load_block(self) -> bool:
-        """Return True if this system exposes a readable HR(540–599) Smart Load block.
+        """Return True if this system exposes a readable HR(540-599) Smart Load block.
 
         Currently False for every model: no inverter has been confirmed to answer the
         read on real hardware, and HYBRID_GEN1 is confirmed to time out on it. See
-        `_SMART_LOAD_CAPABLE_MODELS` (#179).
+        `manifest.CAPABILITIES["has_smart_load_block"]` (#179).
         """
-        return self.device_type in _SMART_LOAD_CAPABLE_MODELS
+        return manifest.has_capability("has_smart_load_block", self.device_type)
 
     @property
     def has_hv_cabinet_block(self) -> bool:
-        """Return True if this system exposes a readable HR(499–510) HV cabinet topology block.
+        """Return True if this system exposes a readable HR(499-510) HV cabinet topology block.
 
         Currently False for every model: no inverter has been confirmed to answer the read on
-        real hardware. See `_HV_CABINET_MODELS` (#265).
+        real hardware. See `manifest.CAPABILITIES["has_hv_cabinet_block"]` (#265).
         """
-        return self.device_type in _HV_CABINET_MODELS
+        return manifest.has_capability("has_hv_cabinet_block", self.device_type)
 
     @property
     def has_peak_shaving_block(self) -> bool:
-        """Return True if this system exposes a readable HR(20000–20051) peak-shaving block.
+        """Return True if this system exposes a readable HR(20000-20051) peak-shaving block.
 
         Currently False for every model: no inverter has been confirmed to answer the read on
-        real hardware. See `_PEAK_SHAVING_MODELS`.
+        real hardware. See `manifest.CAPABILITIES["has_peak_shaving_block"]`.
         """
-        return self.device_type in _PEAK_SHAVING_MODELS
+        return manifest.has_capability("has_peak_shaving_block", self.device_type)
 
     @property
     def is_ems(self) -> bool:

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -398,7 +398,8 @@ class PlantCapabilities(BaseModel):
             f"bcu_stacks=[{bcus}], "
             f"aio_battery_module_addresses=[{aio_mods}], "
             f"hv_bmu_addresses=[{hv_bmus}], "
-            f"lv_bcu_address={lv_bcu})"
+            f"lv_bcu_address={lv_bcu}, "
+            f"arm_firmware_version={self.arm_firmware_version})"
         )
 
     @property

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -52,17 +52,6 @@ from givenergy_modbus.pdu import (
 
 _logger = logging.getLogger(__name__)
 
-# Models that use the extended 10-slot map (HR 240–299 for slots 3–10).
-_EXTENDED_SLOT_MODELS: frozenset[Model] = frozenset(
-    {
-        Model.HYBRID_GEN3,
-        Model.HYBRID_GEN4,
-        Model.ALL_IN_ONE,
-        Model.ALL_IN_ONE_HYBRID,
-        Model.HYBRID_HV_GEN3,
-    }
-)
-
 _CAPABILITIES_LEGACY_ALIASES = {
     "inverter_slave": "inverter_address",
     "meter_slaves": "meter_addresses",
@@ -160,6 +149,10 @@ class PlantCapabilities(BaseModel):
     # LV BCU page address (observed only at 0x31 — see model/lv_bcu.py). None when the
     # block read all-zero at detect time (firmware-gated, #241).
     lv_bcu_address: int | None = None
+    # ARM firmware version, read from HR(21) at detect() time. None if not yet known
+    # (e.g. a pre-Slice-B persisted payload). Enables firmware-gated capability facts
+    # such as has_extended_slots (#293 Slice B).
+    arm_firmware_version: int | None = None
 
     def __init__(
         self,
@@ -318,6 +311,7 @@ class PlantCapabilities(BaseModel):
             "aio_battery_module_addresses": [f"0x{a:02x}" for a in self.aio_battery_module_addresses],
             "hv_bmu_addresses": [f"0x{a:02x}" for a in self.hv_bmu_addresses],
             "lv_bcu_address": f"0x{self.lv_bcu_address:02x}" if self.lv_bcu_address is not None else None,
+            "arm_firmware_version": self.arm_firmware_version,
         }
 
     @classmethod
@@ -382,6 +376,7 @@ class PlantCapabilities(BaseModel):
             lv_bcu_address=(
                 _addr(normalised["lv_bcu_address"]) if normalised.get("lv_bcu_address") is not None else None
             ),
+            arm_firmware_version=normalised.get("arm_firmware_version"),
         )
 
     def __repr__(self) -> str:
@@ -416,7 +411,7 @@ class PlantCapabilities(BaseModel):
     @property
     def has_extended_slots(self) -> bool:
         """Return True if this system supports the extended 10-slot map (HR 240–299)."""
-        return self.device_type in _EXTENDED_SLOT_MODELS
+        return manifest.has_extended_slots(self.device_type, self.arm_firmware_version)
 
     @property
     def has_ac_config_block(self) -> bool:
@@ -594,7 +589,8 @@ def _derive_capabilities(
     raw_dtc = cache.get(HR(0))
     if raw_dtc is None:
         raise CommunicationError("from_caches: HR(0) not present at device 0x11 — cannot determine device type")
-    caps = PlantCapabilities(device_type=resolve_model(raw_dtc, cache.get(HR(21)) or 0))
+    arm_fw = cache.get(HR(21)) or 0
+    caps = PlantCapabilities(device_type=resolve_model(raw_dtc, arm_fw), arm_firmware_version=arm_fw or None)
 
     # HV topology (BCU stacks + AIO/HV-BMU per-module addresses). The is_valid() gates below and in
     # _derive_hv_topology wrap in try/except only when on_reject is not None (live detect path, where

--- a/tests/client/test_detect.py
+++ b/tests/client/test_detect.py
@@ -304,6 +304,33 @@ async def test_detect_resolves_model_from_hr0_hr21():
     assert client.plant.capabilities is caps
 
 
+@pytest.mark.asyncio
+async def test_detect_populates_arm_firmware_version():
+    client = _make_client()
+    _prime_cache(client, 0x11, {HR(0): 0x2001, HR(21): 300})
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock) as mock_req:
+        mock_req.return_value = object()
+        with patch.object(client, "_probe", new=AsyncMock(return_value=False)):
+            caps = await client.detect()
+
+    assert caps.arm_firmware_version == 300
+
+
+@pytest.mark.asyncio
+async def test_detect_arm_firmware_version_none_when_hr21_zero():
+    """arm_fw=0 is the 'HR(21) absent/unpopulated' sentinel — stored as None, not 0."""
+    client = _make_client()
+    _prime_cache(client, 0x11, {HR(0): 0x2001, HR(21): 0})
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock) as mock_req:
+        mock_req.return_value = object()
+        with patch.object(client, "_probe", new=AsyncMock(return_value=False)):
+            caps = await client.detect()
+
+    assert caps.arm_firmware_version is None
+
+
 def _prime_battery_serial(client: Client, device_address: int) -> None:
     """Prime a device cache with a valid battery serial number (IR 110–114)."""
     # "SA1234A567" encoded as five big-endian 16-bit register values.

--- a/tests/client/test_detect.py
+++ b/tests/client/test_detect.py
@@ -331,6 +331,28 @@ async def test_detect_arm_firmware_version_none_when_hr21_zero():
     assert caps.arm_firmware_version is None
 
 
+@pytest.mark.asyncio
+async def test_detect_firmware_only_change_does_not_raise_topology_mismatch():
+    """A firmware upgrade on unchanged hardware must not raise PlantTopologyMismatch.
+
+    arm_firmware_version is informational, not part of the topology contract — the
+    equality check in Client.detect() must exclude it (#293 Slice B).
+    """
+    client = _make_client()
+    # DTC 0x2001 + arm_fw=300 → century 3 → Model.HYBRID_GEN3 (see test_detect_resolves_model_from_hr0_hr21).
+    _prime_cache(client, 0x11, {HR(0): 0x2001, HR(21): 300})
+
+    prior = PlantCapabilities(device_type=Model.HYBRID_GEN3, arm_firmware_version=100)
+
+    with patch.object(client, "send_request_and_await_response", new_callable=AsyncMock) as mock_req:
+        mock_req.return_value = object()
+        with patch.object(client, "_probe", new=AsyncMock(return_value=False)):
+            caps = await client.detect(prior=prior)
+
+    assert caps.arm_firmware_version == 300
+    assert client.plant.capabilities is caps
+
+
 def _prime_battery_serial(client: Client, device_address: int) -> None:
     """Prime a device cache with a valid battery serial number (IR 110–114)."""
     # "SA1234A567" encoded as five big-endian 16-bit register values.

--- a/tests/client/test_load_refresh.py
+++ b/tests/client/test_load_refresh.py
@@ -164,8 +164,12 @@ async def test_load_config_three_phase():
 
 
 async def test_load_config_extended_slots():
-    """Extended-slot DC-coupled model adds HR 240–299 but not HR(300-359)."""
-    client = _client_with_caps(Model.HYBRID_GEN3)
+    """Extended-slot DC-coupled model adds HR 240–299 but not HR(300-359).
+
+    HYBRID_GEN3 is extended-slot only above firmware 302 (#293 Slice B) — pin the
+    firmware above the boundary so this test keeps exercising the extended-slot path.
+    """
+    client = _client_with_caps(Model.HYBRID_GEN3, arm_firmware_version=303)
     with patch.object(client, "_execute_reads", new_callable=AsyncMock) as mock_exec:
         await client.load_config()
     assert _reqs(mock_exec) == [

--- a/tests/model/test_inverter.py
+++ b/tests/model/test_inverter.py
@@ -5,7 +5,6 @@ import pytest
 
 from givenergy_modbus.model import TimeSlot
 from givenergy_modbus.model.inverter import (
-    AC_COUPLED_MODELS,
     BatteryCalibrationStage,
     BatteryPowerMode,
     BatteryType,
@@ -2301,11 +2300,6 @@ def test_battery_energy_facade_routes_by_model():
     assert bare.e_battery_charge_total is None
 
 
-def test_ac_coupled_models_constant():
-    """AC_COUPLED_MODELS is exactly the two AC coarse families (no DC-coupled models)."""
-    assert AC_COUPLED_MODELS == frozenset({Model.AC, Model.AC_3PH})
-
-
 def test_single_phase_inverter_is_ac_coupled():
     """is_ac_coupled is True only for AC-coupled models, via coarse-family resolution.
 
@@ -2578,3 +2572,39 @@ def test_grid_protection_rename_and_deprecated_alias_three_phase(old_name, new_n
     dumped = inv.model_dump()
     assert new_name in dumped
     assert old_name not in dumped
+
+
+def test_ac_coupled_models_deprecated_alias():
+    """AC_COUPLED_MODELS still works via module __getattr__ but warns (#293 Slice B)."""
+    import givenergy_modbus.model.inverter as inverter_module
+    from givenergy_modbus.model.manifest import CAPABILITIES
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        value = inverter_module.AC_COUPLED_MODELS
+    assert value == CAPABILITIES["is_ac_coupled"]
+    deprecations = [x for x in w if issubclass(x.category, DeprecationWarning)]
+    assert len(deprecations) == 1
+    assert "AC_COUPLED_MODELS" in str(deprecations[0].message)
+
+
+def test_three_phase_models_deprecated_alias():
+    """THREE_PHASE_MODELS still works via module __getattr__ but warns (#293 Slice B)."""
+    import givenergy_modbus.model.inverter_threephase as tp_module
+    from givenergy_modbus.model.manifest import CAPABILITIES
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        value = tp_module.THREE_PHASE_MODELS
+    assert value == CAPABILITIES["is_three_phase"]
+    deprecations = [x for x in w if issubclass(x.category, DeprecationWarning)]
+    assert len(deprecations) == 1
+    assert "THREE_PHASE_MODELS" in str(deprecations[0].message)
+
+
+def test_inverter_module_unknown_attribute_still_raises():
+    """__getattr__'s fallback preserves the normal AttributeError for real typos."""
+    import givenergy_modbus.model.inverter as inverter_module
+
+    with pytest.raises(AttributeError):
+        _ = inverter_module.NOT_A_REAL_ATTRIBUTE

--- a/tests/model/test_manifest.py
+++ b/tests/model/test_manifest.py
@@ -1,7 +1,14 @@
 """Tests for the declarative capability manifest (Slice A: register semantics, #293)."""
 
+import pytest
+
 from givenergy_modbus.model.inverter import Model
-from givenergy_modbus.model.manifest import battery_energy_source, ir44_is_inverter_output
+from givenergy_modbus.model.manifest import (
+    battery_energy_source,
+    has_capability,
+    has_extended_slots,
+    ir44_is_inverter_output,
+)
 
 
 def test_battery_energy_source_migrated_rows():
@@ -84,3 +91,73 @@ def test_identity_unresolvable_keeps_status_quo():
     inv = SinglePhaseInverter.from_register_cache(RegisterCache({IR(44): 77}))
     assert inv.e_pv_generation_today == 7.7
     assert inv.e_inverter_out_today is None
+
+
+def test_has_capability_is_hv():
+    """Relocated verbatim from plant.py's _HV_MODELS (#293 Slice B)."""
+    for m in (Model.HYBRID_3PH, Model.AC_3PH, Model.ALL_IN_ONE, Model.HYBRID_HV_GEN3, Model.ALL_IN_ONE_HYBRID):
+        assert has_capability("is_hv", m) is True
+    for m in (Model.HYBRID_GEN1, Model.AC, Model.EMS):
+        assert has_capability("is_hv", m) is False
+
+
+def test_has_capability_is_three_phase():
+    """Relocated from BOTH plant.py and inverter_threephase.py.
+
+    These were independently-maintained duplicates (#293 Slice B).
+    """
+    for m in (Model.HYBRID_3PH, Model.AC_3PH, Model.AIO_COMMERCIAL, Model.ALL_IN_ONE_HYBRID, Model.HYBRID_HV_GEN3):
+        assert has_capability("is_three_phase", m) is True
+    assert has_capability("is_three_phase", Model.ALL_IN_ONE) is False  # HV but single-phase (#105)
+
+
+def test_has_capability_is_ac_coupled():
+    """Relocated from inverter.py's AC_COUPLED_MODELS (#293 Slice B)."""
+    assert has_capability("is_ac_coupled", Model.AC) is True
+    assert has_capability("is_ac_coupled", Model.AC_3PH) is True
+    assert has_capability("is_ac_coupled", Model.HYBRID_GEN1) is False
+
+
+def test_has_capability_has_ac_config_block():
+    """Relocated from plant.py's _AC_CONFIG_BLOCK_MODELS (#293 Slice B)."""
+    for m in (Model.AC, Model.AC_3PH, Model.ALL_IN_ONE):
+        assert has_capability("has_ac_config_block", m) is True
+    assert has_capability("has_ac_config_block", Model.HYBRID_GEN1) is False
+
+
+def test_has_capability_empty_placeholder_facts():
+    """Three empty placeholder capability sets from plant.py.
+
+    No model has been confirmed to answer these blocks on real hardware yet (#293 Slice B).
+    """
+    for name in ("has_smart_load_block", "has_hv_cabinet_block", "has_peak_shaving_block"):
+        assert has_capability(name, Model.HYBRID_GEN1) is False
+        assert has_capability(name, Model.ALL_IN_ONE) is False
+
+
+def test_has_capability_unknown_name_raises():
+    """A typo in the fact name fails loudly, not silently (deliberate — see manifest.py)."""
+    with pytest.raises(KeyError):
+        has_capability("has_typo_block", Model.HYBRID_GEN1)
+
+
+def test_has_extended_slots_unconditional_models():
+    for m in (Model.HYBRID_GEN4, Model.ALL_IN_ONE, Model.ALL_IN_ONE_HYBRID, Model.HYBRID_HV_GEN3):
+        assert has_extended_slots(m) is True
+        assert has_extended_slots(m, arm_fw=1) is True  # unconditional — fw irrelevant
+
+
+def test_has_extended_slots_hybrid_gen3_firmware_gate():
+    """HYBRID_GEN3 extended slots gate at firmware 302.
+
+    This task fixes the firmware-gating rule, matching slot_map.py (#293 Slice B).
+    """
+    assert has_extended_slots(Model.HYBRID_GEN3) is False  # arm_fw=None
+    assert has_extended_slots(Model.HYBRID_GEN3, arm_fw=302) is False
+    assert has_extended_slots(Model.HYBRID_GEN3, arm_fw=303) is True
+
+
+def test_has_extended_slots_non_extended_models():
+    for m in (Model.HYBRID_GEN1, Model.HYBRID_GEN2, Model.AC, Model.EMS):
+        assert has_extended_slots(m) is False
+        assert has_extended_slots(m, arm_fw=999) is False

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -2114,11 +2114,11 @@ class TestPlantCapabilitiesProperties:
 
     from givenergy_modbus.model.plant import PlantCapabilities
 
-    def _caps(self, model: Model) -> "PlantCapabilities":
-        """Build a minimal PlantCapabilities for the given model."""
+    def _caps(self, model: Model, arm_fw: int | None = None) -> "PlantCapabilities":
+        """Build a minimal PlantCapabilities for the given model (and optional firmware)."""
         from givenergy_modbus.model.plant import PlantCapabilities
 
-        return PlantCapabilities(device_type=model)
+        return PlantCapabilities(device_type=model, arm_firmware_version=arm_fw)
 
     def test_is_hv_true_for_hv_models(self):
         """HV models report is_hv True."""
@@ -2163,9 +2163,12 @@ class TestPlantCapabilitiesProperties:
         assert caps.is_three_phase is False
 
     def test_has_extended_slots_true(self):
-        """Models with 10-slot support report has_extended_slots True."""
+        """Models with unconditional 10-slot support report has_extended_slots True.
+
+        HYBRID_GEN3 is excluded here — it's firmware-gated, see
+        test_has_extended_slots_hybrid_gen3_firmware_boundary.
+        """
         extended = (
-            Model.HYBRID_GEN3,
             Model.HYBRID_GEN4,
             Model.ALL_IN_ONE,
             Model.ALL_IN_ONE_HYBRID,
@@ -2173,6 +2176,38 @@ class TestPlantCapabilitiesProperties:
         )
         for m in extended:
             assert self._caps(m).has_extended_slots, f"{m} should have extended slots"
+
+    def test_has_extended_slots_hybrid_gen3_firmware_boundary(self):
+        """The fix: HYBRID_GEN3 is extended only above firmware 302 (#293 Slice B).
+
+        Previously plant.py's _EXTENDED_SLOT_MODELS listed HYBRID_GEN3 unconditionally,
+        which disagreed with the actual slot_map register-layout decision.
+        """
+        assert self._caps(Model.HYBRID_GEN3).has_extended_slots is False  # arm_fw=None
+        assert self._caps(Model.HYBRID_GEN3, arm_fw=302).has_extended_slots is False
+        assert self._caps(Model.HYBRID_GEN3, arm_fw=303).has_extended_slots is True
+
+    def test_arm_firmware_version_defaults_to_none(self):
+        """arm_firmware_version defaults to None when not supplied."""
+        caps = self._caps(Model.HYBRID_GEN1)
+        assert caps.arm_firmware_version is None
+
+    def test_arm_firmware_version_roundtrips_through_to_dict(self):
+        """arm_firmware_version survives a to_dict()/from_dict() round-trip."""
+        from givenergy_modbus.model.plant import PlantCapabilities
+
+        caps = self._caps(Model.HYBRID_GEN1, arm_fw=449)
+        reloaded = PlantCapabilities.from_dict(caps.to_dict())
+        assert reloaded.arm_firmware_version == 449
+
+    def test_arm_firmware_version_missing_from_legacy_payload_loads_as_none(self):
+        """A pre-Slice-B persisted payload has no arm_firmware_version key at all."""
+        from givenergy_modbus.model.plant import PlantCapabilities
+
+        legacy_payload = self._caps(Model.HYBRID_GEN1).to_dict()
+        del legacy_payload["arm_firmware_version"]
+        reloaded = PlantCapabilities.from_dict(legacy_payload)
+        assert reloaded.arm_firmware_version is None
 
     def test_has_extended_slots_false(self):
         """Non-extended models report has_extended_slots False."""

--- a/tests/test_deprecation_aliases.py
+++ b/tests/test_deprecation_aliases.py
@@ -181,6 +181,7 @@ def test_capabilities_to_dict_format():
         "aio_battery_module_addresses": [],
         "hv_bmu_addresses": [],
         "lv_bcu_address": None,
+        "arm_firmware_version": None,
     }
 
 


### PR DESCRIPTION
## Summary

Second of four planned manifest slices (A semantics-routing+renames [merged, #365] → **B fact-table consolidation** → C polling manifest → D write surface), all landing together as **2.10.0**.

Consolidates six scattered model-set constants — some genuinely duplicated across files, one factually wrong — into a `CAPABILITIES` table in `manifest.py` (the module Slice A created):

- **New:** `manifest.CAPABILITIES: dict[str, frozenset[Model]]` + `has_capability(name, model, arm_fw=None)` for seven plain-membership facts (`is_hv`, `is_three_phase`, `is_ac_coupled`, `has_ac_config_block`, `has_smart_load_block`, `has_hv_cabinet_block`, `has_peak_shaving_block`), plus a firmware-aware `has_extended_slots(model, arm_fw=None)` for the one fact that's genuinely firmware-conditional.
- **Bug fix:** `Plant.has_extended_slots` could previously report `True` for a `HYBRID_GEN3` inverter on old firmware (≤302), where the actual register-layout decision (`SinglePhaseInverter.slot_map`) used the non-extended slot map. The two now call the *same* function, so this can't drift apart again. `PlantCapabilities` gained a new optional `arm_firmware_version` field to make this possible — additive, `SCHEMA_VERSION` unchanged, so old persisted payloads still load with the field defaulting to `None`.
- **Deprecation:** `AC_COUPLED_MODELS` (inverter.py) and `THREE_PHASE_MODELS` (inverter_threephase.py) were public, importable constants duplicating manifest facts. Both become PEP 562 module-`__getattr__` shims — access still works and returns the identical value, but now warns, with removal in view at the 3.0 deprecation horizon. Every internal call site is rewired to consult the manifest directly.
- `plant.py`'s six now-redundant private module constants are deleted outright (never public, no compatibility concern).

## Deliberate behaviour change

`has_extended_slots` now correctly returns `False` for a `HYBRID_GEN3` unit on firmware ≤302, where it previously (incorrectly) returned `True`. Worth a changelog call-out as a bug fix at release, since a downstream consumer polling a pre-302 HYBRID_GEN3 would observe the flip.

## Test plan

- [x] Identity-matrix tests for all seven `CAPABILITIES` facts + the firmware boundary (`HYBRID_GEN3` at fw 302 → False, 303 → True)
- [x] `plant.py` predicate migration proven behaviour-identical for the six non-firmware facts
- [x] `arm_firmware_version` round-trips through `to_dict`/`from_dict`, including the legacy-payload-missing-the-key case
- [x] Deprecation shims: warn exactly once, return the correct value, normal `AttributeError` still fires for genuine typos
- [x] Full-suite run under `-W error::DeprecationWarning` confirms no internal code path triggers either new warning
- [x] Full suite (1524 tests), ruff, and tox all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Device detection now records inverter ARM firmware version for more accurate capability handling.
  * Extended time-slot support is now determined automatically from device capabilities and firmware level.

* **Bug Fixes**
  * Improved model and feature detection for three-phase and AC-coupled inverters.
  * Capability information is now derived more consistently when restoring or sharing saved data.

* **Chores**
  * Legacy compatibility remains in place, with warnings for older attribute names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->