### PR TITLE
feat(testing): MockPlant.from_spec — declarative synthetic register state (#324)

### DIFF
--- a/givenergy_modbus/testing/mock_plant.py
+++ b/givenergy_modbus/testing/mock_plant.py
@@ -227,7 +227,12 @@ def _make_device_serials_distinct(plant: Plant) -> None:
         )
 
 
-def _verify_spec_commits(spec: dict[int, dict[tuple[type[Register], int], Sequence[int]]]) -> None:
+def _verify_spec_commits(
+    spec: dict[int, dict[tuple[type[Register], int], Sequence[int]]],
+    *,
+    inverter_serial: str = _FALLBACK_SERIAL,
+    adapter_serial: str = _FALLBACK_SERIAL,
+) -> None:
     """Round-trip every HR/IR bank in *spec* through a scratch ``Plant.update()`` (#324).
 
     Feeds each bank twice — the second pass is the corroborating re-read that commits a
@@ -235,6 +240,10 @@ def _verify_spec_commits(spec: dict[int, dict[tuple[type[Register], int], Sequen
     landed in the plant's caches. Raises ValueError naming the failures, so a synthetic
     bank the commit guards would silently reject (e.g. an internally-impossible battery
     frame, #350) fails fast at construction instead of serving state no client can ingest.
+
+    The envelope serials mirror what the built mock will actually serve, so verification
+    replicates serve-time inputs exactly (they don't gate commits today — update() only
+    adopts them as state — but fidelity here is free).
     """
     from givenergy_modbus.pdu.read_registers import (
         ReadHoldingRegistersResponse,
@@ -264,17 +273,19 @@ def _verify_spec_commits(spec: dict[int, dict[tuple[type[Register], int], Sequen
                     register_count=len(values),
                     register_values=list(values),
                     # Envelope serials a wire decode would carry; update() reads them.
-                    inverter_serial_number=_FALLBACK_SERIAL,
-                    data_adapter_serial_number=_FALLBACK_SERIAL,
+                    inverter_serial_number=inverter_serial or _FALLBACK_SERIAL,
+                    data_adapter_serial_number=adapter_serial or _FALLBACK_SERIAL,
                 )
                 plant.update(pdu)
 
+    _empty = RegisterCache()
     failures = [
         f"0x{device_address:02x}:{reg_cls.__name__}({base + i})"
         for device_address, banks in spec.items()
+        for cache in (plant.register_caches.get(device_address, _empty),)
         for (reg_cls, base), values in banks.items()
         for i, value in enumerate(values)
-        if plant.register_caches.get(device_address, RegisterCache()).get(reg_cls(base + i)) != value
+        if cache.get(reg_cls(base + i)) != value
     ]
     if failures:
         raise ValueError(
@@ -396,7 +407,7 @@ class MockPlant:
                         )
                     cache[reg_cls(base + i)] = value
         if verify:
-            _verify_spec_commits(spec)
+            _verify_spec_commits(spec, inverter_serial=inverter_serial, adapter_serial=adapter_serial)
         return cls(devices, inverter_serial=inverter_serial, adapter_serial=adapter_serial)
 
     # -- serving ---------------------------------------------------------------

--- a/givenergy_modbus/testing/mock_plant.py
+++ b/givenergy_modbus/testing/mock_plant.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import logging
+from collections.abc import Sequence
 from pathlib import Path
 from typing import cast
 
@@ -226,6 +227,65 @@ def _make_device_serials_distinct(plant: Plant) -> None:
         )
 
 
+def _verify_spec_commits(spec: dict[int, dict[tuple[type[Register], int], Sequence[int]]]) -> None:
+    """Round-trip every HR/IR bank in *spec* through a scratch ``Plant.update()`` (#324).
+
+    Feeds each bank twice — the second pass is the corroborating re-read that commits a
+    cold-start-held battery bank (#289) — then asserts every specced register actually
+    landed in the plant's caches. Raises ValueError naming the failures, so a synthetic
+    bank the commit guards would silently reject (e.g. an internally-impossible battery
+    frame, #350) fails fast at construction instead of serving state no client can ingest.
+    """
+    from givenergy_modbus.pdu.read_registers import (
+        ReadHoldingRegistersResponse,
+        ReadInputRegistersResponse,
+    )
+
+    pdu_for: dict[type[Register], type] = {HR: ReadHoldingRegistersResponse, IR: ReadInputRegistersResponse}
+    unsupported = sorted(
+        f"0x{dev:02x}:{reg_cls.__name__}({base})"
+        for dev, banks in spec.items()
+        for (reg_cls, base) in banks
+        if reg_cls not in pdu_for
+    )
+    if unsupported:
+        raise ValueError(
+            f"verify=True can only round-trip HR/IR banks (they are what exists on the read wire); "
+            f"got {', '.join(unsupported)}. Seed other register classes with verify=False."
+        )
+
+    plant = Plant()
+    for _pass in range(2):  # second feed = the corroborating cold-start re-read (#289)
+        for device_address, banks in spec.items():
+            for (reg_cls, base), values in banks.items():
+                pdu = pdu_for[reg_cls](
+                    device_address=device_address,
+                    base_register=base,
+                    register_count=len(values),
+                    register_values=list(values),
+                    # Envelope serials a wire decode would carry; update() reads them.
+                    inverter_serial_number=_FALLBACK_SERIAL,
+                    data_adapter_serial_number=_FALLBACK_SERIAL,
+                )
+                plant.update(pdu)
+
+    failures = [
+        f"0x{device_address:02x}:{reg_cls.__name__}({base + i})"
+        for device_address, banks in spec.items()
+        for (reg_cls, base), values in banks.items()
+        for i, value in enumerate(values)
+        if plant.register_caches.get(device_address, RegisterCache()).get(reg_cls(base + i)) != value
+    ]
+    if failures:
+        raise ValueError(
+            f"{len(failures)} specced register(s) were rejected by the commit guards and never "
+            f"landed in Plant state: {', '.join(failures[:12])}"
+            + (" …" if len(failures) > 12 else "")
+            + ". The served state would be invisible to a real client; fix the bank values "
+            "(or pass verify=False to serve it anyway)."
+        )
+
+
 class MockPlant:
     """A TCP server impersonating a GivEnergy plant, seeded from a capture."""
 
@@ -291,6 +351,43 @@ class MockPlant:
             inverter_serial=plant.inverter_serial_number,
             adapter_serial=plant.data_adapter_serial_number,
         )
+
+    @classmethod
+    def from_spec(
+        cls,
+        spec: dict[int, dict[tuple[type[Register], int], Sequence[int]]],
+        *,
+        verify: bool = True,
+        inverter_serial: str = _FALLBACK_SERIAL,
+        adapter_serial: str = _FALLBACK_SERIAL,
+    ) -> MockPlant:
+        """Build a mock from a pure register spec — no base capture required (#324).
+
+        *spec* maps ``device_address → {(HR|IR|MR, base_register): values}``; each bank
+        seeds ``register_class(base + i) → values[i]``. Together with :meth:`start` this
+        turns arbitrary synthetic state into something the real GE app (or this
+        library's client) can be driven against.
+
+        With ``verify`` (the default), every HR/IR bank is round-tripped through a
+        scratch ``Plant.update()`` first — proving the state would actually *commit*
+        past the client-side guards (cold-start hold #289, splice cohort checks,
+        impossible-frame refusal #350). A synthetic bank can serve fine over the wire
+        yet be silently rejected on ingest, which otherwise surfaces as "the client
+        sees nothing" mid-interrogation. Each bank is fed twice, mirroring detect()'s
+        corroborating re-read, so cold-start-held battery banks commit exactly as they
+        would live. Raises :class:`ValueError` naming every register that failed to
+        commit. Only HR/IR banks exist on the read wire; spec any other register class
+        with ``verify=False`` (direct cache seeding, no round-trip).
+        """
+        devices: dict[int, RegisterCache] = {}
+        for device_address, banks in spec.items():
+            cache = devices.setdefault(device_address, RegisterCache())
+            for (reg_cls, base), values in banks.items():
+                for i, value in enumerate(values):
+                    cache[reg_cls(base + i)] = value
+        if verify:
+            _verify_spec_commits(spec)
+        return cls(devices, inverter_serial=inverter_serial, adapter_serial=adapter_serial)
 
     # -- serving ---------------------------------------------------------------
 

--- a/givenergy_modbus/testing/mock_plant.py
+++ b/givenergy_modbus/testing/mock_plant.py
@@ -378,12 +378,22 @@ class MockPlant:
         would live. Raises :class:`ValueError` naming every register that failed to
         commit. Only HR/IR banks exist on the read wire; spec any other register class
         with ``verify=False`` (direct cache seeding, no round-trip).
+
+        Every value must fit an unsigned 16-bit register word (0..0xFFFF) regardless of
+        ``verify`` — an out-of-range word can never be encoded onto the wire, and would
+        otherwise crash ``struct.pack`` at serve time on the first client read.
         """
         devices: dict[int, RegisterCache] = {}
         for device_address, banks in spec.items():
             cache = devices.setdefault(device_address, RegisterCache())
             for (reg_cls, base), values in banks.items():
                 for i, value in enumerate(values):
+                    if not 0 <= value <= 0xFFFF:
+                        raise ValueError(
+                            f"0x{device_address:02x}:{reg_cls.__name__}({base + i}) = {value} does not "
+                            f"fit an unsigned 16-bit register word (0..65535) and can never be served; "
+                            f"encode signed/scaled quantities to their raw wire representation first."
+                        )
                     cache[reg_cls(base + i)] = value
         if verify:
             _verify_spec_commits(spec)

--- a/givenergy_modbus/testing/mock_plant.py
+++ b/givenergy_modbus/testing/mock_plant.py
@@ -399,11 +399,14 @@ class MockPlant:
             cache = devices.setdefault(device_address, RegisterCache())
             for (reg_cls, base), values in banks.items():
                 for i, value in enumerate(values):
-                    if not 0 <= value <= 0xFFFF:
+                    # struct.pack("H") at serve time demands an actual int in 0..0xFFFF —
+                    # even an integral float (2.0) crashes, and dynamic spec sources
+                    # (JSON/YAML) can easily produce one.
+                    if not isinstance(value, int) or not 0 <= value <= 0xFFFF:
                         raise ValueError(
-                            f"0x{device_address:02x}:{reg_cls.__name__}({base + i}) = {value} does not "
-                            f"fit an unsigned 16-bit register word (0..65535) and can never be served; "
-                            f"encode signed/scaled quantities to their raw wire representation first."
+                            f"0x{device_address:02x}:{reg_cls.__name__}({base + i}) = {value!r} is not "
+                            f"an integer register word in 0..65535 and can never be served; encode "
+                            f"signed/scaled quantities to their raw wire representation first."
                         )
                     cache[reg_cls(base + i)] = value
         if verify:

--- a/tests/testing/test_from_spec.py
+++ b/tests/testing/test_from_spec.py
@@ -1,0 +1,101 @@
+"""MockPlant.from_spec — declarative synthetic register state (#324).
+
+`from_spec` builds a servable mock from a pure register spec (no base capture), and
+with ``verify=True`` round-trips every bank through a scratch ``Plant.update()`` to
+prove the synthetic state would survive the client's commit guards — the capgen
+lesson from #265: a bank can *serve* fine yet be silently rejected on ingest (splice
+guard, cold-start hold, impossible-frame refusal), which reads as "client sees
+nothing" when interrogating the app against a mock.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from givenergy_modbus.model.register import HR, IR, MR
+from givenergy_modbus.testing import MockPlant
+
+
+def _healthy_battery_values() -> list[int]:
+    """A coherent LV battery IR(60,60) bank that commits through the splice guard."""
+    values = [0] * 60
+    for i in range(16):  # 16 cells @ 3.300 V
+        values[i] = 3300
+    for i in range(16, 20):  # IR76-79 cell-mass temps @ 25.0 degC
+        values[i] = 250
+    values[20] = 52800  # IR80 v_cells_sum
+    values[37] = 16  # IR97 num_cells
+    values[38] = 3005  # IR98 bms_firmware_version
+    values[40] = 55  # IR100 soc
+    # valid serial "SA1234A567" at IR(110-114)
+    values[50:55] = [0x5341, 0x3132, 0x3334, 0x4135, 0x3637]
+    return values
+
+
+def _impossible_battery_values() -> list[int]:
+    """The #350 internally-impossible shape: every cell 0 V while firmware/capacity persist."""
+    values = _healthy_battery_values()
+    for i in range(16):
+        values[i] = 0
+    return values
+
+
+def test_from_spec_builds_caches():
+    """Registers land in per-device caches exactly as specced; serials default."""
+    mock = MockPlant.from_spec(
+        {
+            0x11: {(HR, 0): [0x2001, 17], (IR, 0): [1, 2, 3]},
+            0x32: {(IR, 60): [3300, 3301]},
+        },
+        verify=False,
+    )
+    assert mock.devices[0x11][HR(0)] == 0x2001
+    assert mock.devices[0x11][HR(1)] == 17
+    assert mock.devices[0x11][IR(2)] == 3
+    assert mock.devices[0x32][IR(61)] == 3301
+    assert mock.inverter_serial  # falls back to the placeholder serial
+
+
+def test_from_spec_verify_commits_healthy_banks():
+    """verify=True passes when every bank survives Plant.update().
+
+    Covers the cold-start-held battery bank, which needs the corroborating second
+    feed (#289). The inverter bank embeds a valid serial at HR(13-17): the commit
+    path discards an inverter bank whose serial words don't validate — the exact
+    class of silent rejection verify exists to surface.
+    """
+    inverter_bank = [0x2001] + [0] * 59
+    inverter_bank[13:18] = [0x5341, 0x3132, 0x3334, 0x4135, 0x3637]  # "SA1234A567"
+    mock = MockPlant.from_spec(
+        {
+            0x11: {(HR, 0): inverter_bank},
+            0x32: {(IR, 60): _healthy_battery_values()},
+        },
+        verify=True,
+    )
+    assert mock.devices[0x32][IR(98)] == 3005
+
+
+def test_from_spec_verify_raises_on_guard_rejected_bank():
+    """A guard-refused bank (impossible battery frame, #350) fails verification.
+
+    The error names the device and bank — instead of serving state no client
+    will ever ingest.
+    """
+    with pytest.raises(ValueError, match=r"0x32.*IR.*60"):
+        MockPlant.from_spec(
+            {0x32: {(IR, 60): _impossible_battery_values()}},
+            verify=True,
+        )
+
+
+def test_from_spec_verify_rejects_unsupported_register_class():
+    """Only HR/IR banks exist on the read wire; anything else cannot round-trip update()."""
+    with pytest.raises(ValueError, match="MR"):
+        MockPlant.from_spec({0x01: {(MR, 0): [1, 2]}}, verify=True)
+
+
+def test_from_spec_unverified_allows_any_register_class():
+    """verify=False seeds caches verbatim — MR and friends allowed for direct-cache use."""
+    mock = MockPlant.from_spec({0x01: {(MR, 0): [7]}}, verify=False)
+    assert mock.devices[0x01][MR(0)] == 7

--- a/tests/testing/test_from_spec.py
+++ b/tests/testing/test_from_spec.py
@@ -99,3 +99,17 @@ def test_from_spec_unverified_allows_any_register_class():
     """verify=False seeds caches verbatim — MR and friends allowed for direct-cache use."""
     mock = MockPlant.from_spec({0x01: {(MR, 0): [7]}}, verify=False)
     assert mock.devices[0x01][MR(0)] == 7
+
+
+@pytest.mark.parametrize("bad_value", [70000, -1, 0x10000])
+@pytest.mark.parametrize("verify", [True, False])
+def test_from_spec_rejects_unencodable_register_words(bad_value: int, verify: bool):
+    """Register words outside uint16 can never be encoded onto the wire (Codex, PR #391).
+
+    Plant.update() carries Python ints without range checks, so verification alone
+    passed 70000 — and the mock then crashed in struct.pack("H") on the first client
+    read of the bank. The range check is unconditional: an unencodable word is invalid
+    regardless of verify (verify=False only skips the commit-guard round-trip).
+    """
+    with pytest.raises(ValueError, match=r"0x11.*HR\(1\)"):
+        MockPlant.from_spec({0x11: {(HR, 0): [0x2001, bad_value]}}, verify=verify)

--- a/tests/testing/test_from_spec.py
+++ b/tests/testing/test_from_spec.py
@@ -101,15 +101,17 @@ def test_from_spec_unverified_allows_any_register_class():
     assert mock.devices[0x01][MR(0)] == 7
 
 
-@pytest.mark.parametrize("bad_value", [70000, -1, 0x10000])
+@pytest.mark.parametrize("bad_value", [70000, -1, 0x10000, 1.5, 2.0])
 @pytest.mark.parametrize("verify", [True, False])
-def test_from_spec_rejects_unencodable_register_words(bad_value: int, verify: bool):
+def test_from_spec_rejects_unencodable_register_words(bad_value, verify: bool):
     """Register words outside uint16 can never be encoded onto the wire (Codex, PR #391).
 
-    Plant.update() carries Python ints without range checks, so verification alone
-    passed 70000 — and the mock then crashed in struct.pack("H") on the first client
-    read of the bank. The range check is unconditional: an unencodable word is invalid
-    regardless of verify (verify=False only skips the commit-guard round-trip).
+    Plant.update() carries Python numerics without range or type checks, so
+    verification alone passed 70000 — and the mock then crashed in struct.pack("H")
+    on the first client read of the bank. Non-integers are the same class (struct
+    demands an actual int — even an integral 2.0 crashes), reachable from JSON/YAML
+    or other dynamic spec sources. The check is unconditional: an unencodable word
+    is invalid regardless of verify (verify=False only skips the guard round-trip).
     """
     with pytest.raises(ValueError, match=r"0x11.*HR\(1\)"):
         MockPlant.from_spec({0x11: {(HR, 0): [0x2001, bad_value]}}, verify=verify)


### PR DESCRIPTION
Closes #324.

## What

`MockPlant.from_spec({device: {(HR|IR, base): values}}, verify=True)` — build a servable mock from a pure register spec, no base capture required. Together with `start()` / `givenergy-cli mock-server`, this turns arbitrary synthetic state into something the real GE app (or this library's client) can be driven against.

Most of #324 turned out to have already shipped in `6631d43` (the register-identification work: `from_sentinels`, `identify()`, `sentinel_devices()`, `docs/register-identification.md`). This PR adds the remaining library half — declarative arbitrary-value seeding plus the one capgen piece with real teeth:

## The verify step

A synthetic bank can serve fine over the wire yet be **silently rejected on ingest** by the client-side commit guards — which surfaces as "the client sees nothing" mid-interrogation, a confusing dead-end. With `verify=True` (the default) every HR/IR bank is round-tripped through a scratch `Plant.update()` at construction:

- each bank is fed **twice**, mirroring detect()'s corroborating cold-start re-read (#289), so battery banks commit exactly as they would live;
- any register that fails to land raises `ValueError` naming the device and bank;
- non-HR/IR register classes are rejected under verify (they don't exist on the read wire) and allowed with `verify=False` for direct cache seeding.

The TDD run made the case for the feature by itself: the first "healthy" synthetic inverter bank in the test was silently discarded by a guard I hadn't accounted for (serial validation on HR(13-17)) — exactly the invisible-rejection mode verify exists to surface.

## Scope

- Library-side only. The `mock-server --spec` / `--sentinel` CLI flags belong to givenergy-cli; I'll offer that wiring via the usual coordination route once this lands.
- No production/client code touched — `givenergy_modbus/testing/` + tests.

## Tests

`tests/testing/test_from_spec.py` — construction, healthy-bank verification (incl. the cold-start double-feed), guard-rejection error naming, unsupported-class rejection, verify=False passthrough. Full suite 1592 green, tox green (py313/py314/format/lint/build).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a way to create a mock plant directly from an in-memory register specification.
  * Verification can be enabled to confirm supplied values are accepted and stored correctly.
* **Bug Fixes**
  * Improved validation so invalid or unsupported register data is rejected with clearer errors.
  * Added safeguards for inconsistent battery/register values during mock setup.
* **Tests**
  * Expanded coverage for verified and unverified mock plant creation, including supported and unsupported register types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->