### PR TITLE
fix(client): fail-closed envelope-serial redaction in FrameRedactor

### DIFF
--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -179,11 +179,19 @@ class FrameRedactor:
         if isinstance(pdu, LanConfigBroadcast):
             return pdu.redact().encode()
 
-        # Redact envelope serials (present on all Transparent PDUs)
+        # Redact envelope serials (present on all Transparent PDUs). FAIL-CLOSED
+        # (redact_serial_strict): an envelope value that doesn't parse as a GE serial is
+        # blanked, not passed through. The Gateway's write-response envelopes carry a
+        # NUL-interrupted serial variant that fails the pattern, and the fail-open
+        # redact_serial leaked its real unit digits verbatim (first write-path capture,
+        # 2026-07-09). Unlike the register-payload path below — which must fail open
+        # because serial groups overlap ordinary data — the envelope is unambiguous,
+        # so it takes the same strict treatment Plant.redact() applies to these exact
+        # fields (#212/#214).
         if hasattr(pdu, "data_adapter_serial_number"):
-            pdu.data_adapter_serial_number = Converter.redact_serial(pdu.data_adapter_serial_number) or ""
+            pdu.data_adapter_serial_number = Converter.redact_serial_strict(pdu.data_adapter_serial_number)
         if hasattr(pdu, "inverter_serial_number"):
-            pdu.inverter_serial_number = Converter.redact_serial(pdu.inverter_serial_number) or ""
+            pdu.inverter_serial_number = Converter.redact_serial_strict(pdu.inverter_serial_number)
 
         # Redact payload serials in register responses.
         # A serial is stored across 5 consecutive registers; decode the group as a

--- a/scripts/scan_capture_serials.py
+++ b/scripts/scan_capture_serials.py
@@ -6,11 +6,14 @@ can't cover: a serial at an as-yet-undiscovered location, or one stored SPLIT ac
 non-contiguous registers (module 0x55 on the 3ph HV stack, #378 — 'HY' at IR110, the
 '…G705' tail at IR115-118, which the contiguous-group redactor misses).
 
-It's a DETECTOR, not a redactor — run it on a fresh capture before committing. It flags two
+It's a DETECTOR, not a redactor — run it on a fresh capture before committing. It flags three
 shapes carrying non-zero unit digits (redacted serials end in the …000 placeholder, so those
 are ignored):
-  - full GE serial:      [A-Z]{2}\\d{4}[A-Z]\\d{3}   (e.g. HY2336G705)
-  - prefixless tail:     \\d{4}[A-Z]\\d{3}            (the split-serial fragment)
+  - full GE serial:       [A-Z]{2}\\d{4}[A-Z]\\d{3}         (e.g. HY2336G705)
+  - prefixless tail:      \\d{4}[A-Z]\\d{3}                  (the split-serial fragment)
+  - NUL-interrupted:      [A-Z]{2}[\\d\\x00]{4}[A-Z]\\d{3}    (Gateway write-response envelopes
+    carry a serial variant with NUL bytes replacing part of the date — both patterns above
+    structurally miss it; first seen on the 2026-07-09 write-path capture)
 
 A hit means: redact it (hand-zero the unit digits through the library encoder, and where the
 location is contiguous, model the register as C.serial so it auto-redacts thereafter), then
@@ -30,6 +33,10 @@ _CAPTURES = Path(__file__).resolve().parents[1] / "tests" / "fixtures" / "captur
 
 _FULL = re.compile(rb"[A-Z]{2}\d{4}[A-Z]\d{3}")
 _TAIL = re.compile(rb"\d{4}[A-Z]\d{3}")
+# NUL-interrupted serial variant: some Gateway write-response envelopes replace part of the
+# date digits with NUL bytes (e.g. prefix + \x00\x00 + partial date + unit digits), which
+# breaks both patterns above while the live unit digits ride through untouched.
+_NUL_INTERRUPTED = re.compile(rb"[A-Z]{2}[\d\x00]{4}[A-Z]\d{3}")
 
 
 def _frame_bytes(path: Path) -> bytes:
@@ -57,9 +64,17 @@ def scan(path: Path) -> list[str]:
         for m in _TAIL.finditer(data)
         if not m.group().endswith(b"000") and not any(m.group() in f for f in full)
     }
-    return [f"full serial {s.decode()}" for s in sorted(full)] + [
-        f"prefixless tail {s.decode()}" for s in sorted(tails)
-    ]
+    # NUL-interrupted variants, minus clean full-serial matches (the pattern is a superset).
+    nul_hits = {
+        m.group()
+        for m in _NUL_INTERRUPTED.finditer(data)
+        if not m.group().endswith(b"000") and b"\x00" in m.group()
+    }
+    return (
+        [f"full serial {s.decode()}" for s in sorted(full)]
+        + [f"prefixless tail {s.decode()}" for s in sorted(tails)]
+        + [f"NUL-interrupted serial {s.decode('latin1')!r}" for s in sorted(nul_hits)]
+    )
 
 
 def main() -> int:

