### PR TITLE
Share the BCU-count/module-count register decode

### DIFF
--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -38,6 +38,8 @@ from givenergy_modbus.model.plant import (
     Plant,
     PlantCapabilities,
     _aio_module_candidates,
+    _bcu_module_count,
+    _bms_bcu_count,
     _derive_capabilities,
     _hv_bmu_candidates,
 )
@@ -725,7 +727,7 @@ class Client:
                     retries=probe_retries,
                 ):
                     bcu_cache = self.plant.register_caches.get(0x70 + offset, RegisterCache())
-                    actual_modules = bcu_cache.get(IR(64)) or 0
+                    actual_modules = _bcu_module_count(bcu_cache)
                     caps.bcu_stacks.append((offset, actual_modules))
                 else:
                     self.plant.mark_absent(0x70 + offset, "IR", 60, 5)
@@ -743,7 +745,7 @@ class Client:
             self.plant.register_caches.pop(0xA0, None)
             return
         bms_cache: RegisterCache = self.plant.register_caches.get(0xA0, RegisterCache())
-        num_bcus = bms_cache.get(IR(61)) or 0
+        num_bcus = _bms_bcu_count(bms_cache)
         for i in range(num_bcus):
             if await self._probe(
                 ReadInputRegistersRequest(base_register=60, register_count=60, device_address=0x70 + i),
@@ -751,7 +753,7 @@ class Client:
                 retries=probe_retries,
             ):
                 bcu_cache = self.plant.register_caches.get(0x70 + i, RegisterCache())
-                num_modules = bcu_cache.get(IR(64)) or 0
+                num_modules = _bcu_module_count(bcu_cache)
                 caps.bcu_stacks.append((i, num_modules))
             else:
                 self.plant.mark_absent(0x70 + i, "IR", 60, 60)

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -505,6 +505,25 @@ def _aio_module_candidates(num_modules: int) -> list[int]:
     return [0x50 + i for i in range(min(num_modules, _AIO_MAX_MODULES))]
 
 
+def _bms_bcu_count(cache: RegisterCache | None) -> int:
+    """Number of BCU stacks reported by the BMS's IR(61), or 0 if the cache is absent.
+
+    Shared between Client._detect_bcu_stacks (live, cold path) and _derive_hv_topology
+    (offline-safe validate) so the IR(61) decode has one implementation (#293).
+    """
+    return (cache.get(IR(61)) or 0) if cache is not None else 0
+
+
+def _bcu_module_count(cache: RegisterCache | None) -> int:
+    """Number of battery modules reported by a BCU's IR(64), or 0 if the cache is absent.
+
+    Shared between Client._detect_bcu_stacks (live, hinted + cold paths) and
+    _derive_hv_topology (offline-safe validate) so the IR(64) decode has one
+    implementation (#293).
+    """
+    return (cache.get(IR(64)) or 0) if cache is not None else 0
+
+
 def _derive_hv_topology(
     register_caches: dict[int, RegisterCache],
     prior: "PlantCapabilities | None",
@@ -522,9 +541,8 @@ def _derive_hv_topology(
     if prior is not None:
         indices: Any = [offset for offset, _ in prior.bcu_stacks]
     else:
-        bms = register_caches.get(0xA0)
-        indices = range((bms.get(IR(61)) or 0) if bms else 0)
-    caps.bcu_stacks.extend((i, c.get(IR(64)) or 0) for i in indices if (c := register_caches.get(0x70 + i)))
+        indices = range(_bms_bcu_count(register_caches.get(0xA0)))
+    caps.bcu_stacks.extend((i, _bcu_module_count(c)) for i in indices if (c := register_caches.get(0x70 + i)))
     if not caps.bcu_stacks:
         return
 


### PR DESCRIPTION
## Summary

Small follow-up from investigating a planned "Slice C2" for the #293 manifest series (unifying `client.py`'s live `detect()` with `plant.py`'s offline reconstruction path) — that unification turned out to already be complete, done by the earlier #268 epic before the #293 series started. `_derive_capabilities()`/`_derive_hv_topology()` are a single shared function (not two copies) called from both the live and offline paths, and every other piece of candidate-address logic in that area (`_hv_bmu_candidates`, `_aio_module_candidates`, `_COLD_METER_RANGE`, `_COLD_LV_BATTERY_RANGE`) is already shared too.

One small leftover did surface: `_detect_bcu_stacks()` independently re-decoded the raw `IR(61)` BCU-count and `IR(64)` module-count registers in three places (its own hinted path, its own cold path, and again inside `_derive_hv_topology`) instead of going through a shared helper — the one piece of logic in this area that wasn't already DRY.

Extracted `_bms_bcu_count()`/`_bcu_module_count()` in `plant.py` and pointed all four call sites at them. Zero behaviour change — the decode is byte-identical, just written once.

## Test plan

- [x] Full suite (1534 tests) passes unmodified
- [x] mypy, ruff, tox all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)