### PR TITLE
Manifest Slice C1: polling-range manifest (#293)

### DIFF
--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -340,9 +340,11 @@ def _request_for_range(r: manifest.RegisterRange, device_address: int) -> Transp
         return ReadHoldingRegistersRequest(
             base_register=r.base_register, register_count=r.register_count, device_address=device_address
         )
-    return ReadInputRegistersRequest(
-        base_register=r.base_register, register_count=r.register_count, device_address=device_address
-    )
+    if r.reg_type == "IR":
+        return ReadInputRegistersRequest(
+            base_register=r.base_register, register_count=r.register_count, device_address=device_address
+        )
+    raise ValueError(f"Unsupported RegisterRange.reg_type: {r.reg_type!r}")
 
 
 def _refresh_banks(caps: PlantCapabilities) -> list[tuple[int, int, int]]:

--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -28,6 +28,7 @@ from givenergy_modbus.exceptions import (
     RefreshPartiallySucceeded,
 )
 from givenergy_modbus.framer import ClientFramer, Framer
+from givenergy_modbus.model import manifest
 from givenergy_modbus.model.ems import EmsRegisterGetter
 from givenergy_modbus.model.inverter import Model, resolve_model
 from givenergy_modbus.model.lv_bcu import LV_BCU_ADDRESS
@@ -331,6 +332,17 @@ def _strategise(
         [(f"0x{r.device_address:02x}", r.reg_type, r.base_register, r.register_count) for r in ranges],
     )
     return ranges
+
+
+def _request_for_range(r: manifest.RegisterRange, device_address: int) -> TransparentRequest:
+    """Build the read request for one RegisterRange at device_address."""
+    if r.reg_type == "HR":
+        return ReadHoldingRegistersRequest(
+            base_register=r.base_register, register_count=r.register_count, device_address=device_address
+        )
+    return ReadInputRegistersRequest(
+        base_register=r.base_register, register_count=r.register_count, device_address=device_address
+    )
 
 
 def _refresh_banks(caps: PlantCapabilities) -> list[tuple[int, int, int]]:
@@ -1189,44 +1201,12 @@ class Client:
                 ReadInputRegistersRequest(base_register=120, register_count=60, device_address=inverter),
             ]
         if caps.is_three_phase:
-            reqs += [
-                ReadHoldingRegistersRequest(base_register=1000, register_count=60, device_address=inverter),
-                ReadHoldingRegistersRequest(base_register=1060, register_count=60, device_address=inverter),
-                ReadHoldingRegistersRequest(base_register=1120, register_count=5, device_address=inverter),
-            ]
+            reqs += [_request_for_range(r, inverter) for r in manifest.LOAD_CONFIG_THREE_PHASE_RANGES]
         if caps.has_extended_slots:
             reqs.append(ReadHoldingRegistersRequest(base_register=240, register_count=60, device_address=inverter))
