### PR TITLE
fix(model): decode all temperature registers as signed two's-complement

### DIFF
--- a/givenergy_modbus/model/battery.py
+++ b/givenergy_modbus/model/battery.py
@@ -34,18 +34,20 @@ class BatteryRegisterGetter(RegisterGetter):
         "v_cell_14": Def(DT.milli, None, IR(73), min=1.0, max=5.0),
         "v_cell_15": Def(DT.milli, None, IR(74), min=1.0, max=5.0),
         "v_cell_16": Def(DT.milli, None, IR(75), min=1.0, max=5.0),
-        # Temperature `min=-60.0` also (incidentally) rejects the absent-battery-slot sentinel.
-        # The BMS firmware stores temperatures internally with a `+2730` bias and subtracts
-        # 2730 on TX, so an empty slot (internal `0`) emits `0xF556 = -2730 = -273.0 °C`.
+        # Temperatures are SIGNED two's-complement deci (v4.1.6 register map 4.4.1.2:
+        # Cell*_Temp / MOS_Temp / T_max / T_min = "signed" 0.1c) — so a genuine sub-zero
+        # cell decodes correctly instead of as a huge positive. The BMS stores temperatures
+        # with a `+2730` bias and subtracts 2730 on TX, so an empty slot (internal `0`)
+        # emits `0xF556 = -2730 = -273.0 °C`; the `min=-60.0` bound rejects that sentinel.
         # See open-giv/bms-analysis docs/03 ("Absent device pattern") for the firmware path.
-        # If you tighten these bounds, keep the lower bound below `-273.0` or add explicit
+        # If you tighten these bounds, keep the lower bound above `-273.0` or add explicit
         # sentinel rejection — otherwise empty-slot frames will start reaching consumers.
-        "t_cells_01_04": Def(DT.deci, None, IR(76), min=-60.0, max=150.0),
-        "t_cells_05_08": Def(DT.deci, None, IR(77), min=-60.0, max=150.0),
-        "t_cells_09_12": Def(DT.deci, None, IR(78), min=-60.0, max=150.0),
-        "t_cells_13_16": Def(DT.deci, None, IR(79), min=-60.0, max=150.0),
+        "t_cells_01_04": Def(DT.int16, DT.deci, IR(76), min=-60.0, max=150.0),
+        "t_cells_05_08": Def(DT.int16, DT.deci, IR(77), min=-60.0, max=150.0),
+        "t_cells_09_12": Def(DT.int16, DT.deci, IR(78), min=-60.0, max=150.0),
+        "t_cells_13_16": Def(DT.int16, DT.deci, IR(79), min=-60.0, max=150.0),
         "v_cells_sum": Def(DT.milli, None, IR(80), min=16.0, max=80.0),
-        "t_bms_mosfet": Def(DT.deci, None, IR(81), min=-60.0, max=150.0),
+        "t_bms_mosfet": Def(DT.int16, DT.deci, IR(81), min=-60.0, max=150.0),
         "v_out": Def(DT.uint32, DT.milli, IR(82), IR(83), min=16.0, max=80.0),
         "cap_calibrated": Def(DT.uint32, DT.centi, IR(84), IR(85)),
         "cap_design": Def(DT.uint32, DT.centi, IR(86), IR(87)),
@@ -69,8 +71,8 @@ class BatteryRegisterGetter(RegisterGetter):
         # IR(99) unused
         "soc": Def(DT.uint16, None, IR(100), min=0, max=100),
         "cap_design2": Def(DT.uint32, DT.centi, IR(101), IR(102)),
-        "t_max": Def(DT.deci, None, IR(103), min=-60.0, max=150.0),
-        "t_min": Def(DT.deci, None, IR(104), min=-60.0, max=150.0),
+        "t_max": Def(DT.int16, DT.deci, IR(103), min=-60.0, max=150.0),
+        "t_min": Def(DT.int16, DT.deci, IR(104), min=-60.0, max=150.0),
         # IR(105/106) "Battery discharge/charge energy total" (v4.1.6 doc): lifetime
         # totals, 0.1 kWh, unsigned. Field evidence (#238, two LV systems): both packs
         # within a plant report identical values — the counters look stack-level,

