### PR TITLE
feat(model): placeholders for known-but-unreachable battery/meter addresses (#213)

### DIFF
--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -1884,12 +1884,18 @@ class Plant(GivEnergyBaseModel):
 
     @property
     def batteries(self) -> list[Battery]:
-        """Return Battery models for the Plant."""
+        """Return Battery models for the Plant.
+
+        A capabilities-listed address with no register cache yields an all-None placeholder
+        Battery at its index rather than being dropped (#213) — a transiently-absent pack
+        (e.g. a BMS slow to answer after a restart) stays present-but-unavailable and index-
+        aligned instead of shifting its siblings' entities. Subsequent refresh()es populate it
+        if it responds.
+        """
         if self.capabilities:
             return [
-                Battery.from_register_cache(self.register_caches[addr])
+                Battery.from_register_cache(self.register_caches.get(addr, RegisterCache()))
                 for addr in self.capabilities.lv_battery_addresses
-                if addr in self.register_caches
             ]
         return [Battery.from_register_cache(self.register_caches[i + 0x32]) for i in range(self.number_batteries)]
 
@@ -1976,13 +1982,17 @@ class Plant(GivEnergyBaseModel):
 
     @property
     def meters(self) -> dict[int, Meter]:
-        """Return Meter models keyed by device address."""
+        """Return Meter models keyed by device address.
+
+        A listed-but-uncached meter address yields an all-None placeholder Meter at its key
+        rather than being omitted (#213), so a transiently-absent meter reads as present-but-
+        unavailable and is repopulated on a later refresh() if it responds.
+        """
         if not self.capabilities or not self.capabilities.meter_addresses:
             return {}
         return {
-            addr: Meter.from_register_cache(self.register_caches[addr])
+            addr: Meter.from_register_cache(self.register_caches.get(addr, RegisterCache()))
             for addr in self.capabilities.meter_addresses
-            if addr in self.register_caches
         }
 
     @property

--- a/tests/model/test_plant_accessors.py
+++ b/tests/model/test_plant_accessors.py
@@ -73,11 +73,19 @@ def test_batteries_uses_capabilities_address_list():
     assert len(plant.batteries) == 2
 
 
-def test_batteries_skips_missing_caches():
+def test_batteries_placeholder_for_listed_but_uncached_address():
+    """A listed-but-uncached address yields an all-None placeholder Battery, index-aligned (#213).
+
+    A transiently-absent pack (BMS slow to answer after a restart) stays present-but-unavailable
+    rather than being dropped and index-shifting its siblings' entities.
+    """
     plant = _plant_with_caps(device_type=Model.HYBRID, lv_battery_addresses=[0x32, 0x33])
     _prime(plant, 0x32, {IR(60): 1})
-    # 0x33 cache absent — should not raise, just omit it.
-    assert len(plant.batteries) == 1
+    # 0x33 cache absent — placeholder, not dropped: length + index alignment preserved.
+    bats = plant.batteries
+    assert len(bats) == 2
+    assert bats[1].v_cell_01 is None  # type: ignore[attr-defined]
+    assert bats[1].is_valid() is False
 
 
 def test_number_batteries_uses_capabilities():
@@ -225,11 +233,14 @@ def test_meters_returns_dict_keyed_by_address():
     assert all(isinstance(m, Meter) for m in meters.values())
 
 
-def test_meters_skips_missing_caches():
+def test_meters_placeholder_for_listed_but_uncached_address():
+    """A listed-but-uncached meter address yields an all-None placeholder Meter (#213)."""
     plant = _plant_with_caps(device_type=Model.HYBRID, meter_addresses=[0x01, 0x02])
     _prime(plant, 0x01, {IR(60): 100})
-    # 0x02 absent — only one meter returned.
-    assert set(plant.meters.keys()) == {0x01}
+    # 0x02 absent — placeholder at its key, present-but-unavailable, not omitted.
+    meters = plant.meters
+    assert set(meters.keys()) == {0x01, 0x02}
+    assert meters[0x02].v_phase_1 is None  # type: ignore[attr-defined]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #213.

## What

`Plant.batteries` and `Plant.meters` used to silently drop any
capabilities-listed address whose register cache was empty. A battery that
stopped responding just vanished from the list — the consumer couldn't tell
"present but unreachable this poll" from "never existed".

Both accessors now emit an all-None placeholder — `from_register_cache(RegisterCache())` — for every capabilities-listed address, whether or not it responded. Index and key alignment is preserved. On a placeholder, `is_valid()` is `False` and every decoded field is `None`, so a consumer can distinguish the two cases.

## Scope

- **Batteries + meters only.** LV batteries are the demonstrated case of the disappearing-entry behaviour, and meters were named in the issue. No presence-marker gating — the placeholder is keyed purely off the capabilities address list.
- No production change beyond the two accessors; no new public types.

## Behaviour change (release-notes flag)

`len(plant.batteries)` now equals `len(capabilities.lv_battery_addresses)` rather than the count of *responding* packs, and `plant.meters` is keyed by every meter address, not just reachable ones. Anything iterating these needs to guard on `.is_valid()` (or a `None` field) rather than assuming every entry decodes. I'll flag this to the hass and cli agents once it lands.

## Tests

`tests/model/test_plant_accessors.py` — the two former "skips missing caches" tests are flipped to assert the placeholder contract (list length, `is_valid()` False, a representative field `None`). Full suite green (1587), tox green (py313/py314/format/lint/build).