### PR TITLE
fix(hv-bcu): rename mislabelled cluster count registers IR67/IR68

### DIFF
--- a/givenergy_modbus/model/hv_bcu.py
+++ b/givenergy_modbus/model/hv_bcu.py
@@ -61,13 +61,14 @@ class BcuRegisterGetter(RegisterGetter):
         "pack_software_version": Def(C.gateway_version, None, IR(60), IR(61), IR(62), IR(63)),
         "number_of_modules": Def(C.uint16, None, IR(64)),
         "cells_per_module": Def(C.uint16, None, IR(65)),
-        # NOTE: these two names are suspect. In both committed HV fixtures IR(67)/IR(68)
-        # read as counts, not measurements — IR(67) = modules × 24 (total cells), IR(68) =
-        # modules × 12 (total temp sensors), holding a 2:1 ratio across a 4- and a 6-module
-        # stack. So IR(68) is almost certainly a temp-SENSOR COUNT, not a temperature, and
-        # is deliberately left unsigned. Field-identity reconciliation tracked separately.
-        "cluster_cell_voltage": Def(C.uint16, None, IR(67)),
-        "cluster_cell_temperature": Def(C.uint16, None, IR(68)),
+        # IR(67)/IR(68) are COUNTS, not measurements (#382). Across both committed HV
+        # fixtures IR(67) = modules × 24 (total cells) and IR(68) = modules × 12 (total
+        # temperature sensors) — a clean 2:1 ratio holding on a 4- and a 6-module stack,
+        # and the ÷12 is independently confirmed by a module populating exactly 12 temp
+        # sensors. They were mis-modelled as cluster_cell_voltage/cluster_cell_temperature
+        # (both kept as deprecated @property aliases on Bcu).
+        "total_cell_count": Def(C.uint16, None, IR(67)),
+        "total_temperature_sensor_count": Def(C.uint16, None, IR(68)),
         "status": Def(C.uint16, None, IR(70)),
         "status_label": Def(C.uint16, _bcu_status_from, IR(70)),
         "battery_voltage": Def(C.deci, None, IR(73), min=0.0, max=1000.0),
@@ -134,6 +135,30 @@ class Bcu(_BcuBase, RegisterMetadataMixin):  # type: ignore[misc,valid-type]
         """Try to detect if an HV BCU is present based on its attributes."""
         v = self.pack_software_version  # type: ignore[attr-defined]
         return v not in (None, "", "          ") and not all(c == "0" for c in (v or ""))
+
+    # IR(67)/IR(68) were mis-modelled as cluster_cell_voltage / cluster_cell_temperature;
+    # fixtures show they are cell / temperature-sensor COUNTS (#382). Plain @property (not
+    # @computed_field) so the deprecated aliases don't appear in model_dump() output.
+    @property
+    def cluster_cell_voltage(self) -> int | None:
+        """Deprecated: IR(67) is a total cell count, not a voltage. Use `total_cell_count`."""
+        warnings.warn(
+            "Bcu.cluster_cell_voltage is deprecated; IR(67) is a cell count — use total_cell_count",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.total_cell_count  # type: ignore[attr-defined,no-any-return]
+
+    @property
+    def cluster_cell_temperature(self) -> int | None:
+        """Deprecated: IR(68) is a temp-sensor count, not a temperature. Use `total_temperature_sensor_count`."""
+        warnings.warn(
+            "Bcu.cluster_cell_temperature is deprecated; IR(68) is a temperature-sensor count — "
+            "use total_temperature_sensor_count",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.total_temperature_sensor_count  # type: ignore[attr-defined,no-any-return]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/model/test_hv_bcu.py
+++ b/tests/model/test_hv_bcu.py
@@ -80,6 +80,27 @@ def test_bcu_is_valid_empty_version_string():
     assert bcu.is_valid() is False
 
 
+def test_bcu_total_counts_decode():
+    """IR(67)/IR(68) are cell / temp-sensor COUNTS, not voltage/temperature (#382)."""
+    bcu = Bcu.from_register_cache(_cache({IR(67): 144, IR(68): 72}))
+    assert bcu.total_cell_count == 144  # type: ignore[attr-defined]
+    assert bcu.total_temperature_sensor_count == 72  # type: ignore[attr-defined]
+
+
+def test_bcu_cluster_names_deprecated_alias():
+    """The old cluster_cell_voltage/temperature names warn and forward to the counts."""
+    bcu = Bcu.from_register_cache(_cache({IR(67): 96, IR(68): 48}))
+    with pytest.warns(DeprecationWarning, match="cluster_cell_voltage is deprecated"):
+        assert bcu.cluster_cell_voltage == 96  # type: ignore[attr-defined]
+    with pytest.warns(DeprecationWarning, match="cluster_cell_temperature is deprecated"):
+        assert bcu.cluster_cell_temperature == 48  # type: ignore[attr-defined]
+    # deprecated aliases stay out of the serialised model
+    dumped = bcu.model_dump()
+    assert "cluster_cell_voltage" not in dumped
+    assert "cluster_cell_temperature" not in dumped
+    assert dumped["total_cell_count"] == 96
+
+
 def test_bcu_status_label_decode():
     # Every named BCU_STATUS code maps to its label; unknown codes degrade to None.
     assert _bcu_status_from(0) is BcuStatus.BMS_INITIALISING


### PR DESCRIPTION
Closes #382.

## What

`BcuRegisterGetter` modelled IR(67)/IR(68) as `cluster_cell_voltage` / `cluster_cell_temperature`, but the committed HV fixtures show they hold **counts**, not measurements:

| Plant | modules | IR(67) | IR(68) |
|---|---|---|---|
| three_phase_hv_a | 6 | 144 (= 6 × 24) | 72 (= 6 × 12) |
| aio_a | 4 | 96 (= 4 × 24) | 48 (= 4 × 12) |

IR(67) = total cells (24/module), IR(68) = total temperature sensors (12/module) — a clean 2:1 ratio across a 4- and a 6-module stack, nothing like the per-cell readings (~3.3 V, ~25–35 °C). The ÷12 is independently corroborated by module 0x55 populating exactly 12 temp sensors, and `cells_per_module` (IR65) is unpopulated so these are the real totals.

Renamed to `total_cell_count` / `total_temperature_sensor_count`. The old names stay as **deprecated `@property` aliases** (plain `@property`, so they're absent from `model_dump()`), forwarding to the new fields with a `DeprecationWarning` — same pattern as the other register renames.

## Tests

- `test_bcu_total_counts_decode` (count semantics) and `test_bcu_cluster_names_deprecated_alias` (both aliases warn, forward, and stay out of `model_dump`).
- Full suite (1562) + tox green.

Surfaced during the #379 temperature-signedness reconciliation. The sibling identity issue #383 (IR23) stays open pending a targeted capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer count fields for battery module data, showing total cell count and total temperature sensor count.
  * Legacy field names still work, but now display a deprecation warning when used.

* **Bug Fixes**
  * Updated serialised output so the newer count fields appear consistently, while old alias names are no longer included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->