--- a/givenergy_modbus/model/hv_bcu.py
+++ b/givenergy_modbus/model/hv_bcu.py
@@ -61,6 +61,11 @@ class BcuRegisterGetter(RegisterGetter):
         "pack_software_version": Def(C.gateway_version, None, IR(60), IR(61), IR(62), IR(63)),
         "number_of_modules": Def(C.uint16, None, IR(64)),
         "cells_per_module": Def(C.uint16, None, IR(65)),
+        # NOTE: these two names are suspect. In both committed HV fixtures IR(67)/IR(68)
+        # read as counts, not measurements — IR(67) = modules × 24 (total cells), IR(68) =
+        # modules × 12 (total temp sensors), holding a 2:1 ratio across a 4- and a 6-module
+        # stack. So IR(68) is almost certainly a temp-SENSOR COUNT, not a temperature, and
+        # is deliberately left unsigned. Field-identity reconciliation tracked separately.
         "cluster_cell_voltage": Def(C.uint16, None, IR(67)),
         "cluster_cell_temperature": Def(C.uint16, None, IR(68)),
         "status": Def(C.uint16, None, IR(70)),
@@ -148,6 +153,8 @@ _SERIAL_LEN = 5
 # e.g. a serial byte read as a cell when a module stores its serial split across the cell
 # window (#378/#379: "HY" at IR110 decodes as t_cell_21 = 1852.1 °C). An all-zero raw is
 # treated as unset (kept as decoded, not None), matching the RegisterGetter convention.
+# Voltages are unsigned; temps are signed two's-complement (v4.1.6 register map 4.4.1.2),
+# so the negative floor is a real bound a genuine sub-zero cell can sit above.
 _V_CELL_MIN, _V_CELL_MAX = 1.0, 5.0
 _T_CELL_MIN, _T_CELL_MAX = -60.0, 150.0
 
@@ -178,7 +185,7 @@ def cell_temp_serial_register_lut(base: int = 0) -> dict[str, Def]:
     lut: dict[str, Def] = {}
     for i in range(_BMU_CELLS):
         lut[f"v_cell_{i + 1:02d}"] = Def(C.milli, None, IR(_V_CELL_BASE + base + i), min=_V_CELL_MIN, max=_V_CELL_MAX)
-        lut[f"t_cell_{i + 1:02d}"] = Def(C.deci, None, IR(_T_CELL_BASE + base + i), min=_T_CELL_MIN, max=_T_CELL_MAX)
+        lut[f"t_cell_{i + 1:02d}"] = Def(C.int16, C.deci, IR(_T_CELL_BASE + base + i), min=_T_CELL_MIN, max=_T_CELL_MAX)
     lut["serial_number"] = Def(C.serial, None, *(IR(_SERIAL_BASE + base + j) for j in range(_SERIAL_LEN)))
     return lut
 
@@ -197,23 +204,27 @@ def decode_cells_temps_serial(register_cache, base: int = 0) -> dict[str, Any]:
     def _get(reg_idx: int) -> int | None:
         return register_cache.get(IR(reg_idx))
 
-    def _bounded(raw: int | None, scale: int, lo: float, hi: float) -> float | None:
+    def _bounded(raw: int | None, scale: int, lo: float, hi: float, *, signed: bool = False) -> float | None:
         """Decode raw/scale, but suppress non-zero values outside [lo, hi] to None.
 
         Mirrors the RegisterGetter bounds handling: an all-zero raw is unset (kept as
         the decoded 0.0), a non-zero out-of-range value is corruption and returns None.
+        ``signed`` interprets the raw word as two's-complement first — temperatures are
+        signed per the firmware register map (v4.1.6 4.4.1.2: Cell*_Temp = signed 0.1c),
+        so a genuine sub-zero reading decodes correctly instead of as a huge positive.
         """
         if raw is None:
             return None
-        val = raw / scale
+        val = (C.int16(raw) if signed else raw) / scale
         if raw != 0 and not (lo <= val <= hi):
             return None
         return val
 
     for i in range(_BMU_CELLS):
+        # Cell voltages are unsigned (always positive); temps are signed two's-complement.
         data[f"v_cell_{i + 1:02d}"] = _bounded(_get(_V_CELL_BASE + base + i), 1000, _V_CELL_MIN, _V_CELL_MAX)
     for i in range(_BMU_CELLS):
