### PR TITLE
Manifest Slice D: write surface (#293)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,8 +71,10 @@ Prefer real evidence (wire captures, GivTCP cross-reference) before adding a wri
 register. A new writable register must be added in **two** places or it fails at
 send time:
 
-1. the command-mixin `WRITE_SAFE_REGISTERS` in `client/commands.py`, and
-2. the canonical `WRITE_SAFE_REGISTERS` in `pdu/write_registers.py` — enforced by
+1. the model-aware `WRITE_SAFE_*` set in `model/manifest.py` (Gate 1 — the client-boundary
+   check via `write_safe_registers()`; add to the set matching the models that physically
+   accept the register: `WRITE_SAFE_SINGLE_PHASE` / `_THREE_PHASE` / `_EMS` / `_AC_CONFIG`), and
+2. the canonical `WRITE_SAFE_REGISTERS` in `pdu/write_registers.py` (Gate 2) — enforced by
    `WriteHoldingRegisterRequest.ensure_valid_state()` at `encode()` time. A register
    missing here builds a request fine but raises `InvalidPduState` on the wire.
 

--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -1373,6 +1373,21 @@ class Client:
                     retry_delay=retry_delay,
                 )
 
+    def _resolve_write_safe(self) -> frozenset[int]:
+        """Registers the detected model permits at the normal (non-installer) write tier.
+
+        The single source of the caps→manifest resolution shared by one_shot_command()
+        and installer_command() — write-gating logic that must stay identical across
+        both call sites. Composition (base selection, AC-config union with its
+        not-three-phase guard, undetected→single-phase fallback) lives in
+        manifest.write_safe_registers (#293 Slice D).
+        """
+        caps = self.plant.capabilities
+        return manifest.write_safe_registers(
+            caps.device_type if caps is not None else None,
+            caps.arm_firmware_version if caps is not None else None,
+        )
+
     async def one_shot_command(
         self,
         requests: list[TransparentRequest],
@@ -1392,13 +1407,7 @@ class Client:
         never passes for a request real execution would reject.
         """
         caps = self.plant.capabilities
-        # Model→register-set composition (base selection, AC-config union with its
-        # not-three-phase guard, undetected→single-phase fallback) lives in
-        # manifest.write_safe_registers (#293 Slice D) — shared with installer_command().
-        safe = manifest.write_safe_registers(
-            caps.device_type if caps is not None else None,
-            caps.arm_firmware_version if caps is not None else None,
-        )
+        safe = self._resolve_write_safe()
         model_label = caps.device_type.name if caps is not None else "undetected"
         for req in requests:
             if isinstance(req, WriteHoldingRegisterRequest):
@@ -1435,10 +1444,7 @@ class Client:
         If dry_run is True, validates but does not transmit.
         """
         caps = self.plant.capabilities
-        model_safe = manifest.write_safe_registers(
-            caps.device_type if caps is not None else None,
-            caps.arm_firmware_version if caps is not None else None,
-        )
+        model_safe = self._resolve_write_safe()
         installer_safe = model_safe | INSTALLER_WRITE_REGISTERS
         model_label = caps.device_type.name if caps is not None else "undetected"
         for req in requests:

--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -10,12 +10,6 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Literal
 
-from givenergy_modbus.client.commands import (
-    _AC_CONFIG_WRITE_SAFE_REGISTERS,
-    _EmsCommands,
-    _InverterCommands,
-    _ThreePhaseCommands,
-)
 from givenergy_modbus.exceptions import (
     CommunicationError,
     ConnectionLost,
@@ -1398,18 +1392,13 @@ class Client:
         never passes for a request real execution would reject.
         """
         caps = self.plant.capabilities
-        if caps is not None and caps.is_ems:
-            safe = _EmsCommands.WRITE_SAFE_REGISTERS
-        elif caps is not None and caps.is_three_phase:
-            safe = _ThreePhaseCommands.WRITE_SAFE_REGISTERS
-        else:
-            safe = _InverterCommands.WRITE_SAFE_REGISTERS
-        # HR(300-359) AC-output config-block writes (battery_*_limit_ac, #295) are gated on the
-        # capability, not the model class: only a model that exposes the block (Model.AC / AIO)
-        # accepts them — never a DC-coupled hybrid, a three-phase unit (it remaps to HR1110/1108),
-        # or an undetected client (#296 review).
-        if caps is not None and caps.has_ac_config_block and not caps.is_three_phase:
-            safe = safe | _AC_CONFIG_WRITE_SAFE_REGISTERS
+        # Model→register-set composition (base selection, AC-config union with its
+        # not-three-phase guard, undetected→single-phase fallback) lives in
+        # manifest.write_safe_registers (#293 Slice D) — shared with installer_command().
+        safe = manifest.write_safe_registers(
+            caps.device_type if caps is not None else None,
+            caps.arm_firmware_version if caps is not None else None,
+        )
         model_label = caps.device_type.name if caps is not None else "undetected"
         for req in requests:
             if isinstance(req, WriteHoldingRegisterRequest):
@@ -1446,14 +1435,10 @@ class Client:
         If dry_run is True, validates but does not transmit.
         """
         caps = self.plant.capabilities
-        if caps is not None and caps.is_ems:
-            model_safe = _EmsCommands.WRITE_SAFE_REGISTERS
-        elif caps is not None and caps.is_three_phase:
-            model_safe = _ThreePhaseCommands.WRITE_SAFE_REGISTERS
-        else:
-            model_safe = _InverterCommands.WRITE_SAFE_REGISTERS
-        if caps is not None and caps.has_ac_config_block and not caps.is_three_phase:
-            model_safe = model_safe | _AC_CONFIG_WRITE_SAFE_REGISTERS
+        model_safe = manifest.write_safe_registers(
+            caps.device_type if caps is not None else None,
+            caps.arm_firmware_version if caps is not None else None,
+        )
         installer_safe = model_safe | INSTALLER_WRITE_REGISTERS
         model_label = caps.device_type.name if caps is not None else "undetected"
         for req in requests:

--- a/givenergy_modbus/client/commands.py
+++ b/givenergy_modbus/client/commands.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 from datetime import time as dt_time
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING
 
 from typing_extensions import deprecated
 
@@ -1374,34 +1374,16 @@ def restore_factory_defaults(*, confirm: bool = False) -> list[WriteHoldingRegis
     return [WriteHoldingRegisterRequest(RegisterMap.RESTORE_FACTORY_DEFAULTS, 1, installer=True)]
 
 
-# HR(300-359) AC-output config-block writes that are gated on capabilities.has_ac_config_block
-# rather than the model-class allowlist — one_shot_command unions these into the safe set only when
-# the detected model exposes the block (Model.AC / All-in-One), never for a DC-coupled hybrid, a
-# three-phase unit, or an undetected client (#295/#296 review). The AC charge/discharge limits plus
-# export priority (HR311) and EPS enable (HR317) — the whole HR(300-359) writable block is now gated
-# here (#297); 311/317 were previously in the universal set, accepted on DC hybrids and undetected.
-_AC_CONFIG_WRITE_SAFE_REGISTERS: frozenset[int] = frozenset(
-    {
-        RegisterMap.EXPORT_PRIORITY,  # 311
-        RegisterMap.BATTERY_CHARGE_LIMIT_AC,  # 313
-        RegisterMap.BATTERY_DISCHARGE_LIMIT_AC,  # 314
-        RegisterMap.ENABLE_EPS,  # 317
-    }
-)
-
-
 class _InverterCommands:
     """Commands every inverter supports, mixed into Inverter model classes.
 
     Methods delegate to the module-level primitive functions above so the
     primitives stay accessible to lower-level callers (tests, alternate code
-    paths). The mixin's value-add is twofold: it removes the boilerplate of
-    threading `slot_map` through every slot call (it's read from `self`), and
-    it carries a per-model `WRITE_SAFE_REGISTERS` set so model-specific
-    mixins can constrain the allowlist further than the global one.
+    paths). The mixin's value-add is removing the boilerplate of threading
+    `slot_map` through every slot call (it's read from `self`).
 
-    The base mixin's `WRITE_SAFE_REGISTERS` is the universally-applicable
-    subset — registers every inverter accepts writes to. Three-phase / EMS /
+    The write-safe register allowlist for this model shape lives in
+    `manifest.write_safe_registers()`, not on this class. Three-phase / EMS /
     pause-mode commands and their registers will land in additional mixins
     (composed onto the relevant inverter classes) in later 2.x minors once
     the model-vs-firmware ambiguities flagged on #75 are resolved against
@@ -1419,80 +1401,6 @@ class _InverterCommands:
 
         @property
         def slot_map(self) -> SlotMap: ...
-
-    # Universally-applicable subset of pdu.write_registers.WRITE_SAFE_REGISTERS.
-    # Single-phase shape: contains HR(96/110/116) and single-phase slot pairs (94/95,
-    # 31/32 charge; 56/57, 44/45 discharge). ThreePhaseInverter replaces these via
-    # _ThreePhaseCommands.WRITE_SAFE_REGISTERS (defined below, overrides this per MRO).
-    # Excludes 311/313/314/317: these belong to the HR(300-359) AC-output config block, absent
-    # (reads time out) on DC-coupled hybrids, so the whole writable block is gated on
-    # capabilities.has_ac_config_block at the client boundary instead — one_shot_command unions
-    # _AC_CONFIG_WRITE_SAFE_REGISTERS in for Model.AC/AIO only, never a DC hybrid, three-phase, or an
-    # undetected client (#295/#296/#297 review). Also excludes 318-320 (pause mode, firmware-gated),
-    # 1078/1109/1111-1123 (native three-phase), and 2040/2062-2069 (EMS).
-    WRITE_SAFE_REGISTERS: ClassVar[frozenset[int]] = frozenset(
-        {
-            20,  # ENABLE_CHARGE_TARGET
-            27,  # BATTERY_POWER_MODE
-            29,  # SOC_FORCE_ADJUST
-            31,
-            32,  # CHARGE_SLOT_2
-            35,
-            36,
-            37,
-            38,
-            39,
-            40,  # SYSTEM_TIME_*
-            44,
-            45,  # DISCHARGE_SLOT_2
-            50,  # ACTIVE_POWER_RATE
-            56,
-            57,  # DISCHARGE_SLOT_1
-            59,  # ENABLE_DISCHARGE
-            94,
-            95,  # CHARGE_SLOT_1
-            96,  # ENABLE_CHARGE
-            110,  # BATTERY_SOC_RESERVE
-            111,  # BATTERY_CHARGE_LIMIT
-            112,  # BATTERY_DISCHARGE_LIMIT
-            114,  # BATTERY_DISCHARGE_MIN_POWER_RESERVE
-            116,  # CHARGE_TARGET_SOC
-            163,  # REBOOT
-            166,  # ENABLE_RTC
-            246,
-            247,
-            249,
-            250,
-            252,
-            253,
-            255,
-            256,
-            258,
-            259,
-            261,
-            262,
-            264,
-            265,
-            267,
-            268,  # CHARGE_SLOT_3..10
-            276,
-            277,
-            279,
-            280,
-            282,
-            283,
-            285,
-            286,
-            288,
-            289,
-            291,
-            292,
-            294,
-            295,
-            297,
-            298,  # DISCHARGE_SLOT_3..10
-        }
-    )
 
     # --- charge target -------------------------------------------------------
 
@@ -1644,39 +1552,11 @@ class _ThreePhaseCommands:
     MRO puts `_ThreePhaseCommands` before `_InverterCommands` on `ThreePhaseInverter`,
     so these overrides take precedence.
 
-    The `WRITE_SAFE_REGISTERS` frozenset reflects the correct three-phase register
-    addresses: single-phase slot pairs (94/95, 31/32, 56/57, 44/45) and the
-    single-phase-only scalars (96, 110, 116) are replaced by their three-phase
-    counterparts (1113-1116, 1118-1121, 1112, 1109, 1111).
+    The three-phase write-safe register allowlist lives in
+    `manifest.write_safe_registers()`, not on this class: single-phase slot pairs
+    (94/95, 31/32, 56/57, 44/45) and the single-phase-only scalars (96, 110, 116) are
+    replaced there by their three-phase counterparts (1113-1116, 1118-1121, 1112, 1109, 1111).
     """
-
-    # Three-phase allowlist: derived from _InverterCommands.WRITE_SAFE_REGISTERS with
-    # single-phase slot pairs and scalar registers swapped out for three-phase equivalents.
-    WRITE_SAFE_REGISTERS: ClassVar[frozenset[int]] = frozenset(
-        (
-            _InverterCommands.WRITE_SAFE_REGISTERS
-            # remove single-phase slot pairs and scalars
-            - {94, 95, 31, 32}  # charge slots 1-2
-            - {56, 57, 44, 45}  # discharge slots 1-2
-            - {96, 110, 116}  # ENABLE_CHARGE, BATTERY_SOC_RESERVE, CHARGE_TARGET_SOC
-        )
-        | {
-            1078,  # BATTERY_RESERVE_SOC (three-phase only)
-            1109,  # BATTERY_SOC_RESERVE_3PH (shadows HR 110)
-            1111,  # CHARGE_TARGET_SOC_3PH (shadows HR 116)
-            1112,  # AC_CHARGE_ENABLE (three-phase; replaces ENABLE_CHARGE HR 96)
-            1113,
-            1114,  # charge slot 1 (three-phase)
-            1115,
-            1116,  # charge slot 2 (three-phase)
-            1118,
-            1119,  # discharge slot 1 (three-phase)
-            1120,
-            1121,  # discharge slot 2 (three-phase)
-            1122,  # FORCE_DISCHARGE_ENABLE
-            1123,  # FORCE_CHARGE_ENABLE
-        }
-    )
 
     # --- three-phase-only enables --------------------------------------------
 
@@ -1740,11 +1620,10 @@ class _EmsCommands:
     dependency.
 
     The EMS register block (HR 2040, 2044–2071) is decoded in
-    `givenergy_modbus.model.ems`; write-safety for those registers is enforced
-    both here and at the PDU level (`pdu.write_registers.WRITE_SAFE_REGISTERS`).
+    `givenergy_modbus.model.ems`; the write-safe allowlist for those registers lives
+    in `manifest.write_safe_registers()`, enforced there and at the PDU level
+    (`pdu.write_registers.WRITE_SAFE_REGISTERS`).
     """
-
-    WRITE_SAFE_REGISTERS: ClassVar[frozenset[int]] = frozenset({2040, *range(2044, 2072)})
 
     # --- plant master enable -------------------------------------------------
 

--- a/givenergy_modbus/model/ems.py
+++ b/givenergy_modbus/model/ems.py
@@ -171,9 +171,9 @@ class Ems(_EmsBase, _EmsCommands, RegisterMetadataMixin):  # type: ignore[misc,v
 
     Composes the `_EmsCommands` mixin so EMS-targeted writes (`set_ems_plant`,
     `set_ems_charge_slot`, `set_export_slot`, etc.) are exposed as instance
-    methods on the EMS object. The mixin's `WRITE_SAFE_REGISTERS` covers the
-    EMS HR block (2040, 2044–2071); the inverter-level allowlist intentionally
-    does not apply here — EMS is a peer device, not an inverter.
+    methods on the EMS object. `manifest.WRITE_SAFE_EMS` covers the EMS HR
+    block (2040, 2044–2071); the inverter-level allowlist intentionally does
+    not apply here — EMS is a peer device, not an inverter.
     """
 
     REGISTER_GETTER: ClassVar[type[RegisterGetter]] = EmsRegisterGetter

--- a/givenergy_modbus/model/inverter_threephase.py
+++ b/givenergy_modbus/model/inverter_threephase.py
@@ -559,10 +559,10 @@ class ThreePhaseInverter(  # type: ignore[valid-type,misc]
 
     Composes the `_InverterCommands` base mixin alongside `_ThreePhaseCommands`
     (which adds `set_ac_charge`, `set_force_charge`, `set_force_discharge` and
-    their HR(1112/1122/1123) allowlist entries). MRO puts `_ThreePhaseCommands`
-    first so the three-phase `WRITE_SAFE_REGISTERS` (a superset) wins. Methods
-    on the two mixins are disjoint so the resolution order doesn't matter for
-    behaviour.
+    their HR(1112/1122/1123) allowlist entries; the write-safe allowlist for this
+    shape is `manifest.WRITE_SAFE_THREE_PHASE`, not a mixin attribute). MRO puts
+    `_ThreePhaseCommands` first, but methods on the two mixins are disjoint so
+    the resolution order doesn't matter for behaviour.
     """
 
     REGISTER_GETTER: ClassVar[type[RegisterGetter]] = ThreePhaseInverterRegisterGetter

--- a/givenergy_modbus/model/manifest.py
+++ b/givenergy_modbus/model/manifest.py
@@ -374,6 +374,12 @@ def write_safe_registers(model: Model | None, arm_fw: int | None = None) -> froz
     INSTALLER_WRITE_REGISTERS: the installer tier is a universal danger classification,
     unioned at the client boundary, not a per-model capability. ``arm_fw`` is accepted
     for signature consistency; no write capability is firmware-gated today.
+
+    Callers pass the resolved ``caps.device_type`` (not the ``caps`` object) — this gate
+    keys off the model directly, unlike the polling path's ``getattr(caps, name)`` in
+    client.load_config(), which routes through the instance properties so tests can
+    PropertyMock a not-yet-confirmed capability. There is no such test seam on the write
+    path, so keying off the model is the simpler, equivalent choice here.
     """
     if has_capability("is_ems", model):
         safe = WRITE_SAFE_EMS

--- a/givenergy_modbus/model/manifest.py
+++ b/givenergy_modbus/model/manifest.py
@@ -4,8 +4,10 @@ One place answering "what does this register/field mean on this model". Grown in
 slices: A (this file's initial content) covers register SEMANTICS — value-source
 routing and per-model field identity. Slice B added the capability fact tables
 (`CAPABILITIES`, `has_extended_slots`); Slice C1 added the polling-range tables
-(`LOAD_CONFIG_RANGES`, `REFRESH_IR_RANGES`, `gated_ranges`); C2/D will add
-detect-time polling and the write surface.
+(`LOAD_CONFIG_RANGES`, `REFRESH_IR_RANGES`, `gated_ranges`); Slice D added the
+write surface (`WRITE_SAFE_*`, `write_safe_registers`); detect-time polling
+remains in client.py/plant.py's already-shared helpers (C2 was investigated and
+found already unified by #268).
 
 Keys are the RESOLVED specific ``Model`` (from ``resolve_model``), never the coarse
 family. Every accessor takes ``arm_fw`` so a firmware column exists in the contract
@@ -260,3 +262,125 @@ def gated_ranges(
 ) -> list[RegisterRange]:
     """Every RegisterRange in `table` whose capability gate is true for `model`."""
     return [r for name, entries in table.items() if has_capability(name, model, arm_fw) for r in entries]
+
+
+# ---------------------------------------------------------------------------
+# Write surface (#293 Slice D): which registers each model accepts at the normal
+# (non-installer) write tier. Relocated from client/commands.py's mixin ClassVars
+# (_InverterCommands/_ThreePhaseCommands/_EmsCommands.WRITE_SAFE_REGISTERS) and the
+# module-level _AC_CONFIG_WRITE_SAFE_REGISTERS. These are Gate 1 of the two-gate
+# write-safety model — the model/capability-aware gate; Gate 2 (the universal
+# pdu.write_registers supersets) and the confirm=True destructive gate are
+# deliberately NOT here (danger classifications true on every model are not
+# per-model capability facts). Register names in comments mirror
+# client.commands.RegisterMap (not imported — commands.py sits inside the
+# manifest→inverter→commands import cycle, so names live in comments).
+
+# Universally-applicable single-phase subset — registers every single-phase inverter
+# accepts. Excludes 311/313/314/317 (HR300-359 AC-config block, absent on DC hybrids —
+# gated via WRITE_SAFE_AC_CONFIG below, #295/#296/#297), 318-320 (pause mode,
+# firmware-gated), the 1000-range (three-phase) and 2040+ (EMS) registers.
+WRITE_SAFE_SINGLE_PHASE: frozenset[int] = frozenset(
+    {
+        20,  # ENABLE_CHARGE_TARGET
+        27,  # BATTERY_POWER_MODE
+        29,  # SOC_FORCE_ADJUST
+        *(31, 32),  # CHARGE_SLOT_2 (start, end)
+        *range(35, 41),  # SYSTEM_TIME_YEAR/MONTH/DAY/HOUR/MINUTE/SECOND (35-40)
+        *(44, 45),  # DISCHARGE_SLOT_2 (start, end)
+        50,  # ACTIVE_POWER_RATE
+        *(56, 57),  # DISCHARGE_SLOT_1 (start, end)
+        59,  # ENABLE_DISCHARGE
+        *(94, 95),  # CHARGE_SLOT_1 (start, end)
+        96,  # ENABLE_CHARGE
+        110,  # BATTERY_SOC_RESERVE
+        111,  # BATTERY_CHARGE_LIMIT
+        112,  # BATTERY_DISCHARGE_LIMIT
+        114,  # BATTERY_DISCHARGE_MIN_POWER_RESERVE
+        116,  # CHARGE_TARGET_SOC
+        163,  # REBOOT
+        166,  # ENABLE_RTC
+        *(b + o for b in range(246, 269, 3) for o in (0, 1)),  # CHARGE_SLOT_3..10 (start/end pairs at 246+3k)
+        *(b + o for b in range(276, 299, 3) for o in (0, 1)),  # DISCHARGE_SLOT_3..10 (start/end pairs at 276+3k)
+    }
+)
+
+# Three-phase allowlist — DERIVED from the single-phase set (never re-typed): the
+# single-phase slot pairs and scalars are swapped for their 1000-range equivalents.
+WRITE_SAFE_THREE_PHASE: frozenset[int] = frozenset(
+    (
+        WRITE_SAFE_SINGLE_PHASE
+        - {94, 95}  # CHARGE_SLOT_1_START/_END → 1113/1114
+        - {31, 32}  # CHARGE_SLOT_2_START/_END → 1115/1116
+        - {56, 57}  # DISCHARGE_SLOT_1_START/_END → 1118/1119
+        - {44, 45}  # DISCHARGE_SLOT_2_START/_END → 1120/1121
+        - {96}  # ENABLE_CHARGE → AC_CHARGE_ENABLE (1112)
+        - {110}  # BATTERY_SOC_RESERVE → BATTERY_SOC_RESERVE_3PH (1109)
+        - {116}  # CHARGE_TARGET_SOC → CHARGE_TARGET_SOC_3PH (1111)
+    )
+    | frozenset(
+        {
+            1078,  # BATTERY_RESERVE_SOC (three-phase only; no single-phase equivalent)
+            1109,  # BATTERY_SOC_RESERVE_3PH (shadows HR 110)
+            1111,  # CHARGE_TARGET_SOC_3PH (shadows HR 116)
+            1112,  # AC_CHARGE_ENABLE (replaces ENABLE_CHARGE, HR 96)
+            *range(1113, 1117),  # charge slots 1-2 (three-phase; start/end pairs 1113/1114, 1115/1116)
+            *range(1118, 1122),  # discharge slots 1-2 (three-phase; start/end pairs 1118/1119, 1120/1121)
+            1122,  # FORCE_DISCHARGE_ENABLE
+            1123,  # FORCE_CHARGE_ENABLE
+        }
+    )
+)
+
+# EMS plant-controller allowlist — the EMS is a peer device, not an inverter subclass;
+# its set does not derive from the single-phase base. Slot start/end pairs mirror
+# model/slot_map.EMS_SLOTS; scalar names mirror RegisterMap.
+WRITE_SAFE_EMS: frozenset[int] = frozenset(
+    {
+        2040,  # EMS_PLANT_ENABLE
+        # EMS scheduling block (layout mirrors slot_map.EMS_SLOTS + RegisterMap scalars):
+        #   2044-2052 — discharge slots 1-3, each a (start, end, EMS_DISCHARGE_TARGET_SOC_n) triple
+        #   2053-2061 — charge slots 1-3, each a (start, end, EMS_CHARGE_TARGET_SOC_n) triple
+        #   2062-2070 — export slots 1-3, each a (EXPORT_SLOT_n_START, _END, EMS_EXPORT_TARGET_SOC_n) triple
+        #   2071 — EMS_EXPORT_POWER_LIMIT
+        *range(2044, 2072),
+    }
+)
+
+# HR(300-359) AC-output config-block writes, gated on has_ac_config_block rather than
+# the model class: only a model that exposes the block (Model.AC / All-in-One) accepts
+# them — never a DC-coupled hybrid, a three-phase unit (it remaps these controls to
+# HR1110/1108), or an undetected client (#295/#296 review). 311/317 were previously in
+# the universal set, accepted on DC hybrids and undetected (#297 moved them here).
+WRITE_SAFE_AC_CONFIG: frozenset[int] = frozenset(
+    {
+        311,  # EXPORT_PRIORITY
+        313,  # BATTERY_CHARGE_LIMIT_AC
+        314,  # BATTERY_DISCHARGE_LIMIT_AC
+        317,  # ENABLE_EPS
+    }
+)
+
+
+def write_safe_registers(model: Model | None, arm_fw: int | None = None) -> frozenset[int]:
+    """Registers this model/firmware permits at the normal (non-installer) write tier.
+
+    Encapsulates the model→set decision previously duplicated across client.py's two
+    write methods: EMS / three-phase / single-phase base selection, plus the AC-config
+    union gated on has_ac_config_block AND NOT is_three_phase (AC_3PH has the block but
+    remaps those controls — #295/#296/#297), plus the model=None → single-phase
+    conservative fallback (has_capability returns False for None, so an undetected
+    client falls through every branch — no special case needed). Does NOT include
+    INSTALLER_WRITE_REGISTERS: the installer tier is a universal danger classification,
+    unioned at the client boundary, not a per-model capability. ``arm_fw`` is accepted
+    for signature consistency; no write capability is firmware-gated today.
+    """
+    if has_capability("is_ems", model):
+        safe = WRITE_SAFE_EMS
+    elif has_capability("is_three_phase", model):
+        safe = WRITE_SAFE_THREE_PHASE
+    else:
+        safe = WRITE_SAFE_SINGLE_PHASE
+    if has_capability("has_ac_config_block", model) and not has_capability("is_three_phase", model):
+        safe = safe | WRITE_SAFE_AC_CONFIG
+    return safe

--- a/tests/client/test_client_write_safety.py
+++ b/tests/client/test_client_write_safety.py
@@ -1,9 +1,10 @@
 """Tests for model-aware write safety at the Client boundary.
 
 one_shot_command() validates every WriteHoldingRegisterRequest against the
-model-specific WRITE_SAFE_REGISTERS set before transmitting. A caller who
-bypasses the command mixins and hand-builds a WriteHoldingRegisterRequest still
-gets rejected if the register is not valid for the detected inverter model.
+model-specific write-safe register set (from manifest.write_safe_registers()) before
+transmitting. A caller who bypasses the command mixins and hand-builds a
+WriteHoldingRegisterRequest still gets rejected if the register is not valid for the
+detected inverter model.
 
 Uses dry_run=True throughout so no network transport is needed.
 """
@@ -11,19 +12,19 @@ Uses dry_run=True throughout so no network transport is needed.
 import pytest
 
 from givenergy_modbus.client.client import Client
-from givenergy_modbus.client.commands import _EmsCommands, _InverterCommands, _ThreePhaseCommands
 from givenergy_modbus.exceptions import InvalidPduState
+from givenergy_modbus.model import manifest
 from givenergy_modbus.model.inverter import Model
 from givenergy_modbus.model.plant import PlantCapabilities
 from givenergy_modbus.pdu.write_registers import INSTALLER_WRITE_REGISTERS as PDU_INSTALLER_WRITE_REGISTERS
 from givenergy_modbus.pdu.write_registers import WRITE_SAFE_REGISTERS as PDU_WRITE_SAFE_REGISTERS
 from givenergy_modbus.pdu.write_registers import WriteHoldingRegisterRequest
 
-# HR 96 = ENABLE_CHARGE — in _InverterCommands.WRITE_SAFE_REGISTERS (single-phase)
-# HR 1112 = AC_CHARGE_ENABLE — in _ThreePhaseCommands.WRITE_SAFE_REGISTERS only
+# HR 96 = ENABLE_CHARGE — in manifest.WRITE_SAFE_SINGLE_PHASE (single-phase)
+# HR 1112 = AC_CHARGE_ENABLE — in manifest.WRITE_SAFE_THREE_PHASE only
 _SINGLE_PHASE_REG = 96
 _THREE_PHASE_REG = 1112
-# HR 1078 = BATTERY_RESERVE_SOC — three-phase-only; not in base _InverterCommands set
+# HR 1078 = BATTERY_RESERVE_SOC — three-phase-only; not in base manifest.WRITE_SAFE_SINGLE_PHASE set
 _THREE_PHASE_ONLY_REG = 1078
 # HR 2040 = EMS_PLANT_ENABLE — EMS-only
 _EMS_REG = 2040
@@ -118,12 +119,10 @@ _EXPORT_EPS_REGS = (311, 317)
 
 def test_export_priority_eps_gated_not_universal():
     """311/317 are AC-config-gated, not in the universal or three-phase model allowlists (#297)."""
-    from givenergy_modbus.client.commands import _AC_CONFIG_WRITE_SAFE_REGISTERS
-
     for reg in _EXPORT_EPS_REGS:
-        assert reg in _AC_CONFIG_WRITE_SAFE_REGISTERS
-        assert reg not in _InverterCommands.WRITE_SAFE_REGISTERS
-        assert reg not in _ThreePhaseCommands.WRITE_SAFE_REGISTERS
+        assert reg in manifest.WRITE_SAFE_AC_CONFIG
+        assert reg not in manifest.WRITE_SAFE_SINGLE_PHASE
+        assert reg not in manifest.WRITE_SAFE_THREE_PHASE
 
 
 @pytest.mark.asyncio
@@ -266,31 +265,31 @@ async def test_dry_run_false_calls_execute(monkeypatch):
 
 
 def test_single_phase_reg_in_base_set():
-    assert _SINGLE_PHASE_REG in _InverterCommands.WRITE_SAFE_REGISTERS
+    assert _SINGLE_PHASE_REG in manifest.WRITE_SAFE_SINGLE_PHASE
 
 
 def test_three_phase_reg_not_in_base_set():
-    assert _THREE_PHASE_REG not in _InverterCommands.WRITE_SAFE_REGISTERS
+    assert _THREE_PHASE_REG not in manifest.WRITE_SAFE_SINGLE_PHASE
 
 
 def test_three_phase_reg_in_three_phase_set():
-    assert _THREE_PHASE_REG in _ThreePhaseCommands.WRITE_SAFE_REGISTERS
+    assert _THREE_PHASE_REG in manifest.WRITE_SAFE_THREE_PHASE
 
 
 def test_single_phase_reg_not_in_three_phase_set():
-    assert _SINGLE_PHASE_REG not in _ThreePhaseCommands.WRITE_SAFE_REGISTERS
+    assert _SINGLE_PHASE_REG not in manifest.WRITE_SAFE_THREE_PHASE
 
 
 def test_ems_reg_in_ems_set():
-    assert _EMS_REG in _EmsCommands.WRITE_SAFE_REGISTERS
+    assert _EMS_REG in manifest.WRITE_SAFE_EMS
 
 
 def test_ems_reg_not_in_base_set():
-    assert _EMS_REG not in _InverterCommands.WRITE_SAFE_REGISTERS
+    assert _EMS_REG not in manifest.WRITE_SAFE_SINGLE_PHASE
 
 
 def test_ems_set_covers_full_range():
-    assert _EmsCommands.WRITE_SAFE_REGISTERS == frozenset({2040, *range(2044, 2072)})
+    assert manifest.WRITE_SAFE_EMS == frozenset({2040, *range(2044, 2072)})
 
 
 # ---------------------------------------------------------------------------
@@ -303,9 +302,9 @@ def test_ems_set_covers_full_range():
 @pytest.mark.parametrize(
     "command_set",
     [
-        _InverterCommands.WRITE_SAFE_REGISTERS,
-        _ThreePhaseCommands.WRITE_SAFE_REGISTERS,
-        _EmsCommands.WRITE_SAFE_REGISTERS,
+        manifest.WRITE_SAFE_SINGLE_PHASE,
+        manifest.WRITE_SAFE_THREE_PHASE,
+        manifest.WRITE_SAFE_EMS,
     ],
 )
 def test_model_command_set_subset_of_pdu_allowlist(command_set):

--- a/tests/client/test_inverter_commands.py
+++ b/tests/client/test_inverter_commands.py
@@ -22,7 +22,7 @@ from givenergy_modbus.client.commands import (
     _InverterCommands,
     _ThreePhaseCommands,
 )
-from givenergy_modbus.model import TimeSlot
+from givenergy_modbus.model import TimeSlot, manifest
 from givenergy_modbus.model.battery import ExportPriority
 from givenergy_modbus.model.ems import Ems
 from givenergy_modbus.model.inverter import SinglePhaseInverter
@@ -63,11 +63,11 @@ def test_mixin_write_safe_registers_is_universal_subset():
     # has_ac_config_block at the client boundary (#295/#296); 318-320 (pause mode) stay
     # firmware-gated.
     excluded = {313, 314, 318, 319, 320, 1112, 1122, 1123, 2040, 2062, 2063, 2065, 2066, 2068, 2069}
-    assert excluded.isdisjoint(_InverterCommands.WRITE_SAFE_REGISTERS)
+    assert excluded.isdisjoint(manifest.WRITE_SAFE_SINGLE_PHASE)
     # Sanity: still substantial, includes the bread-and-butter ones.
-    assert 20 in _InverterCommands.WRITE_SAFE_REGISTERS  # ENABLE_CHARGE_TARGET
-    assert 96 in _InverterCommands.WRITE_SAFE_REGISTERS  # ENABLE_CHARGE
-    assert 116 in _InverterCommands.WRITE_SAFE_REGISTERS  # CHARGE_TARGET_SOC
+    assert 20 in manifest.WRITE_SAFE_SINGLE_PHASE  # ENABLE_CHARGE_TARGET
+    assert 96 in manifest.WRITE_SAFE_SINGLE_PHASE  # ENABLE_CHARGE
+    assert 116 in manifest.WRITE_SAFE_SINGLE_PHASE  # CHARGE_TARGET_SOC
 
 
 def test_mixin_classvar_does_not_leak_into_model_dump():
@@ -316,8 +316,8 @@ def test_single_phase_set_charge_target_unchanged():
 
 
 def test_three_phase_write_safe_registers_contains_three_phase_entries():
-    """_ThreePhaseCommands.WRITE_SAFE_REGISTERS must include three-phase-specific registers."""
-    wsr = _ThreePhaseCommands.WRITE_SAFE_REGISTERS
+    """manifest.WRITE_SAFE_THREE_PHASE must include three-phase-specific registers."""
+    wsr = manifest.WRITE_SAFE_THREE_PHASE
     assert RegisterMap.CHARGE_TARGET_SOC_3PH in wsr  # 1111
     assert RegisterMap.BATTERY_SOC_RESERVE_3PH in wsr  # 1109
     assert RegisterMap.BATTERY_RESERVE_SOC in wsr  # 1078
@@ -363,7 +363,7 @@ def test_three_phase_set_charge_target_100_disables_charge_target():
 
 def test_three_phase_write_safe_registers_excludes_single_phase_entries():
     """Single-phase-only registers must be absent from the three-phase allowlist."""
-    wsr = _ThreePhaseCommands.WRITE_SAFE_REGISTERS
+    wsr = manifest.WRITE_SAFE_THREE_PHASE
     assert RegisterMap.CHARGE_TARGET_SOC not in wsr  # 116 — replaced by 1111
     assert RegisterMap.BATTERY_SOC_RESERVE not in wsr  # 110 — replaced by 1109
     assert RegisterMap.ENABLE_CHARGE not in wsr  # 96 — replaced by AC_CHARGE_ENABLE
@@ -526,17 +526,16 @@ def test_ems_target_soc_validation_holds_through_mixin(method_name):
 
 
 def test_mixin_write_safe_registers_is_subset_of_pdu_set():
-    """The mixin's documentation-level set must never contain a register the PDU layer rejects.
+    """The manifest's documentation-level set must never contain a register the PDU layer rejects.
 
-    The PDU-level WRITE_SAFE_REGISTERS is the enforced allowlist; the mixin set is the
+    The PDU-level WRITE_SAFE_REGISTERS is the enforced allowlist; the manifest set is the
     documented universally-applicable subset (per-model allowlists deferred to #106/#203).
     Lagging additions are by design; an entry the PDU layer would reject is drift (audit L2).
     """
-    from givenergy_modbus.client.commands import _InverterCommands
     from givenergy_modbus.pdu.write_registers import WRITE_SAFE_REGISTERS as PDU_SET
 
-    rogue = _InverterCommands.WRITE_SAFE_REGISTERS - PDU_SET
-    assert not rogue, f"mixin WRITE_SAFE_REGISTERS contains registers the PDU layer rejects: {sorted(rogue)}"
+    rogue = manifest.WRITE_SAFE_SINGLE_PHASE - PDU_SET
+    assert not rogue, f"manifest WRITE_SAFE_SINGLE_PHASE contains registers the PDU layer rejects: {sorted(rogue)}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/model/test_manifest.py
+++ b/tests/model/test_manifest.py
@@ -285,6 +285,31 @@ def test_write_safe_ac_config_membership_and_disjointness():
     assert WRITE_SAFE_AC_CONFIG.isdisjoint(WRITE_SAFE_EMS)
 
 
+def test_write_safe_single_phase_literal_pin():
+    """Hardcoded regression fence for the write allowlist (#293 Slice D).
+
+    An edit to the collapsed range/comprehension expressions that shifts a register
+    must fail here, not silently change what's writable. Enumerated in full,
+    deliberately not derived.
+    """
+    assert WRITE_SAFE_SINGLE_PHASE == frozenset(
+        {20, 27, 29, 31, 32, 35, 36, 37, 38, 39, 40, 44, 45, 50, 56, 57, 59, 94, 95, 96,
+         110, 111, 112, 114, 116, 163, 166,
+         246, 247, 249, 250, 252, 253, 255, 256, 258, 259, 261, 262, 264, 265, 267, 268,
+         276, 277, 279, 280, 282, 283, 285, 286, 288, 289, 291, 292, 294, 295, 297, 298}
+    )  # fmt: skip
+
+
+def test_write_safe_three_phase_literal_pin():
+    """Hardcoded regression fence for the three-phase write allowlist (#293 Slice D)."""
+    assert WRITE_SAFE_THREE_PHASE == frozenset(
+        {20, 27, 29, 35, 36, 37, 38, 39, 40, 50, 59, 111, 112, 114, 163, 166,
+         246, 247, 249, 250, 252, 253, 255, 256, 258, 259, 261, 262, 264, 265, 267, 268,
+         276, 277, 279, 280, 282, 283, 285, 286, 288, 289, 291, 292, 294, 295, 297, 298,
+         1078, 1109, 1111, 1112, 1113, 1114, 1115, 1116, 1118, 1119, 1120, 1121, 1122, 1123}
+    )  # fmt: skip
+
+
 def test_write_safe_registers_model_matrix():
     """The base-set selection: EMS → EMS set, three-phase → 3ph set, else single-phase.
 

--- a/tests/model/test_manifest.py
+++ b/tests/model/test_manifest.py
@@ -4,10 +4,15 @@ import pytest
 
 from givenergy_modbus.model.inverter import Model
 from givenergy_modbus.model.manifest import (
+    WRITE_SAFE_AC_CONFIG,
+    WRITE_SAFE_EMS,
+    WRITE_SAFE_SINGLE_PHASE,
+    WRITE_SAFE_THREE_PHASE,
     battery_energy_source,
     has_capability,
     has_extended_slots,
     ir44_is_inverter_output,
+    write_safe_registers,
 )
 
 
@@ -266,3 +271,77 @@ def test_gated_ranges_accepts_none_model():
     )
 
     assert gated_ranges(LOAD_CONFIG_RANGES, None) == []
+
+
+def test_write_safe_sets_match_pre_migration_values():
+    """TEMPORARY transcription bridge (#293 Slice D) — REMOVED once Task 3 deletes the originals.
+
+    Pins each relocated manifest constant byte-equal to its still-live commands.py
+    predecessor, proving the relocation transcribed nothing wrong. Task 3 deletes the
+    predecessors and this test with them; the permanent membership pins below and the
+    untouched behavioural matrix in test_client_write_safety.py carry the contract on.
+    """
+    from givenergy_modbus.client.commands import (
+        _AC_CONFIG_WRITE_SAFE_REGISTERS,
+        _EmsCommands,
+        _InverterCommands,
+        _ThreePhaseCommands,
+    )
+
+    assert WRITE_SAFE_SINGLE_PHASE == _InverterCommands.WRITE_SAFE_REGISTERS
+    assert WRITE_SAFE_THREE_PHASE == _ThreePhaseCommands.WRITE_SAFE_REGISTERS
+    assert WRITE_SAFE_EMS == _EmsCommands.WRITE_SAFE_REGISTERS
+    assert WRITE_SAFE_AC_CONFIG == _AC_CONFIG_WRITE_SAFE_REGISTERS
+
+
+def test_write_safe_ac_config_membership_and_disjointness():
+    """Permanent #297 pins at the manifest level.
+
+    The AC-config block is exactly HR311/313/314/317 and is in NEITHER base set
+    (it only arrives via the union).
+    """
+    assert WRITE_SAFE_AC_CONFIG == frozenset({311, 313, 314, 317})
+    assert WRITE_SAFE_AC_CONFIG.isdisjoint(WRITE_SAFE_SINGLE_PHASE)
+    assert WRITE_SAFE_AC_CONFIG.isdisjoint(WRITE_SAFE_THREE_PHASE)
+    assert WRITE_SAFE_AC_CONFIG.isdisjoint(WRITE_SAFE_EMS)
+
+
+def test_write_safe_registers_model_matrix():
+    """The base-set selection: EMS → EMS set, three-phase → 3ph set, else single-phase.
+
+    AC/AIO additionally get the AC-config union (#295).
+    """
+    assert write_safe_registers(Model.EMS) == WRITE_SAFE_EMS
+    assert write_safe_registers(Model.EMS_COMMERCIAL) == WRITE_SAFE_EMS
+    assert write_safe_registers(Model.HYBRID_3PH) == WRITE_SAFE_THREE_PHASE
+    assert write_safe_registers(Model.HYBRID_GEN1) == WRITE_SAFE_SINGLE_PHASE
+    assert write_safe_registers(Model.AC) == WRITE_SAFE_SINGLE_PHASE | WRITE_SAFE_AC_CONFIG
+    assert write_safe_registers(Model.ALL_IN_ONE) == WRITE_SAFE_SINGLE_PHASE | WRITE_SAFE_AC_CONFIG
+
+
+def test_write_safe_registers_ac_3ph_no_ac_config_union():
+    """The load-bearing guard: AC_3PH HAS has_ac_config_block but is three-phase.
+
+    It remaps those controls to the 1000-range, so it must NOT get the HR300-359
+    union (#295/#296; pinned behaviourally in test_client_write_safety.py too).
+    """
+    result = write_safe_registers(Model.AC_3PH)
+    assert result == WRITE_SAFE_THREE_PHASE
+    for reg in (311, 313, 314, 317):
+        assert reg not in result
+
+
+def test_write_safe_registers_undetected_falls_back_to_single_phase():
+    """model=None (undetected client) → conservative single-phase base, no AC-config union.
+
+    Falls out of has_capability's None→False contract, not a special case (#296).
+    """
+    assert write_safe_registers(None) == WRITE_SAFE_SINGLE_PHASE
+
+
+def test_write_safe_registers_accepts_fw_param():
+    """arm_fw column exists in the signature from day one.
+
+    Unused — no write capability is firmware-gated today.
+    """
+    assert write_safe_registers(Model.HYBRID_GEN1, arm_fw=449) == WRITE_SAFE_SINGLE_PHASE

--- a/tests/model/test_manifest.py
+++ b/tests/model/test_manifest.py
@@ -273,27 +273,6 @@ def test_gated_ranges_accepts_none_model():
     assert gated_ranges(LOAD_CONFIG_RANGES, None) == []
 
 
-def test_write_safe_sets_match_pre_migration_values():
-    """TEMPORARY transcription bridge (#293 Slice D) — REMOVED once Task 3 deletes the originals.
-
-    Pins each relocated manifest constant byte-equal to its still-live commands.py
-    predecessor, proving the relocation transcribed nothing wrong. Task 3 deletes the
-    predecessors and this test with them; the permanent membership pins below and the
-    untouched behavioural matrix in test_client_write_safety.py carry the contract on.
-    """
-    from givenergy_modbus.client.commands import (
-        _AC_CONFIG_WRITE_SAFE_REGISTERS,
-        _EmsCommands,
-        _InverterCommands,
-        _ThreePhaseCommands,
-    )
-
-    assert WRITE_SAFE_SINGLE_PHASE == _InverterCommands.WRITE_SAFE_REGISTERS
-    assert WRITE_SAFE_THREE_PHASE == _ThreePhaseCommands.WRITE_SAFE_REGISTERS
-    assert WRITE_SAFE_EMS == _EmsCommands.WRITE_SAFE_REGISTERS
-    assert WRITE_SAFE_AC_CONFIG == _AC_CONFIG_WRITE_SAFE_REGISTERS
-
-
 def test_write_safe_ac_config_membership_and_disjointness():
     """Permanent #297 pins at the manifest level.
 


### PR DESCRIPTION
## Summary

Fourth and **final** manifest slice (A semantics-routing+renames [#365] → B fact-table consolidation [#366] → C1 polling-range manifest [#367] → C2 [investigated, already unified by #268; leftover in #368] → **D write surface**). With this merged, `manifest.py` owns every model/capability-keyed decision across the read AND write surface, and **2.10.0 can cut.**

This is the highest-risk surface in the codebase (register writes to real hardware), so it carries an extra verification layer — see the test plan.

Relocates the four write-safe register allowlists from `commands.py` into `manifest.py` and unifies the write-gating decision:

- **New:** `manifest.WRITE_SAFE_SINGLE_PHASE` / `WRITE_SAFE_THREE_PHASE` (derived from the single-phase set) / `WRITE_SAFE_EMS` / `WRITE_SAFE_AC_CONFIG` — every register annotated with its meaning for visual inspectability — plus `write_safe_registers(model, arm_fw=None)`, one accessor encoding the base-set selection, the AC-config union gated on `has_ac_config_block AND NOT is_three_phase` (AC_3PH has the block but remaps those controls, so it's correctly excluded), and the `model=None` → single-phase conservative fallback.
- `client.py`'s `one_shot_command()` and `installer_command()` each drop their ~7-line duplicated inline dispatch for one accessor call. The `installer_command()` `| INSTALLER_WRITE_REGISTERS` union stays at the client boundary — the installer/destructive tier is a universal danger classification, deliberately NOT a per-model fact.
- `commands.py`'s three mixin `WRITE_SAFE_REGISTERS` ClassVars + module-level `_AC_CONFIG_WRITE_SAFE_REGISTERS` are deleted; every test repointed to the manifest constants.

## Zero behaviour change

Pure relocation — no model gains or loses write permission for any register. `#297` (HR311/317 folded into `has_ac_config_block`) was already landed before this slice; nothing about the gate semantics changes here.

## Test plan

- [x] A temporary bridging test proved each relocated set byte-equal to its `commands.py` original, then was removed once its job was done
- [x] Hardcoded-literal regression pins for the single-phase and three-phase sets — non-tautological fences so a future edit to the collapsed range/comprehension expressions fails loud rather than silently shifting the allowlist (the three-phase pin double-covers the derived set)
- [x] The full accept/reject behavioural matrix in `test_client_write_safety.py` (per model, per tier, incl. the AC_3PH-no-union case and the undetected→single-phase fallback) passes with no assertion weakened
- [x] **`register-safety-reviewer` PASS** — independently expanded every range comprehension against the originals, verified the AC_3PH guard, the None fallback, and the installer-tier boundary
- [x] Full suite (1541), mypy, ruff, and tox all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unified write-safe register handling based on device model, including support for single-phase, three-phase, EMS and AC-config register sets.
  * Improved register validation so writes are checked against the appropriate model-specific allowlist.

* **Bug Fixes**
  * Refined write permissions for certain devices so the correct registers are available for supported configurations.
  * Updated coverage to better protect against allowlist drift and unexpected register writes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->