-        if caps.has_smart_load_block:
-            # HR(540-599) — Smart Load scheduling slots 1–10 (HR554-573). Gated because
-            # the block was added from the app's Direct Control catalogue (writable
-            # surface only — never confirmed to answer a live read) and HYBRID_GEN1 times
-            # out on it (#179). The gate set is currently empty, so this is off for every
-            # model pending hardware confirmation; the smart_load_slot_* decode Defs and
-            # set_smart_load_slot_* write helpers are unaffected. Unmodelled registers in
-            # 540-553 and 574-599 are silently ignored by Plant.update(). (#48, #179)
-            reqs.append(ReadHoldingRegistersRequest(base_register=540, register_count=60, device_address=inverter))
-        if caps.has_hv_cabinet_block:
-            # HR(499-510) — HV cabinet topology (12 registers: counts, ratings). Gated
-            # because the block is from the GivEnergy app v4.0.7 and no model
-            # has been confirmed to answer a live read. The gate set is empty until a
-            # capture confirms the block responds. (#265)
-            reqs.append(ReadHoldingRegistersRequest(base_register=499, register_count=12, device_address=inverter))
-        if caps.has_peak_shaving_block:
-            # HR(20000-20051) — peak-shaving / valley-filling (sparse: 20000-20003,
-            # 20020-20021, 20050-20051). Gated because the block is from the
-            # GivEnergy app v4.0.7 and no model has been confirmed to answer a live read.
-            # The 52-register window covers all defined offsets; undefined registers in
-            # the middle are silently ignored by Plant.update().
-            reqs.append(ReadHoldingRegistersRequest(base_register=20000, register_count=52, device_address=inverter))
-        if caps.has_ac_config_block:
-            # HR(300-359) — AC-output config: export_priority (HR311), battery_*_limit_ac
-            # (HR313/314), enable_eps (HR317), pause mode/slot (HR318-320). Present on
-            # AC-coupled inverters AND the All-in-One; DC-coupled/hybrid models time out on
-            # this block (#162). Confirmed present on Model.AC (hass#52 portal writes) and
-            # the AIO (live poll populated these fields, #105).
-            reqs.append(ReadHoldingRegistersRequest(base_register=300, register_count=60, device_address=inverter))
-        if caps.is_ems:
-            reqs.append(ReadHoldingRegistersRequest(base_register=2040, register_count=36, device_address=inverter))
+        for name, entries in manifest.LOAD_CONFIG_RANGES.items():
+            if getattr(caps, name):
+                reqs += [_request_for_range(r, inverter) for r in entries]
         await self._execute_reads(reqs, timeout=timeout, retries=retries, retry_delay=retry_delay)
         return self.plant
 

--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -351,14 +351,10 @@ def _refresh_banks(caps: PlantCapabilities) -> list[tuple[int, int, int]]:
     banks: list[tuple[int, int, int]] = []
     if not caps.is_ems:
         banks += [(inverter, 0, 60), (inverter, 180, 60)]
-    if caps.is_three_phase:
-        for base in range(1000, 1414, 60):
-            banks.append((inverter, base, min(60, 1414 - base)))
-    if caps.is_ems:
-        banks.append((inverter, 2040, 55))
-    if caps.is_gateway:
-        for base in range(1600, 1860, 60):
-            banks.append((inverter, base, min(60, 1860 - base)))
+    banks += [
+        (inverter, r.base_register, r.register_count)
+        for r in manifest.gated_ranges(manifest.REFRESH_IR_RANGES, caps.device_type, caps.arm_firmware_version)
+    ]
     for addr in caps.lv_battery_addresses:
         banks.append((addr, 60, 60))
     if caps.lv_bcu_address is not None:

--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -1200,6 +1200,13 @@ class Client:
             reqs += [_request_for_range(r, inverter) for r in manifest.LOAD_CONFIG_THREE_PHASE_RANGES]
         if caps.has_extended_slots:
             reqs.append(ReadHoldingRegistersRequest(base_register=240, register_count=60, device_address=inverter))
+        # getattr(caps, name), not manifest.gated_ranges(...): the latter reads
+        # manifest.CAPABILITIES directly and is blind to PropertyMock-patched
+        # instance properties, which two tests rely on for facts with no confirmed
+        # model yet (has_hv_cabinet_block/has_peak_shaving_block, #293). Every
+        # LOAD_CONFIG_RANGES fact today is firmware-independent, so this is safe;
+        # a future firmware-gated fact here would need manifest.gated_ranges(...,
+        # caps.arm_firmware_version) instead, since getattr() can't pass arm_fw.
         for name, entries in manifest.LOAD_CONFIG_RANGES.items():
             if getattr(caps, name):
                 reqs += [_request_for_range(r, inverter) for r in entries]