--- a/tests/client/test_capture.py
+++ b/tests/client/test_capture.py
@@ -90,6 +90,45 @@ def test_frame_redactor_redacts_envelope_serial():
     assert len(out) == len(frame)
 
 
+def test_frame_redactor_blanks_unrecognised_envelope_serial():
+    r"""An envelope serial that doesn't parse as a GE serial is BLANKED, not passed through.
+
+    Field regression (2026-07-09, first-ever write-path capture): the Gateway's
+    WriteHoldingRegisterResponse envelopes carry a NUL-interrupted serial variant
+    (prefix + NUL bytes + partial date + unit digits) that fails the serial pattern —
+    and the envelope path used fail-open redact_serial, so the REAL unit digits leaked
+    verbatim into the capture (~30 frames). The envelope has no overlapping-group concern (unlike the
+    register-payload path, which must fail open), so it takes the same fail-closed
+    redact_serial_strict treatment Plant.redact() already applies to these exact
+    fields (#212/#214).
+    """
+    from givenergy_modbus.pdu import ClientIncomingMessage, WriteHoldingRegisterResponse
+
+    pdu = WriteHoldingRegisterResponse(
+        data_adapter_serial_number="WF1234G567",
+        inverter_serial_number="GW\x00\x0034A567",
+        register=116,
+        value=81,
+        device_address=0x11,
+        padding=0x8A,
+        error=False,
+    )
+    frame = pdu.encode()
+    assert b"34A567" in frame  # the leak shape is on the wire pre-redaction
+
+    r = FrameRedactor()
+    out = r.feed(frame) + r.flush()
+
+    assert b"34A567" not in out  # the live unit digits must be gone
+    decoded = ClientIncomingMessage.decode_bytes(out)
+    # Unrecognised envelope serial → blanked fail-closed (strict returns ""; the encoder
+    # pads the fixed-width field, so no digit of the original may survive). The recognised
+    # adapter serial still gets the ordinary date-preserving redaction.
+    assert not any(c.isdigit() for c in decoded.inverter_serial_number)
+    assert decoded.data_adapter_serial_number == "WF1234G000"
+    assert len(out) == len(frame)
+
+
 def test_frame_redactor_redacts_payload_inverter_serial():
     """HR(13-17) register group (inverter serial) is redacted in the register payload."""
     from givenergy_modbus.pdu import ClientIncomingMessage


### PR DESCRIPTION
## What

The first-ever write-path capture (Gateway, tonight) exposed a FrameRedactor blind spot: the Gateway's `WriteHoldingRegisterResponse` envelopes carry a NUL-interrupted serial variant — prefix + NUL bytes + partial date + live unit digits — that doesn't parse as a GE serial. The envelope path used the fail-open `redact_serial`, which returns unrecognised shapes unchanged, so the real unit digits passed verbatim into the shared capture (~30 frames). Both `scan_capture_serials.py` patterns structurally miss the shape too: the NULs break the two-letter-prefix match, and the surviving tail is too short for the tail pattern.

## Fix

- **Envelope serials → `redact_serial_strict`** (blank anything unparseable). This is the same fail-closed treatment `Plant.redact()` already applies to these exact header fields (#212/#214) — the envelope has no overlapping-group ambiguity, unlike the register-payload path, which must stay fail-open by design.
- **Scanner gains a third, NUL-tolerant pattern** so the detector catches this family wherever it appears next; validated against the leaking capture (flags it) and the full committed corpus (no false positives).

The affected shared capture has been re-redacted through the fixed path (exactly the 30 frames rewritten, re-scan clean, still decodes) and the public copy taken down.

## Exposure

Nil in practice until tonight: this shape only appears on write responses, and no write-path capture had ever been taken. But the cli `capture` command and the HA integration's capture path both rely on FrameRedactor, and write-path capture requests are now circulating for the Gateway work — so I intend to cut a patch release promptly once this lands and ask the downstream integrations to bump before soliciting more write captures.

## Tests

New `test_frame_redactor_blanks_unrecognised_envelope_serial` (fabricated placeholder serials, real leak shape) — red against the fail-open path, green with strict; existing envelope test pins that recognised serials keep the date-preserving redaction. Full suite 1604 green, tox green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved serial-number redaction so any values that do not look like valid device serials are now hidden more reliably.
  * Reduced the chance of sensitive serial information appearing in captured output when data contains unusual byte patterns.
  * Expanded serial scanning to detect an additional masked pattern that could previously slip through checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->