### PR TITLE
fix(model): widen v_battery bound to admit HV integrated-stack voltage (AIO)

### DIFF
--- a/givenergy_modbus/model/inverter.py
+++ b/givenergy_modbus/model/inverter.py
@@ -974,7 +974,11 @@ class SinglePhaseInverterRegisterGetter(RegisterGetter):
         # as a deprecated alias on the inverter classes for a release.
         "work_time_total_hours": Def(C.uint32, None, IR(47), IR(48), max=876_000),
         "system_mode": Def(C.uint16, None, IR(49)),
-        "v_battery": Def(C.centi, None, IR(50), min=0.0, max=100.0),
+        # max 600 V (not 100): IR(50) is inverter-level battery voltage, and on an AIO it
+        # carries the HV integrated stack (~300-500 V), not just an LV pack (~50 V). The old
+        # LV-calibrated 100 V ceiling clamped a real HV reading to None (permanently-Unknown
+        # entity). 600 V admits both while still suppressing raw garbage (65535 -> 655.35).
+        "v_battery": Def(C.centi, None, IR(50), min=0.0, max=600.0),
         "i_battery": Def(C.int16, C.centi, IR(51), min=-300.0, max=300.0),
         "p_battery": Def(C.int16, None, IR(52)),
         "v_ac1_output": Def(C.deci, None, IR(53), min=0.0, max=500.0),  # might be v_eps_backup?

--- a/tests/client/test_mock_plant_integration.py
+++ b/tests/client/test_mock_plant_integration.py
@@ -227,6 +227,10 @@ def _assert_aio_redetect(plant):
     # LOAD_CONFIG_RANGES and polled ONLY by load_config; first capture to carry it
     # live. Pins the capability-gated table entry end-to-end (#293/#295).
     assert inv.battery_charge_limit_ac == 50
+    # Inverter-level v_battery (IR50) now admits the AIO's HV integrated-stack voltage
+    # (~300 V) instead of clamping it to None under the old LV-calibrated 100 V bound —
+    # so an AIO gets a real Battery Voltage rather than a permanently-Unknown entity.
+    assert inv.v_battery == pytest.approx(312.78)
     # Each module's split serial's "HY" prefix lands on t_cell_21's register; the
     # bounds check (#379) suppresses that non-zero out-of-range raw to None rather than
     # surfacing a ~1852 °C phantom.

--- a/tests/model/test_inverter.py
+++ b/tests/model/test_inverter.py
@@ -66,6 +66,33 @@ def test_installer_config_register_scales(field, reg, raw, expected):
     assert getattr(inv, field) == pytest.approx(expected)
 
 
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (5387, 53.87),  # LV pack (~54 V) — still decodes, unchanged
+        (31348, 313.48),  # HV integrated stack on an AIO (4 modules) — was clamped to None
+        (47180, 471.80),  # HV stack near a 6-module ceiling — headroom
+        (65535, None),  # raw garbage (655.35 V) still clamps
+    ],
+)
+def test_v_battery_bounds_admit_hv_stack_voltage(raw, expected):
+    """v_battery (IR50) decodes HV integrated-stack voltages, not just LV packs (AIO report).
+
+    The max bound was 100 V (LV-pack calibrated), so an AIO's HV stack — which runs to
+    ~300-500 V and is the same inverter-level v_battery register — decoded to None and
+    surfaced a permanently-Unknown entity. Widened to 600 V: LV packs unchanged, HV
+    stacks admitted, and raw garbage (65535 -> 655.35) still suppressed. Corroborated
+    against a live AIO where IR50=31348 (313.48 V) matched the BCU cluster voltage to
+    within 1 V. Bounds are a sanity net, not model knowledge; the splice guards remain
+    the real corruption defence on battery data.
+    """
+    inv = SinglePhaseInverter.from_register_cache(RegisterCache({IR(50): raw}))
+    if expected is None:
+        assert inv.v_battery is None
+    else:
+        assert inv.v_battery == pytest.approx(expected)
+
+
 def test_inverter_temps_signed_deci():
     """Inverter heatsink / charger / battery temps decode as signed int16 deci (#379).
 


### PR DESCRIPTION
## What

On an All-in-One, the inverter-level `v_battery` register (IR50) carries the **HV integrated stack** voltage (~300–500 V), not an LV pack (~50 V). The Def's `max` bound was 100 V — LV-calibrated — so a real AIO stack voltage decoded to `None`, giving those owners a permanently-Unknown "Battery Voltage" entity (AberDino report via the HA side).

Same failure class as #381 (signed temps) and #379 (cell bounds): a bound calibrated on one hardware family silently suppressing a legitimate reading on another.

## Fix

`v_battery` Def `max` 100 → 600 V. LV packs unchanged, HV stacks admitted, and raw garbage still clamps (65535 → 655.35 V → None). The three-phase inverter is unaffected — it reads battery voltage from its own registers (`v_battery_lv/cv/bms/pcs`, already `max=1000`), not IR50.

Bounds here are a sanity net, not model knowledge; the splice guards remain the real corruption defence on battery data, so blunting this ceiling on LV units costs nothing meaningful.

## Evidence

- Live AIO capture: IR50 = 31348 → **313.48 V**, matching the same plant's BCU cluster voltage (314.1 V) to within 1 V.
- Committed corpus AIO fixtures read 31278 / 31314 — sane, slowly-drifting stack voltages.

## Tests

- `test_v_battery_bounds_admit_hv_stack_voltage` — parametrised: LV (53.87) unchanged, two HV cases (313.48 / 471.80) now decode, garbage (655.35) still None. Red on the two HV cases before the widening.
- Full-cycle integration fence: the `aio_redetect_clean` case now pins `v_battery == 312.78` end-to-end through the live detect→load_config→refresh cycle.

Full suite 1607 green, tox green.

## Downstream

Unblocks the hass-side row hass was about to gate off (their note asked whether to drop it permanently — answer was no, it's real, we were suppressing it). I'll confirm once this lands.