--- a/givenergy_modbus/model/manifest.py
+++ b/givenergy_modbus/model/manifest.py
@@ -218,9 +218,29 @@ LOAD_CONFIG_THREE_PHASE_RANGES: list[RegisterRange] = [
 # is_three_phase/has_extended_slots in the original code — safe to drive off one
 # generic table+loop in this exact insertion order (#293 Slice C1).
 LOAD_CONFIG_RANGES: dict[str, list[RegisterRange]] = {
+    # HR(540-599) — Smart Load scheduling slots 1–10 (HR554-573). Gated because the
+    # block was added from the app's Direct Control catalogue (writable surface only
+    # — never confirmed to answer a live read) and HYBRID_GEN1 times out on it (#179).
+    # The gate set is currently empty, so this is off for every model pending
+    # hardware confirmation. Unmodelled registers in 540-553 and 574-599 are
+    # silently ignored by Plant.update(). (#48, #179)
     "has_smart_load_block": [RegisterRange("HR", 540, 60)],
+    # HR(499-510) — HV cabinet topology (12 registers: counts, ratings). Gated
+    # because the block is from the GivEnergy app v4.0.7 and no model has been
+    # confirmed to answer a live read. The gate set is empty until a capture
+    # confirms the block responds. (#265)
     "has_hv_cabinet_block": [RegisterRange("HR", 499, 12)],
+    # HR(20000-20051) — peak-shaving / valley-filling (sparse: 20000-20003,
+    # 20020-20021, 20050-20051). Gated because the block is from the GivEnergy app
+    # v4.0.7 and no model has been confirmed to answer a live read. The 52-register
+    # window covers all defined offsets; undefined registers in the middle are
+    # silently ignored by Plant.update().
     "has_peak_shaving_block": [RegisterRange("HR", 20000, 52)],
+    # HR(300-359) — AC-output config: export_priority (HR311), battery_*_limit_ac
+    # (HR313/314), enable_eps (HR317), pause mode/slot (HR318-320). Present on
+    # AC-coupled inverters AND the All-in-One; DC-coupled/hybrid models time out on
+    # this block (#162). Confirmed present on Model.AC (hass#52 portal writes) and
+    # the AIO (live poll populated these fields, #105).
     "has_ac_config_block": [RegisterRange("HR", 300, 60)],
     "is_ems": [RegisterRange("HR", 2040, 36)],
 }

--- a/givenergy_modbus/model/manifest.py
+++ b/givenergy_modbus/model/manifest.py
@@ -3,13 +3,17 @@
 One place answering "what does this register/field mean on this model". Grown in
 slices: A (this file's initial content) covers register SEMANTICS — value-source
 routing and per-model field identity. Slice B added the capability fact tables
-(`CAPABILITIES`, `has_extended_slots`); slices C-D will add the polling ranges and the write surface.
+(`CAPABILITIES`, `has_extended_slots`); Slice C1 added the polling-range tables
+(`LOAD_CONFIG_RANGES`, `REFRESH_IR_RANGES`, `gated_ranges`); C2/D will add
+detect-time polling and the write surface.
 
 Keys are the RESOLVED specific ``Model`` (from ``resolve_model``), never the coarse
 family. Every accessor takes ``arm_fw`` so a firmware column exists in the contract
 from day one; no Slice A row uses it (future users: slot_map's ``HYBRID_GEN3 and
 arm_fw > 302`` extended-slot wrinkle, the Gateway V1/V2 layout variant — Slice B+).
 """
+
+from dataclasses import dataclass
 
 from givenergy_modbus.model.inverter import Model
 
@@ -145,6 +149,10 @@ CAPABILITIES: dict[str, frozenset[Model]] = {
     # Models with a readable peak-shaving block at HR(20000-20051). Deliberately
     # empty — no model confirmed on real hardware yet.
     "has_peak_shaving_block": frozenset(),
+    # EMS models — energy management systems.
+    "is_ems": frozenset({Model.EMS, Model.EMS_COMMERCIAL}),
+    # Gateway models.
+    "is_gateway": frozenset({Model.GATEWAY}),
 }
 
 
@@ -183,3 +191,52 @@ def has_extended_slots(model: Model, arm_fw: int | None = None) -> bool:
         return True
     threshold = _EXTENDED_SLOT_FIRMWARE_GATE.get(model)
     return threshold is not None and arm_fw is not None and arm_fw > threshold
+
+
+@dataclass(frozen=True)
+class RegisterRange:
+    """A register range to poll: type, base address, and count (#293 Slice C1)."""
+
+    reg_type: str  # "HR" | "IR"
+    base_register: int
+    register_count: int
+
+
+# HR(1000-1124) — three-phase config block. Kept as a standalone constant (not a
+# LOAD_CONFIG_RANGES entry) because load_config()'s original code checks
+# is_three_phase BEFORE has_extended_slots BEFORE the five tail facts below, and
+# ALL_IN_ONE_HYBRID/HYBRID_HV_GEN3 can have both is_three_phase and
+# has_extended_slots true simultaneously — the relative order matters and must
+# stay exactly as it was (#293 Slice C1).
+LOAD_CONFIG_THREE_PHASE_RANGES: list[RegisterRange] = [
+    RegisterRange("HR", 1000, 60),
+    RegisterRange("HR", 1060, 60),
+    RegisterRange("HR", 1120, 5),
+]
+
+# The five load_config() facts with no interleaving among themselves or with
+# is_three_phase/has_extended_slots in the original code — safe to drive off one
+# generic table+loop in this exact insertion order (#293 Slice C1).
+LOAD_CONFIG_RANGES: dict[str, list[RegisterRange]] = {
+    "has_smart_load_block": [RegisterRange("HR", 540, 60)],
+    "has_hv_cabinet_block": [RegisterRange("HR", 499, 12)],
+    "has_peak_shaving_block": [RegisterRange("HR", 20000, 52)],
+    "has_ac_config_block": [RegisterRange("HR", 300, 60)],
+    "is_ems": [RegisterRange("HR", 2040, 36)],
+}
+
+# _refresh_banks()'s three capability-gated IR ranges — no interleaving among
+# themselves in the original code, safe to drive off one generic table+loop
+# (#293 Slice C1).
+REFRESH_IR_RANGES: dict[str, list[RegisterRange]] = {
+    "is_three_phase": [RegisterRange("IR", b, min(60, 1414 - b)) for b in range(1000, 1414, 60)],
+    "is_ems": [RegisterRange("IR", 2040, 55)],
+    "is_gateway": [RegisterRange("IR", b, min(60, 1860 - b)) for b in range(1600, 1860, 60)],
+}
+
+
+def gated_ranges(
+    table: dict[str, list[RegisterRange]], model: Model | None, arm_fw: int | None = None
+) -> list[RegisterRange]:
+    """Every RegisterRange in `table` whose capability gate is true for `model`."""
+    return [r for name, entries in table.items() if has_capability(name, model, arm_fw) for r in entries]

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -458,12 +458,12 @@ class PlantCapabilities(BaseModel):
     @property
     def is_ems(self) -> bool:
         """Return True if this system is an EMS plant controller (HR/IR 2040-range)."""
-        return self.device_type in (Model.EMS, Model.EMS_COMMERCIAL)
+        return manifest.has_capability("is_ems", self.device_type)
 
     @property
     def is_gateway(self) -> bool:
         """Return True if this system is a Gateway (IR 1600-range)."""
-        return self.device_type == Model.GATEWAY
+        return manifest.has_capability("is_gateway", self.device_type)
 
 
 def _validated_serial(device: Any) -> str | None:

--- a/tests/client/test_load_refresh.py
+++ b/tests/client/test_load_refresh.py
@@ -196,6 +196,29 @@ async def test_load_config_residential_aio_no_1000_range():
     assert all(base < 1000 for _, _, base, _ in reqs), "AIO must not poll the 1000-range bank"
 
 
+async def test_load_config_hybrid_hv_gen3_three_phase_before_extended_slots():
+    """HYBRID_HV_GEN3 has BOTH is_three_phase and has_extended_slots true (#293 Slice C1).
+
+    The HR(1000+) three-phase block must appear BEFORE HR(240) — the relative order
+    between these two facts is a real behaviour contract, preserved by keeping both
+    as literal inline checks in load_config() rather than folding either into the
+    generic capability-gated table (which would iterate in a different order).
+    """
+    client = _client_with_caps(Model.HYBRID_HV_GEN3)
+    with patch.object(client, "_execute_reads", new_callable=AsyncMock) as mock_exec:
+        await client.load_config()
+    assert _reqs(mock_exec) == [
+        _hr(0, 60),
+        _hr(60, 60),
+        _hr(120, 60),
+        _ir(120, 60),
+        _hr(1000, 60),
+        _hr(1060, 60),
+        _hr(1120, 5),
+        _hr(240, 60),
+    ]
+
+
 async def test_load_config_ems():
     """EMS plant controllers expose HR(0,60) (identity/firmware/serial) and HR(2040,36) only.
 

--- a/tests/model/test_manifest.py
+++ b/tests/model/test_manifest.py
@@ -161,3 +161,108 @@ def test_has_extended_slots_non_extended_models():
     for m in (Model.HYBRID_GEN1, Model.HYBRID_GEN2, Model.AC, Model.EMS):
         assert has_extended_slots(m) is False
         assert has_extended_slots(m, arm_fw=999) is False
+
+
+def test_capabilities_gained_is_ems_and_is_gateway():
+    """Extends Slice B's CAPABILITIES table — is_ems/is_gateway were never migrated (#293 Slice C1)."""
+    assert has_capability("is_ems", Model.EMS) is True
+    assert has_capability("is_ems", Model.EMS_COMMERCIAL) is True
+    assert has_capability("is_ems", Model.HYBRID_GEN1) is False
+    assert has_capability("is_gateway", Model.GATEWAY) is True
+    assert has_capability("is_gateway", Model.HYBRID_GEN1) is False
+
+
+def test_load_config_three_phase_ranges_exact_values():
+    from givenergy_modbus.model.manifest import (
+        LOAD_CONFIG_THREE_PHASE_RANGES,
+        RegisterRange,
+    )
+
+    assert LOAD_CONFIG_THREE_PHASE_RANGES == [
+        RegisterRange("HR", 1000, 60),
+        RegisterRange("HR", 1060, 60),
+        RegisterRange("HR", 1120, 5),
+    ]
+
+
+def test_load_config_ranges_exact_values():
+    from givenergy_modbus.model.manifest import (
+        LOAD_CONFIG_RANGES,
+        RegisterRange,
+    )
+
+    assert LOAD_CONFIG_RANGES == {
+        "has_smart_load_block": [RegisterRange("HR", 540, 60)],
+        "has_hv_cabinet_block": [RegisterRange("HR", 499, 12)],
+        "has_peak_shaving_block": [RegisterRange("HR", 20000, 52)],
+        "has_ac_config_block": [RegisterRange("HR", 300, 60)],
+        "is_ems": [RegisterRange("HR", 2040, 36)],
+    }
+
+
+def test_refresh_ir_ranges_exact_values():
+    from givenergy_modbus.model.manifest import (
+        REFRESH_IR_RANGES,
+        RegisterRange,
+    )
+
+    assert REFRESH_IR_RANGES["is_ems"] == [RegisterRange("IR", 2040, 55)]
+    assert REFRESH_IR_RANGES["is_three_phase"] == [
+        RegisterRange("IR", 1000, 60),
+        RegisterRange("IR", 1060, 60),
+        RegisterRange("IR", 1120, 60),
+        RegisterRange("IR", 1180, 60),
+        RegisterRange("IR", 1240, 60),
+        RegisterRange("IR", 1300, 60),
+        RegisterRange("IR", 1360, 54),
+    ]
+    assert REFRESH_IR_RANGES["is_gateway"] == [
+        RegisterRange("IR", 1600, 60),
+        RegisterRange("IR", 1660, 60),
+        RegisterRange("IR", 1720, 60),
+        RegisterRange("IR", 1780, 60),
+        RegisterRange("IR", 1840, 20),
+    ]
+
+
+def test_gated_ranges_returns_only_true_facts():
+    """AC is has_ac_config_block + is_ems=False → exactly the HR(300,60) entry."""
+    from givenergy_modbus.model.manifest import (
+        LOAD_CONFIG_RANGES,
+        RegisterRange,
+        gated_ranges,
+    )
+
+    ranges = gated_ranges(LOAD_CONFIG_RANGES, Model.AC)
+    assert ranges == [RegisterRange("HR", 300, 60)]
+
+
+def test_gated_ranges_ems_model():
+    from givenergy_modbus.model.manifest import (
+        LOAD_CONFIG_RANGES,
+        RegisterRange,
+        gated_ranges,
+    )
+
+    ranges = gated_ranges(LOAD_CONFIG_RANGES, Model.EMS)
+    assert ranges == [RegisterRange("HR", 2040, 36)]
+
+
+def test_gated_ranges_no_facts_true():
+    from givenergy_modbus.model.manifest import (
+        LOAD_CONFIG_RANGES,
+        gated_ranges,
+    )
+
+    ranges = gated_ranges(LOAD_CONFIG_RANGES, Model.HYBRID_GEN1)
+    assert ranges == []
+
+
+def test_gated_ranges_accepts_none_model():
+    """Model | None consistent with has_capability's own None-safety (#293 Slice B)."""
+    from givenergy_modbus.model.manifest import (
+        LOAD_CONFIG_RANGES,
+        gated_ranges,
+    )
+
+    assert gated_ranges(LOAD_CONFIG_RANGES, None) == []


### PR DESCRIPTION
## Summary

Third of four planned manifest slices (A semantics-routing+renames [merged, #365] → B fact-table consolidation [merged, #366] → **C1 polling-range manifest** → C2 detect()/plant.py parity unification [deferred, separate design] → D write surface), all landing together as **2.10.0**.

A pure refactor — zero intended wire-behaviour change — replacing hardcoded, capability-gated register ranges in `Client.load_config()` and `_refresh_banks()` with lookups into two new declarative tables in `manifest.py`:

- **New:** `manifest.RegisterRange` (a small frozen dataclass), `manifest.LOAD_CONFIG_RANGES` (5 keys) + a standalone `LOAD_CONFIG_THREE_PHASE_RANGES`, `manifest.REFRESH_IR_RANGES` (3 keys), and a generic `gated_ranges(table, model, arm_fw=None)` accessor.
- **Closes a Slice B gap:** `is_ems`/`is_gateway` were never migrated onto `manifest.CAPABILITIES` in the prior slice — that slice's own final review flagged it for follow-up. Both are now proper `CAPABILITIES` entries, and `PlantCapabilities`'s corresponding properties consult them, matching the other seven predicates already migrated.
- `is_three_phase` and `has_extended_slots` stay as literal inline checks in `load_config()`, deliberately — their relative order is a real behaviour contract (two real models, `ALL_IN_ONE_HYBRID` and `HYBRID_HV_GEN3`, have both facts true simultaneously, and the three-phase HR(1000+) block must poll before HR(240)). Folding either into the generic table would have silently reordered requests for those two models.

## A worthwhile mid-implementation discovery

The plan's literal code for `load_config()`'s tail facts called `manifest.gated_ranges()` directly against the manifest table — but that bypasses `PlantCapabilities`'s own properties, which broke two pre-existing tests that use `unittest.mock.PropertyMock` to patch `has_hv_cabinet_block`/`has_peak_shaving_block` (both facts have empty `CAPABILITIES` sets today — no real hardware has confirmed either block yet — so mocking the property is the only way to test the "when eventually confirmed" branch). Fixed by gating via `getattr(caps, name)` instead, which is behaviourally identical for every real model (each property just calls `manifest.has_capability(...)` internally) while still honouring the test seam. `_refresh_banks()`'s three facts (`is_three_phase`/`is_ems`/`is_gateway`) all have real, non-empty model membership, so they use the plan's original `gated_ranges()` call as designed.

## Test plan

- [x] Direct tests for `RegisterRange`, both tables' exact values, and `gated_ranges()` (including the `Model | None` edge case)
- [x] Every existing `load_config()`/`refresh()` test passes unmodified — the regression fence for wire-request order
- [x] New regression test pinning the `HYBRID_HV_GEN3` both-true ordering contract (HR(1000+) before HR(240)) — passed on first run against the implementation, confirming the order-preservation claim holds by construction, not luck
- [x] Full suite (1534 tests), mypy, ruff, and tox all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved device compatibility so configuration and refresh requests are built dynamically for more inverter types, including three-phase, EMS, and gateway models.
  * Expanded support for additional device capability checks, helping the app handle a wider range of hardware accurately.

* **Bug Fixes**
  * Corrected the order of some configuration reads to ensure important device data is requested in the expected sequence.

* **Tests**
  * Added coverage for new capability handling and request ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->