### PR TITLE
fix(gateway): report AIO power in house convention (positive = discharge)

### DIFF
--- a/givenergy_modbus/model/gateway.py
+++ b/givenergy_modbus/model/gateway.py
@@ -74,7 +74,13 @@ _GATEWAY_COMMON_LUT = {
     "p_ac1": Def(C.int16, None, IR(1616)),
     "p_pv": Def(C.uint16, None, IR(1617), max=50000),
     "p_load": Def(C.uint16, None, IR(1618), max=50000),
-    "p_liberty": Def(C.int16, None, IR(1619)),
+    # p_liberty / p_aio_total / p_aio{1,2,3}_inverter: firmware reports positive
+    # while charging; C.negate brings them into the library's house convention
+    # (positive = discharge), matching the single-phase inverter's p_battery.
+    # Fixture-confirmed on gateway_2aio_a (night: battery discharge → raw −797;
+    # daylight: charge → raw +154). p_liberty's exact semantics are still open,
+    # but it tracks p_aio_total's sign, so the same treatment applies (#194/hass).
+    "p_liberty": Def(C.int16, C.negate, IR(1619)),
     "fault_protection": Def(C.uint32, None, IR(1620), IR(1621)),
     "gateway_fault_codes": Def(C.uint32, _gateway_fault_code, IR(1622), IR(1623)),
     "v_grid_relay": Def(C.deci, None, IR(1624), min=0.0, max=500.0),
@@ -94,7 +100,7 @@ _GATEWAY_COMMON_LUT = {
     #
     "parallel_aio_num": Def(C.uint16, None, IR(1700)),
     "parallel_aio_online_num": Def(C.uint16, None, IR(1701)),
-    "p_aio_total": Def(C.int16, None, IR(1702)),
+    "p_aio_total": Def(C.int16, C.negate, IR(1702)),
     "aio_state": Def(C.uint16, State, IR(1703)),
     "battery_firmware_version": Def(C.uint16, None, IR(1704)),
     #
@@ -114,9 +120,9 @@ _GATEWAY_COMMON_LUT = {
     "aio1_soc": Def(C.uint16, None, IR(1801), min=0, max=100),
     "aio2_soc": Def(C.uint16, None, IR(1802), min=0, max=100),
     "aio3_soc": Def(C.uint16, None, IR(1803), min=0, max=100),
-    "p_aio1_inverter": Def(C.int16, None, IR(1816)),
-    "p_aio2_inverter": Def(C.int16, None, IR(1817)),
-    "p_aio3_inverter": Def(C.int16, None, IR(1818)),
+    "p_aio1_inverter": Def(C.int16, C.negate, IR(1816)),
+    "p_aio2_inverter": Def(C.int16, C.negate, IR(1817)),
+    "p_aio3_inverter": Def(C.int16, C.negate, IR(1818)),
 }
 
 # Energy totals — high/low register order used by GA000009 and earlier

--- a/givenergy_modbus/model/register.py
+++ b/givenergy_modbus/model/register.py
@@ -166,6 +166,18 @@ class Converter:
             return val if val < 0x8000 else val - 0x10000
 
     @staticmethod
+    def negate(val: int | float | None) -> int | float | None:
+        """Flip the sign of a post-converted value.
+
+        A composable post-converter: pairs after a width/sign converter (e.g.
+        ``Def(C.int16, C.negate, ...)``) to bring a register into the library's
+        house convention where positive = discharge/export. Used for the Gateway
+        AIO power fields (IR1619/1702/1816-1818), whose firmware reports positive
+        while charging — inverted vs the single-phase inverter's ``p_battery``.
+        """
+        return None if val is None else -val
+
+    @staticmethod
     def deci(val: int) -> float:
         """Represent a register value as a float in 1/10 units."""
         if val is not None:
@@ -256,6 +268,7 @@ _PRECISION_BY_CONVERTER: dict[Any, int] = {
     Converter.int32: 0,
     Converter.duint8: 0,
     Converter.bitfield: 0,
+    Converter.negate: 0,
 }
 
 

--- a/scripts/audit_register_doc.py
+++ b/scripts/audit_register_doc.py
@@ -287,6 +287,7 @@ _CONV_SCALE = {
     "int16": 1.0,
     "uint32": 1.0,
     "int32": 1.0,
+    "negate": 1.0,
 }
 
 

--- a/tests/model/test_fixture_golden_master.py
+++ b/tests/model/test_fixture_golden_master.py
@@ -301,6 +301,12 @@ async def test_gateway_classifies_and_decodes_v1_totals():
     assert gw.aio1_serial_number == "CH2414G000"
     assert gw.aio2_serial_number == "CH2542G000"
     assert not gw.aio3_serial_number  # only two AIOs on this plant
+    # AIO power sign convention (house: positive = discharge). Daylight, near-full
+    # batteries absorbing PV surplus → charging → negative after C.negate.
+    assert gw.p_aio_total < 0
+    assert gw.p_liberty < 0
+    # Per-AIO components share the total's convention and sum to it (both negated).
+    assert gw.p_aio1_inverter < 0 and gw.p_aio2_inverter < 0
 
 
 @pytest.mark.timeout(20)
@@ -323,3 +329,10 @@ async def test_gateway_night_capture_classifies_and_selects_v1():
     assert gw.p_pv == 0  # deep night
     # V1 word order holds on this capture too (V2 order would inflate ~1.5e8)
     assert 8000 < gw.e_battery_charge_total < 9000
+    # AIO power sign convention (house: positive = discharge). Deep night, PV=0,
+    # grid ~0 → the house runs off the batteries → discharging → positive after
+    # C.negate. Unambiguous: p_aio_total ~ p_load. Per-AIO parts sum to the total.
+    assert gw.p_aio_total > 0
+    assert gw.p_liberty > 0
+    assert gw.p_aio1_inverter > 0 and gw.p_aio2_inverter > 0
+    assert gw.p_aio1_inverter + gw.p_aio2_inverter == pytest.approx(gw.p_aio_total)

--- a/tests/model/test_gateway.py
+++ b/tests/model/test_gateway.py
@@ -86,7 +86,8 @@ def test_gateway_power_readings():
             IR(1609): 100,  # i_grid = 10.0 A
             IR(1617): 3000,  # p_pv = 3000 W
             IR(1618): 2000,  # p_load = 2000 W
-            IR(1619): 65536 - 500,  # p_liberty = -500 (int16)
+            IR(1619): 65536 - 500,  # p_liberty raw = -500 (int16); house convention negates → +500
+            IR(1702): 154,  # p_aio_total raw = +154 (charging) → house convention -154
             IR(1604): 2,  # work_mode = ON_GRID
         }
     )
