### PR TITLE
feat(model): add remaining battery energy fields

### DIFF
--- a/givenergy_modbus/model/battery.py
+++ b/givenergy_modbus/model/battery.py
@@ -1,7 +1,7 @@
 from enum import IntEnum
 from typing import ClassVar
 
-from pydantic import ConfigDict, create_model
+from pydantic import ConfigDict, computed_field, create_model
 
 from givenergy_modbus.model.register import (
     IR,
@@ -104,6 +104,10 @@ _BatteryBase = create_model(  # type: ignore[call-overload]
 )
 
 
+# LiFePO4 nominal cell voltage — 16 cells × 3.2 V = the GivEnergy "51.2 V" LV pack convention.
+_LIFEPO4_NOMINAL_CELL_V = 3.2
+
+
 class Battery(_BatteryBase, RegisterMetadataMixin):  # type: ignore[misc,valid-type]
     """GivEnergy battery data model."""
 
@@ -117,6 +121,39 @@ class Battery(_BatteryBase, RegisterMetadataMixin):  # type: ignore[misc,valid-t
     def is_valid(self) -> bool:
         """Try to detect if a battery exists based on its attributes."""
         return is_valid_serial(self.serial_number)  # type: ignore[attr-defined]
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def remaining_energy_nominal_wh(self) -> int | None:
+        """Remaining stored energy (Wh), nominal-voltage basis: cap_remaining × num_cells × 3.2 V.
+
+        Nominal voltage is stable across load/SOC (the basis nameplate capacity is quoted on),
+        so this is the figure to sum for a slowly-varying "remaining energy" reading (#374). If
+        the pack doesn't report num_cells, fall back to the measured pack voltage so it still
+        contributes to a plant-level sum rather than silently dropping — the exact failure mode
+        #318 is about. None if cap_remaining is None or no voltage basis is available.
+        """
+        cap = self.cap_remaining  # type: ignore[attr-defined]
+        if cap is None:
+            return None
+        nominal_v = self.num_cells * _LIFEPO4_NOMINAL_CELL_V if self.num_cells else self.v_out  # type: ignore[attr-defined]
+        if nominal_v is None:
+            return None
+        return round(cap * nominal_v)
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def remaining_energy_measured_wh(self) -> int | None:
+        """Remaining stored energy (Wh), measured-voltage basis: cap_remaining × v_out.
+
+        Instantaneous; fluctuates ~2-3% with SOC and sags under load. None if cap_remaining or
+        v_out is None.
+        """
+        cap = self.cap_remaining  # type: ignore[attr-defined]
+        v_out = self.v_out  # type: ignore[attr-defined]
+        if cap is None or v_out is None:
+            return None
+        return round(cap * v_out)
 
 
 class State(IntEnum):

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -1894,6 +1894,24 @@ class Plant(GivEnergyBaseModel):
         return [Battery.from_register_cache(self.register_caches[i + 0x32]) for i in range(self.number_batteries)]
 
     @property
+    def remaining_battery_energy_wh(self) -> int | None:
+        """Total remaining battery energy (Wh) summed over this Plant's LV packs (#374).
+
+        Nominal-voltage basis (``Battery.remaining_energy_nominal_wh``). This sums every pack on
+        *this* dongle, so on an inverter with a primary/secondary chain it includes the secondary
+        pack the EMS controller's own figure (``Ems.remaining_battery_wh``, IR2091) drops.
+
+        Returns ``None`` (not ``0``) when no pack decodes — e.g. an EMS-controller dongle has no
+        LV battery sub-bus, so its Plant returns ``None`` rather than a misleading ``0 Wh``.
+
+        Scope: one Plant is one dongle, and battery sub-bus addresses collide across managed
+        inverters (each reuses 0x32-0x37), so this cannot span inverters. A consumer holding
+        several inverter connections sums their per-Plant values for the site total.
+        """
+        present = [e for e in (b.remaining_energy_nominal_wh for b in self.batteries) if e is not None]
+        return sum(present) if present else None
+
+    @property
     def hv_stacks(self) -> list[HvStack]:
         """Return HV battery stacks (BCU + per-module BMUs) for HV systems; [] for LV systems.
 

--- a/tests/model/test_battery.py
+++ b/tests/model/test_battery.py
@@ -3,6 +3,53 @@ from givenergy_modbus.model.register import IR
 from givenergy_modbus.model.register_cache import RegisterCache
 
 
+def _energy_cache(overrides: dict | None = None) -> RegisterCache:
+    """A minimal cache with the fields the remaining-energy computed fields read.
+
+    cap_remaining is uint32 centi at IR(88)/IR(89); v_out is uint32 milli at IR(82)/IR(83);
+    num_cells is uint16 at IR(97). Defaults give a 16S pack at 47.81 Ah / 52.203 V. An
+    override value of None drops that register from the cache (simulating an absent read).
+    """
+    values = {
+        IR(97): 16,  # num_cells
+        IR(88): 0,
+        IR(89): 4781,  # cap_remaining = 47.81 Ah (centi)
+        IR(82): 0,
+        IR(83): 52203,  # v_out = 52.203 V (milli)
+    }
+    values.update(overrides or {})
+    return RegisterCache({k: v for k, v in values.items() if v is not None})
+
+
+def test_remaining_energy_nominal_wh():
+    """cap_remaining (Ah) x nominal voltage (num_cells x 3.2 V), in Wh (#374)."""
+    b = Battery.from_register_cache(_energy_cache())
+    assert b.remaining_energy_nominal_wh == 2448  # 47.81 Ah x 51.2 V
+
+
+def test_remaining_energy_measured_wh():
+    """cap_remaining (Ah) x measured v_out (V), in Wh (#374)."""
+    b = Battery.from_register_cache(_energy_cache())
+    assert b.remaining_energy_measured_wh == 2496  # 47.81 Ah x 52.203 V
+
+
+def test_remaining_energy_none_when_cap_remaining_absent():
+    b = Battery.from_register_cache(_energy_cache({IR(88): None, IR(89): None}))
+    assert b.remaining_energy_nominal_wh is None
+    assert b.remaining_energy_measured_wh is None
+
+
+def test_remaining_energy_nominal_falls_back_to_measured_when_num_cells_absent():
+    """A pack that doesn't report num_cells still contributes (via v_out) rather than dropping."""
+    b = Battery.from_register_cache(_energy_cache({IR(97): None}))
+    assert b.remaining_energy_nominal_wh == 2496  # falls back to measured basis
+
+
+def test_remaining_energy_nominal_none_when_num_cells_and_v_out_absent():
+    b = Battery.from_register_cache(_energy_cache({IR(97): None, IR(82): None, IR(83): None}))
+    assert b.remaining_energy_nominal_wh is None
+
+
 def test_from_registers(register_cache):
     """Ensure we can return a dict view of battery data."""
     assert Battery.from_register_cache(register_cache).model_dump() == {
@@ -17,6 +64,8 @@ def test_from_registers(register_cache):
         "num_cells": 16,
         "num_cycles": 12,
         "cap_remaining": 18.04,
+        "remaining_energy_nominal_wh": 924,
+        "remaining_energy_measured_wh": 903,
         "serial_number": "BG1234G567",
         "soc": 9,
         "status_1": 0,
@@ -71,6 +120,8 @@ def test_from_registers_actual_data(register_cache_battery_daytime_discharging):
         "num_cells": 16,
         "num_cycles": 23,
         "cap_remaining": 131.42,
+        "remaining_energy_nominal_wh": 6729,
+        "remaining_energy_measured_wh": 6810,
         "serial_number": "BG1234G567",
         "soc": 67,
         "status_1": 0,
@@ -128,6 +179,8 @@ def test_from_registers_unsure_data(register_cache_battery_unsure):
         "i_battery": 0.0,
         "num_cells": 0,
         "num_cycles": 0,
+        "remaining_energy_nominal_wh": 0,
+        "remaining_energy_measured_wh": 0,
         "serial_number": "",
         "soc": 0,
         "status_1": 0,
@@ -247,6 +300,8 @@ def test_empty():
             "i_battery": None,
             "num_cells": None,
             "num_cycles": None,
+            "remaining_energy_nominal_wh": None,
+            "remaining_energy_measured_wh": None,
             "serial_number": None,
             "soc": None,
             "status_1": None,

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -1487,6 +1487,8 @@ def test_from_actual():
         "num_cells": 16,
         "num_cycles": 116,
         "cap_remaining": 110.71,
+        "remaining_energy_nominal_wh": 5668,
+        "remaining_energy_measured_wh": 5707,
         "serial_number": "BG1234G567",
         "soc": 58,
         "status_1": 0,

--- a/tests/model/test_plant_accessors.py
+++ b/tests/model/test_plant_accessors.py
@@ -119,6 +119,16 @@ def test_remaining_battery_energy_wh_skips_undecodable_packs():
     assert plant.remaining_battery_energy_wh == 2448
 
 
+def test_remaining_battery_energy_wh_is_attribute_only_not_in_model_dump():
+    """Derived accessor: attribute-accessible but excluded from the raw-state model_dump,
+    consistent with the sibling device accessors (inverter/batteries/ems/hv_stacks). A
+    SOC-varying derivation does not belong in the plant's dumpable/persistable state."""
+    plant = _plant_with_caps(device_type=Model.HYBRID, lv_battery_addresses=[0x32])
+    _prime(plant, 0x32, _PACK_A)
+    assert plant.remaining_battery_energy_wh == 2448  # attribute access works
+    assert "remaining_battery_energy_wh" not in plant.model_dump()
+
+
 @pytest.mark.timeout(15)
 def test_remaining_battery_energy_wh_fixture_backed():
     """Real 2x Giv-Bat 5.2 capture: the two packs sum to ~5087 Wh nominal (#374)."""

--- a/tests/model/test_plant_accessors.py
+++ b/tests/model/test_plant_accessors.py
@@ -91,6 +91,48 @@ def test_batteries_empty_without_capabilities_and_no_valid_data():
 
 
 # ---------------------------------------------------------------------------
+# plant.remaining_battery_energy_wh — per-dongle nominal sum (#374)
+# ---------------------------------------------------------------------------
+
+_PACK_A = {IR(97): 16, IR(88): 0, IR(89): 4781, IR(82): 0, IR(83): 52203}  # 47.81 Ah, 16S → 2448 Wh
+_PACK_B = {IR(97): 16, IR(88): 0, IR(89): 5155, IR(82): 0, IR(83): 52700}  # 51.55 Ah, 16S → 2639 Wh
+
+
+def test_remaining_battery_energy_wh_sums_packs_on_the_dongle():
+    """Sums remaining_energy_nominal_wh across all packs — the primary/secondary chain IR2091 drops."""
+    plant = _plant_with_caps(device_type=Model.HYBRID, lv_battery_addresses=[0x32, 0x33])
+    _prime(plant, 0x32, _PACK_A)
+    _prime(plant, 0x33, _PACK_B)
+    assert plant.remaining_battery_energy_wh == 2448 + 2639  # 5087
+
+
+def test_remaining_battery_energy_wh_none_when_no_batteries():
+    """An EMS-dongle Plant (no LV battery sub-bus) returns None, not 0 — signals 'sum the inverters'."""
+    assert Plant().remaining_battery_energy_wh is None
+
+
+def test_remaining_battery_energy_wh_skips_undecodable_packs():
+    """A pack whose energy can't be computed is skipped, not counted as 0."""
+    plant = _plant_with_caps(device_type=Model.HYBRID, lv_battery_addresses=[0x32, 0x33])
+    _prime(plant, 0x32, _PACK_A)
+    _prime(plant, 0x33, {IR(60): 1})  # present but no cap_remaining → remaining_energy is None
+    assert plant.remaining_battery_energy_wh == 2448
+
+
+@pytest.mark.timeout(15)
+def test_remaining_battery_energy_wh_fixture_backed():
+    """Real 2x Giv-Bat 5.2 capture: the two packs sum to ~5087 Wh nominal (#374)."""
+    from pathlib import Path
+
+    from givenergy_modbus.testing.mock_plant import plant_from_capture
+
+    cap = Path(__file__).parents[1] / "fixtures" / "captures" / "ems_2_inv_3_bat_a" / "ac_arm282_2x_givbat52_30min.log"
+    plant = plant_from_capture(cap)
+    plant.capabilities = PlantCapabilities(device_type=Model.AC, lv_battery_addresses=[0x32, 0x33])
+    assert plant.remaining_battery_energy_wh == 5087
+
+
+# ---------------------------------------------------------------------------
 # plant.hv_stacks
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #374.

## What

Adds a correct "remaining battery energy" figure that includes **every** pack — the remedy for the #318 EMS undercount — as decode-side model fields. No polling change; `IR2091` / `Ems.remaining_battery_wh` untouched.

- **`Battery.remaining_energy_nominal_wh`** — `cap_remaining (Ah) × num_cells × 3.2 V`. Nominal voltage is stable across load/SOC (the basis nameplate capacity is quoted on), so it's the figure to sum for a slowly-varying reading. If a pack doesn't report `num_cells`, falls back to measured `v_out` so it still contributes rather than silently dropping — the exact failure mode #318 is about.
- **`Battery.remaining_energy_measured_wh`** — `cap_remaining × v_out`, instantaneous (fluctuates ~2–3% with SOC / load).
- **`Plant.remaining_battery_energy_wh`** — sums the nominal field over the Plant's LV packs. On a primary/secondary chain this includes the secondary pack IR2091 drops. `None` (not `0`) when no pack decodes, so an EMS-controller dongle signals "sum the inverter dongles" rather than a misleading `0 Wh`.

Both Battery fields are whole **Wh** (`int`), matching the `remaining_battery_wh` sibling and keeping `model_dump()` stable.

## The topology boundary (why this shape)

Exploring `ems_2_inv_3_bat_a` (four separate dongle captures) confirmed the EMS controller and its managed inverters sit on **physically separate buses, each behind its own dongle**. A `Plant` is one dongle connection, and battery sub-bus addresses collide across inverters (each reuses `0x32–0x37`), so **no single Plant can hold all packs**. This PR fixes the **within-dongle** undercount (a primary/secondary chain has both packs on its dongle); **cross-inverter aggregation stays with the consumer** (hass), which holds the per-inverter connections. Documented in the `Plant` property docstring.

## Tests (TDD)

Every field written test-first. Battery: nominal, measured, `None`-cap, `num_cells`-absent → `v_out` fallback, both-absent → `None`. Plant: synthetic multi-pack sum, `None` on empty, skips undecodable packs, and a **fixture-backed** test decoding the real 2× Giv-Bat 5.2 capture → **5087 Wh** nominal (the sum IR2091 collapses). Full suite (1571) + tox (py311–314, lint, format, build) green.

## Consumer handoff (post-merge)

Boundary note to hass: repoint the "EMS Remaining Battery Energy" sensor off `Ems.remaining_battery_wh` (IR2091) to a cross-inverter sum of each managed inverter's `Plant.remaining_battery_energy_wh`. Library figure is nominal-basis Wh; IR2091 stays available for diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added battery remaining-energy values in Wh, calculated using both nominal and measured voltage bases.
  * Added a plant-level total for remaining battery energy across connected low-voltage packs.

* **Bug Fixes**
  * Improved handling of missing battery data, returning no value where key inputs are unavailable.
  * Updated plant totals to ignore undecodable packs instead of counting them as zero.

* **Tests**
  * Expanded coverage for battery energy calculations and plant-level energy totals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->