-        data[f"t_cell_{i + 1:02d}"] = _bounded(_get(_T_CELL_BASE + base + i), 10, _T_CELL_MIN, _T_CELL_MAX)
+        data[f"t_cell_{i + 1:02d}"] = _bounded(_get(_T_CELL_BASE + base + i), 10, _T_CELL_MIN, _T_CELL_MAX, signed=True)
     sn_regs = [_get(_SERIAL_BASE + base + j) for j in range(_SERIAL_LEN)]
     if None not in sn_regs:
         data["serial_number"] = (

--- a/givenergy_modbus/model/hv_bcu.py
+++ b/givenergy_modbus/model/hv_bcu.py
@@ -143,6 +143,13 @@ _V_CELL_BASE = 60  # IR(60+base .. 83+base) — 24 cell voltages, milli (÷1000)
 _T_CELL_BASE = 90  # IR(90+base .. 113+base) — 24 cell temps, deci (÷10)
 _SERIAL_BASE = 114  # IR(114+base .. 118+base) — 5-register module serial
 _SERIAL_LEN = 5
+# Plausibility bounds, mirroring the LV pack (BatteryRegisterGetter, battery.py). Shared
+# by the LUT Defs and the imperative decode. A non-zero raw outside these is corruption —
+# e.g. a serial byte read as a cell when a module stores its serial split across the cell
+# window (#378/#379: "HY" at IR110 decodes as t_cell_21 = 1852.1 °C). An all-zero raw is
+# treated as unset (kept as decoded, not None), matching the RegisterGetter convention.
+_V_CELL_MIN, _V_CELL_MAX = 1.0, 5.0
+_T_CELL_MIN, _T_CELL_MAX = -60.0, 150.0
 
 
 def module_cell_temp_serial_fields() -> dict[str, tuple[Any, None]]:
@@ -170,8 +177,8 @@ def cell_temp_serial_register_lut(base: int = 0) -> dict[str, Def]:
     """
     lut: dict[str, Def] = {}
     for i in range(_BMU_CELLS):
-        lut[f"v_cell_{i + 1:02d}"] = Def(C.milli, None, IR(_V_CELL_BASE + base + i), min=1.0, max=5.0)
-        lut[f"t_cell_{i + 1:02d}"] = Def(C.deci, None, IR(_T_CELL_BASE + base + i))
+        lut[f"v_cell_{i + 1:02d}"] = Def(C.milli, None, IR(_V_CELL_BASE + base + i), min=_V_CELL_MIN, max=_V_CELL_MAX)
+        lut[f"t_cell_{i + 1:02d}"] = Def(C.deci, None, IR(_T_CELL_BASE + base + i), min=_T_CELL_MIN, max=_T_CELL_MAX)
     lut["serial_number"] = Def(C.serial, None, *(IR(_SERIAL_BASE + base + j) for j in range(_SERIAL_LEN)))
     return lut
 
@@ -190,12 +197,23 @@ def decode_cells_temps_serial(register_cache, base: int = 0) -> dict[str, Any]:
     def _get(reg_idx: int) -> int | None:
         return register_cache.get(IR(reg_idx))
 
+    def _bounded(raw: int | None, scale: int, lo: float, hi: float) -> float | None:
+        """Decode raw/scale, but suppress non-zero values outside [lo, hi] to None.
+
+        Mirrors the RegisterGetter bounds handling: an all-zero raw is unset (kept as
+        the decoded 0.0), a non-zero out-of-range value is corruption and returns None.
+        """
+        if raw is None:
+            return None
+        val = raw / scale
+        if raw != 0 and not (lo <= val <= hi):
+            return None
+        return val
+
     for i in range(_BMU_CELLS):
-        v = _get(_V_CELL_BASE + base + i)
-        data[f"v_cell_{i + 1:02d}"] = v / 1000 if v is not None else None
+        data[f"v_cell_{i + 1:02d}"] = _bounded(_get(_V_CELL_BASE + base + i), 1000, _V_CELL_MIN, _V_CELL_MAX)
     for i in range(_BMU_CELLS):
-        t = _get(_T_CELL_BASE + base + i)
-        data[f"t_cell_{i + 1:02d}"] = t / 10 if t is not None else None
+        data[f"t_cell_{i + 1:02d}"] = _bounded(_get(_T_CELL_BASE + base + i), 10, _T_CELL_MIN, _T_CELL_MAX)
     sn_regs = [_get(_SERIAL_BASE + base + j) for j in range(_SERIAL_LEN)]
     if None not in sn_regs:
         data["serial_number"] = (

--- a/givenergy_modbus/model/inverter.py
+++ b/givenergy_modbus/model/inverter.py
@@ -941,7 +941,10 @@ class SinglePhaseInverterRegisterGetter(RegisterGetter):
         # is unreconciled (see #330), so no message decode here.
         "inverter_fault_code": Def(C.uint16, (C.hex, 4), IR(39)),
         "inverter_warning_code": Def(C.uint16, (C.hex, 4), IR(40)),
-        "t_inverter_heatsink": Def(C.deci, None, IR(41), min=-40.0, max=100.0),
+        # Temperatures are signed two's-complement deci (v4.1.6 register map 4.1.2:
+        # Inverter Temperature / CHG_Temper / Bat_Temper = "signed" 0.1c) — the negative
+        # floor is a real bound, so a genuine sub-zero ambient reading decodes correctly.
+        "t_inverter_heatsink": Def(C.int16, C.deci, IR(41), min=-40.0, max=100.0),
         # House load / consumption at the busbar, independently sensed — empirically NOT
         # a derived IR(24)−IR(30) identity (residual non-zero in 68% of samples, though
         # small and centred on zero). That residual is NOT the EPS branch: across 259
@@ -976,8 +979,8 @@ class SinglePhaseInverterRegisterGetter(RegisterGetter):
         "p_battery": Def(C.int16, None, IR(52)),
         "v_ac1_output": Def(C.deci, None, IR(53), min=0.0, max=500.0),  # might be v_eps_backup?
         "f_ac1_output": Def(C.centi, None, IR(54), min=40.0, max=70.0),  # might be f_eps_backup?
-        "t_charger": Def(C.deci, None, IR(55), min=-40.0, max=100.0),
-        "t_battery": Def(C.deci, None, IR(56), min=-40.0, max=100.0),
+        "t_charger": Def(C.int16, C.deci, IR(55), min=-40.0, max=100.0),
+        "t_battery": Def(C.int16, C.deci, IR(56), min=-40.0, max=100.0),
         "charger_warning_code": Def(C.uint16, None, IR(57)),
         "charger_warning_messages": Def(C.uint16, _charger_warning_code, IR(57)),
         # Inverter AC grid-terminal current; pairs with IR(24)/IR(43) (I×V ≈ IR43 VA),

--- a/givenergy_modbus/model/inverter_threephase.py
+++ b/givenergy_modbus/model/inverter_threephase.py
@@ -430,9 +430,10 @@ _THREE_PHASE_LUT = {
     # battery_type (IR) at IR(1121) — read-only decoded value alongside HR(1080)
     "battery_type_ir": Def(C.uint16, BatteryType, IR(1121)),
     "dc_status": Def(C.uint16, Status, IR(1124)),
-    "t_inverter": Def(C.deci, None, IR(1128), min=-60.0, max=150.0),
-    "t_boost": Def(C.deci, None, IR(1129), min=-60.0, max=150.0),
-    "t_buck_boost": Def(C.deci, None, IR(1130), min=-60.0, max=150.0),
+    # Signed two's-complement deci (v4.1.6 register map 4.1.2: NTC2/Boost/BuckBoost = int16).
+    "t_inverter": Def(C.int16, C.deci, IR(1128), min=-60.0, max=150.0),
+    "t_boost": Def(C.int16, C.deci, IR(1129), min=-60.0, max=150.0),
+    "t_buck_boost": Def(C.int16, C.deci, IR(1130), min=-60.0, max=150.0),
     "v_battery_bms": Def(C.deci, None, IR(1131), min=0.0, max=1000.0),
     # battery_soc shadows single-phase IR(59)
     "battery_soc": Def(C.uint16, None, IR(1132), min=0, max=100),

--- a/tests/client/test_mock_plant_integration.py
+++ b/tests/client/test_mock_plant_integration.py
@@ -227,6 +227,11 @@ def _assert_aio_redetect(plant):
     # LOAD_CONFIG_RANGES and polled ONLY by load_config; first capture to carry it
     # live. Pins the capability-gated table entry end-to-end (#293/#295).
     assert inv.battery_charge_limit_ac == 50
+    # Each module's split serial's "HY" prefix lands on t_cell_21's register; the
+    # bounds check (#379) suppresses that non-zero out-of-range raw to None rather than
+    # surfacing a ~1852 °C phantom.
+    for m in plant.aio_battery_modules:
+        assert m.t_cell_21 is None
     # All 4 HV modules decode through the live cycle, with distinct serials. The
     # fixture's serials are prefixless placeholders ("2414G000"): this BMU firmware
     # (BAAA0013) stores serials SPLIT on the wire (prefix at IR110, tail at

--- a/tests/model/test_battery.py
+++ b/tests/model/test_battery.py
@@ -181,6 +181,31 @@ def test_i_battery_signed_centi():
     assert discharging.i_battery == 41.83
 
 
+def test_cell_temps_signed_deci():
+    """Cell / MOS / min-max temps decode as signed int16 deci (v4.1.6 4.4.1.2).
+
+    A genuine sub-zero reading decodes to its negative value; the empty-slot sentinel
+    (0xF556 = -273.0 °C) and a positive reading both round-trip, with the sentinel
+    suppressed to None by the -60.0 floor.
+    """
+    b = Battery.from_register_cache(
+        RegisterCache(
+            {
+                IR(76): 65536 - 55,  # t_cells_01_04 = -5.5 °C (signed)
+                IR(77): 231,  # t_cells_05_08 = 23.1 °C
+                IR(81): 65536 - 100,  # t_bms_mosfet = -10.0 °C
+                IR(103): 0xF556,  # t_max = -273.0 °C empty-slot sentinel → None
+                IR(104): 205,  # t_min = 20.5 °C
+            }
+        )
+    )
+    assert b.t_cells_01_04 == -5.5
+    assert b.t_cells_05_08 == 23.1
+    assert b.t_bms_mosfet == -10.0
+    assert b.t_max is None
+    assert b.t_min == 20.5
+
+
 def test_energy_totals_deci_kwh():
     """IR(105/106) decode as unsigned 0.1 kWh lifetime energy totals (#238/#241).
 

--- a/tests/model/test_hv_bcu.py
+++ b/tests/model/test_hv_bcu.py
@@ -126,11 +126,13 @@ def test_bmu_index_0():
 
 
 def test_bmu_cell_decode_suppresses_out_of_bounds():
-    """Non-zero raw cell values outside the plausibility bounds decode to None (#379).
+    """Cell decode: unsigned voltages, SIGNED temps, out-of-range suppressed (#379).
 
-    A serial byte read as a cell (some BMU firmware stores the serial split across the
-    cell window, #378) produces a wildly-out-of-range value; a zero raw is kept as the
-    decoded 0.0 (unset, not corruption), matching the RegisterGetter bounds convention.
+    Temperatures are signed two's-complement per the firmware register map, so a genuine
+    sub-zero reading decodes correctly while the empty-slot sentinel (0xF556 = -273 °C)
+    and a serial byte misread as a cell (some firmware stores the serial split across the
+    cell window, #378) both fall outside the bounds and return None. A zero raw is kept as
+    the decoded 0.0 (unset, not corruption), matching the RegisterGetter convention.
     """
     cache = _cache(
         {
@@ -138,6 +140,8 @@ def test_bmu_cell_decode_suppresses_out_of_bounds():
             IR(61): 0,  # v_cell_02 raw 0 → unset, decoded 0.0 (not None)
             IR(62): 800,  # v_cell_03 = 0.8 V — below 1.0 floor → None
             IR(90): 250,  # t_cell_01 = 25.0 °C — in range, kept
+            IR(91): 0xFF9C,  # t_cell_02 = -10.0 °C (signed) — genuine sub-zero, kept
+            IR(92): 0xF556,  # t_cell_03 = -273.0 °C empty-slot sentinel → below floor → None
             IR(110): 0x4859,  # t_cell_21 = "HY" serial prefix → 1852.1 °C → None
             IR(111): 0,  # t_cell_22 raw 0 → 0.0 (not None)
         }
@@ -147,6 +151,8 @@ def test_bmu_cell_decode_suppresses_out_of_bounds():
     assert bmu.v_cell_02 == pytest.approx(0.0)  # type: ignore[attr-defined]
     assert bmu.v_cell_03 is None  # type: ignore[attr-defined]
     assert bmu.t_cell_01 == pytest.approx(25.0)  # type: ignore[attr-defined]
+    assert bmu.t_cell_02 == pytest.approx(-10.0)  # type: ignore[attr-defined]
+    assert bmu.t_cell_03 is None  # type: ignore[attr-defined]
     assert bmu.t_cell_21 is None  # type: ignore[attr-defined]
     assert bmu.t_cell_22 == pytest.approx(0.0)  # type: ignore[attr-defined]
 

--- a/tests/model/test_hv_bcu.py
+++ b/tests/model/test_hv_bcu.py
@@ -125,6 +125,32 @@ def test_bmu_index_0():
     assert bmu.serial_number == "ABCDEFGHI"  # type: ignore[attr-defined]
 
 
+def test_bmu_cell_decode_suppresses_out_of_bounds():
+    """Non-zero raw cell values outside the plausibility bounds decode to None (#379).
+
+    A serial byte read as a cell (some BMU firmware stores the serial split across the
+    cell window, #378) produces a wildly-out-of-range value; a zero raw is kept as the
+    decoded 0.0 (unset, not corruption), matching the RegisterGetter bounds convention.
+    """
+    cache = _cache(
+        {
+            IR(60): 3300,  # v_cell_01 = 3.300 V — in range, kept
+            IR(61): 0,  # v_cell_02 raw 0 → unset, decoded 0.0 (not None)
+            IR(62): 800,  # v_cell_03 = 0.8 V — below 1.0 floor → None
+            IR(90): 250,  # t_cell_01 = 25.0 °C — in range, kept
+            IR(110): 0x4859,  # t_cell_21 = "HY" serial prefix → 1852.1 °C → None
+            IR(111): 0,  # t_cell_22 raw 0 → 0.0 (not None)
+        }
+    )
+    bmu = Bmu.from_register_cache(cache, bmu_index=0)
+    assert bmu.v_cell_01 == pytest.approx(3.3)  # type: ignore[attr-defined]
+    assert bmu.v_cell_02 == pytest.approx(0.0)  # type: ignore[attr-defined]
+    assert bmu.v_cell_03 is None  # type: ignore[attr-defined]
+    assert bmu.t_cell_01 == pytest.approx(25.0)  # type: ignore[attr-defined]
+    assert bmu.t_cell_21 is None  # type: ignore[attr-defined]
+    assert bmu.t_cell_22 == pytest.approx(0.0)  # type: ignore[attr-defined]
+
+
 def test_bmu_index_is_a_label_not_a_stride():
     # Post-#265: every BMU reads its OWN device-address cache at base=0 (IR 60-118). bmu_index
     # is just a label; it no longer shifts the register window (the old 120*index stride read

--- a/tests/model/test_inverter.py
+++ b/tests/model/test_inverter.py
@@ -18,7 +18,7 @@ from givenergy_modbus.model.inverter import (
     inverter_address_for,
     resolve_model,
 )
-from givenergy_modbus.model.register import HR
+from givenergy_modbus.model.register import HR, IR
 from givenergy_modbus.model.register_cache import RegisterCache
 
 
@@ -31,6 +31,27 @@ def test_first_battery_serial_number_removed():
     assert "first_battery_serial_number" not in SinglePhaseInverter().model_dump()
     cache = RegisterCache({HR(8): 0x4843, HR(9): 0x3234, HR(10): 0x3134, HR(11): 0x4731, HR(12): 0x3637})
     assert "first_battery_serial_number" not in SinglePhaseInverter.from_register_cache(cache).model_dump()
+
+
+def test_inverter_temps_signed_deci():
+    """Inverter heatsink / charger / battery temps decode as signed int16 deci (#379).
+
+    v4.1.6 register map 4.1.2 marks IR41/55/56 as signed 0.1c. A positive reading is
+    unchanged; a genuine sub-zero ambient reading decodes to its negative value instead
+    of a huge positive that the max bound would suppress.
+    """
+    inv = SinglePhaseInverter.from_register_cache(
+        RegisterCache(
+            {
+                IR(41): 376,  # t_inverter_heatsink = 37.6 °C (positive, unchanged)
+                IR(55): 65536 - 55,  # t_charger = -5.5 °C (signed)
+                IR(56): 65536 - 123,  # t_battery = -12.3 °C (signed)
+            }
+        )
+    )
+    assert inv.t_inverter_heatsink == pytest.approx(37.6)
+    assert inv.t_charger == pytest.approx(-5.5)
+    assert inv.t_battery == pytest.approx(-12.3)
 
 
 def test_inverter():

--- a/tests/model/test_register_conventions.py
+++ b/tests/model/test_register_conventions.py
@@ -1,0 +1,63 @@
+"""Cross-model decode-convention invariants.
+
+These guard conventions that span every register map, so a new Def that violates one
+fails CI regardless of which model it lives in. Born from #379: several temperature
+fields declared a negative ``min`` bound but decoded as unsigned, so a genuine sub-zero
+reading wrapped to a huge positive and was silently suppressed. The firmware register map
+(v4.1.6) marks every temperature ``signed``; the invariant below generalises that.
+"""
+
+from givenergy_modbus.model.aio_battery import AioBatteryModuleRegisterGetter
+from givenergy_modbus.model.battery import BatteryRegisterGetter
+from givenergy_modbus.model.ems import EmsRegisterGetter
+from givenergy_modbus.model.gateway import GatewayV1RegisterGetter, GatewayV2RegisterGetter
+from givenergy_modbus.model.hv_bcu import BcuRegisterGetter, BmuRegisterGetter
+from givenergy_modbus.model.inverter import SinglePhaseInverterRegisterGetter
+from givenergy_modbus.model.inverter_threephase import ThreePhaseInverterRegisterGetter
+from givenergy_modbus.model.lv_bcu import LvBcuRegisterGetter
+from givenergy_modbus.model.meter import MeterRegisterGetter
+
+_GETTERS = {
+    "SinglePhaseInverter": SinglePhaseInverterRegisterGetter,
+    "ThreePhaseInverter": ThreePhaseInverterRegisterGetter,
+    "Battery": BatteryRegisterGetter,
+    "Bcu": BcuRegisterGetter,
+    "Bmu": BmuRegisterGetter,
+    "AioBatteryModule": AioBatteryModuleRegisterGetter,
+    "LvBcu": LvBcuRegisterGetter,
+    "Ems": EmsRegisterGetter,
+    "GatewayV1": GatewayV1RegisterGetter,
+    "GatewayV2": GatewayV2RegisterGetter,
+    "Meter": MeterRegisterGetter,
+}
+
+# Converters that yield a signed value: the width converters, and the power-factor
+# converters, which sign-convert internally (pf_signed wraps int16; pf applies a -1 offset).
+_SIGNED_CONVERTERS = {"int16", "int32", "pf", "pf_signed"}
+
+
+def _conv_name(c) -> str | None:
+    if c is None:
+        return None
+    if isinstance(c, tuple):
+        return _conv_name(c[0])
+    return getattr(c, "__name__", str(c))
+
+
+def test_negative_floor_fields_decode_signed():
+    """A Def declaring ``min < 0`` must decode signed — otherwise the floor is unreachable.
+
+    An unsigned decode can never produce a value below zero (a two's-complement negative
+    wraps to a large positive that the ``max`` bound suppresses), so a negative ``min`` on
+    an unsigned field is either dead or, worse, silently drops genuine negative readings.
+    """
+    offenders = []
+    for gname, getter in _GETTERS.items():
+        for attr, defn in getter.REGISTER_LUT.items():
+            if defn.min_value is None or defn.min_value >= 0:
+                continue
+            convs = {_conv_name(defn.pre_conv), _conv_name(defn.post_conv)}
+            if not (convs & _SIGNED_CONVERTERS):
+                addrs = [r._idx for r in defn.registers]
+                offenders.append(f"{gname}.{attr} IR{addrs} min={defn.min_value} convs={convs - {None}}")
+    assert not offenders, "negative-floor fields decoding unsigned:\n  " + "\n  ".join(offenders)

--- a/tests/model/test_three_phase_from_capture.py
+++ b/tests/model/test_three_phase_from_capture.py
@@ -153,10 +153,8 @@ def test_multi_module_bmu_per_cell_decode(multi_module_plant: Plant):
         # near-full LiFePO4 pack: all 24 cells in a tight band around 3.35 V
         assert all(3.3 < v < 3.4 for v in v_cells), f"BMU 0x{addr:02x} cell voltages {v_cells}"
     # Temperatures: modules 0x50-0x54 populate all 24 sensors; 0x55 populates only the
-    # first 12, and its split serial's "HY" prefix at IR(110) decodes as
-    # t_cell_21 = 1852.1 — the imperative decode applies no bounds (the LUT's declared
-    # min/max are inert), so the artefact passes through. Pinned as-is (characterisation);
-    # the decode-bounds gap is tracked as a follow-up.
+    # first 12. Its split serial's "HY" prefix at IR(110) decodes to a raw 0x4859, which
+    # the bounds check (#379) now suppresses to None rather than surfacing 1852.1 °C.
     for addr in range(0x50, 0x55):
         bmu = Bmu.from_register_cache(multi_module_plant.register_caches[addr])
         t_cells = [getattr(bmu, f"t_cell_{i:02d}") for i in range(1, 25)]
@@ -164,7 +162,7 @@ def test_multi_module_bmu_per_cell_decode(multi_module_plant: Plant):
     bmu_55 = Bmu.from_register_cache(multi_module_plant.register_caches[0x55])
     t_55 = [getattr(bmu_55, f"t_cell_{i:02d}") for i in range(1, 25)]
     assert all(25.0 < t < 40.0 for t in t_55[:12]), f"BMU 0x55 populated temps {t_55[:12]}"
-    assert t_55[20] == pytest.approx(1852.1)  # "HY" (0x4859) read as a temperature
+    assert t_55[20] is None  # "HY" (0x4859) out of range → suppressed (#379)
     # Serials are date-redacted placeholders. Module 0x55's firmware stores its serial
     # SPLIT on the wire ("HY" at IR(110), the tail at IR(115-118)) — preserved as
     # captured, so its decoded IR(114-118) serial carries no prefix (see README).


### PR DESCRIPTION
Closes #379.

## What

A reviewer flagged that a battery cell temp with a `-60` floor decoded unsigned — so a genuine sub-zero reading wraps to a huge positive and the `max` bound suppresses it to `None`. Rather than patch the one path, this reconciles **every** temperature register against the v4.1.6 firmware register map, which marks all temperatures `signed` 0.1c (§4.4.1.2 cells / `MOS_Temp` / `T_max`/`T_min`; §4.1.2 `Inverter Temperature`/`CHG_Temper`/`Bat_Temper` and `NTC2`/`Boost`/`BuckBoost`).

The discriminator: any Def with a **negative `min` bound that decodes unsigned** is a latent bug (an unsigned decode can never reach below zero, so the floor is dead or drops real negatives). Never observed in the field — LiFePO4 packs self-heat above the floor and no capture was taken in sub-zero ambient.

## Fixed (`deci` → `int16`+`deci`)

- **LV pack** (`battery.py`): cell temps, `t_bms_mosfet`, `t_max`/`t_min`
- **HV BMU / AIO** (`hv_bcu.py` shared decode): per-cell temps — imperative path sign-converts, LUT Defs match; voltages stay unsigned
- **Inverter** (`inverter.py`): `t_inverter_heatsink`/`t_charger`/`t_battery` (IR41/55/56)
- **Three-phase** (`inverter_threephase.py`): `t_inverter`/`t_boost`/`t_buck_boost` (IR1128–1130)

All fixture-verified as genuine temperatures (heatsink ~38–48 °C, boost ~41–45 °C). Positive temps decode identically, so no existing pins moved. The `0xF556 = -273.0 °C` empty-slot sentinel (`battery.py` already documented it) and the split-serial `HY` artefact (#378) both fall outside the bounds → `None`.

## Permanent guard

`tests/model/test_register_conventions.py::test_negative_floor_fields_decode_signed` iterates every model LUT and asserts each `min<0` field decodes signed — so a new unsigned-with-negative-floor Def fails CI. Power-factor (`pf`/`pf_signed`) and `int32` powers are recognised as already-signed.

## Deliberately left unsigned + follow-ups

- **`Bcu.cluster_cell_temperature` (IR68)** — the fixtures show it holds a **count** (modules × 12 temp sensors; IR67 = modules × 24 cells, a 2:1 ratio across a 4- and a 6-module stack), not a temperature. Annotated in place; field-identity rename tracked as a follow-up.
- **IR23** — doc marks it `wM3_Temper` (signed temp); we model it as `e_solar_diverter` (energy). A separate field-identity conflict, follow-up filed.

## Verification

- New regressions for the negative + `0xF556` sentinel cases on the BMU, LV pack, and inverter paths.
- Full suite (1560) + tox (py311–314, lint, format, build) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved battery, inverter, and BCU temperature decoding to correctly interpret readings as signed two’s-complement deci-degrees.
  * Added plausibility bounds so non-zero but out-of-range cell/temperature values are suppressed instead of shown as valid readings.
  * Preserves true zeros and treats missing registers as empty values.
* **Tests**
  * Added unit coverage for bounds-based suppression and signed temperature decoding.
  * Updated mock integration and multi-module inverter assertions to reflect the corrected behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->