@@ -95,7 +96,10 @@ def test_gateway_power_readings():
     assert gw.i_grid == 10.0  # type: ignore[attr-defined]
     assert gw.p_pv == 3000  # type: ignore[attr-defined]
     assert gw.p_load == 2000  # type: ignore[attr-defined]
-    assert gw.p_liberty == -500  # type: ignore[attr-defined]
+    # AIO power fields are negated into the house convention (positive = discharge):
+    # raw -500 → +500 (discharge), raw +154 → -154 (charge). See gateway.py comment.
+    assert gw.p_liberty == 500  # type: ignore[attr-defined]
+    assert gw.p_aio_total == -154  # type: ignore[attr-defined]
     assert gw.work_mode == WorkMode.ON_GRID  # type: ignore[attr-defined]
 
 

--- a/tests/model/test_register.py
+++ b/tests/model/test_register.py
@@ -633,6 +633,18 @@ def test_precision_post_conv_wins_over_pre_conv():
     assert RegisterDefinition(Converter.int16, Converter.centi, IR(0)).precision == 2
 
 
+def test_negate_flips_sign_and_passes_none():
+    assert Converter.negate(500) == -500
+    assert Converter.negate(-154) == 154
+    assert Converter.negate(0) == 0
+    assert Converter.negate(None) is None
+
+
+def test_negate_post_conv_keeps_integer_precision():
+    """int16 -> negate stays whole-number precision (composition proven in test_gateway)."""
+    assert RegisterDefinition(Converter.int16, Converter.negate, IR(0)).precision == 0
+
+
 def test_precision_non_numeric_is_none():
     """Enums, bools, strings and timeslots have no numeric precision."""
     assert RegisterDefinition(Converter.bool, None, IR(0)).precision is None


### PR DESCRIPTION
## What

The Gateway firmware reports its AIO power fields **positive-while-charging** — inverted relative to the single-phase inverter's `p_battery` (which is positive = discharge) and relative to GivTCP. This adds a small composable `Converter.negate` post-converter and applies it to all five affected fields so they land in the library's house convention (**positive = discharge/export**), letting consumers drop their own negations.

Fields flipped:
- `p_liberty` (IR1619)
- `p_aio_total` (IR1702)
- `p_aio1_inverter` / `p_aio2_inverter` / `p_aio3_inverter` (IR1816-1818)

## Evidence (fixture-confirmed, not just external comparison)

Decoded `gateway_2aio_a`:

| Field (raw) | Daylight (PV=1997W) | Night (PV=0) |
|---|---|---|
| `p_aio_total` | +154 | −797 |
| `p_liberty` | +212 | −786 |
| `p_aio1/2_inverter` | +76 / +85 | −386 / −411 |

The **night capture is unambiguous**: PV=0, grid ≈ −31W, load=817W → the house runs off the batteries (discharging ~797W), raw reads **−797**. Daylight: PV surplus into near-full batteries (94/96% SOC) → charging, raw reads **+154**. So raw is positive-while-charging; negating gives positive = discharge, consistent with `p_battery`.

## Scope note (2 → 5)

hass asked for `p_liberty` + `p_aio_total`. The fixtures show the per-AIO components carry the **same** convention and sum exactly to the total (night: −386 + −411 = −797), so flipping the total without them would ship an internally inconsistent model. All five flip together. `p_ac1` (grid) is a separate convention and is left untouched.

`p_liberty`'s exact semantics remain unconfirmed, but it tracks `p_aio_total`'s sign across both captures, so the same treatment applies.

## Tests

- `Converter.negate` unit test (sign flip + None passthrough) and precision.
- `test_gateway_power_readings` updated for the flipped expectations.
- `test_fixture_golden_master` gateway day/night cases now assert the sign convention against real captures (charge → negative, discharge → positive, per-AIO sum == total). Mutation-checked: dropping either `negate` turns both fixture cases red.
- Full suite + tox (py311-314, lint, format, build) green.

Coordination context: dewet22/givenergy-hass#95.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected sign handling for several gateway power readings, including Liberty, total AIO power, and per-inverter AIO values.
  * Improved displayed power values so they now follow the expected convention across different fixture states.

* **Tests**
  * Expanded coverage for gateway power readings and fixture checks.
  * Added unit tests for sign-flipping behaviour and numeric precision handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->