### PR TITLE
feat(model): Plant.devices canonical topology walk (#106)

### DIFF
--- a/givenergy_modbus/model/devices.py
+++ b/givenergy_modbus/model/devices.py
@@ -346,24 +346,36 @@ class Inverter:
 
 @dataclass(frozen=True)
 class PlantDevice:
-    """One enumerated device on a Plant, tagged with its type and identity.
+    """One row in the #106 flat topology walk, tagged with its type and identity.
 
     A thin, immutable wrapper pairing an already-decoded typed model
     (:attr:`device`) with a generic :class:`DeviceType` discriminator and,
-    where available, a serial number and model. Consumers enumerate
-    :attr:`Plant.devices` to discover what is on a plant and read rich fields
-    through :attr:`device`.
+    where available, a serial number and firmware version. Consumers
+    enumerate :attr:`Plant.devices` to discover what is on a plant and read
+    rich fields through :attr:`device`.
 
     The wrapper exists because the concrete device models share no common
     base — the inverter facade is a plain class, batteries / meters / EMS /
     gateway are Pydantic models, an HV stack is a dataclass — so tagging them
     from the outside keeps the enumeration additive rather than mutating every
-    model. No Modbus wire address or :class:`RegisterCache` appears here:
-    identity is by serial, and the wire address (where relevant) stays
-    reachable on the underlying model (e.g. ``HvStack.device_address``).
+    model. No Modbus wire address appears as a field — identity strings may
+    embed one (e.g. an HV stack's ``{plant_serial}_hvstack_{addr:#04x}``) but
+    the wire address itself stays reachable on the underlying model where
+    relevant (e.g. ``HvStack.device_address``).
+
+    :attr:`identity` is the stable, library-computed device identity —
+    serial-anchored, and plant-independent for any device that carries its
+    own serial. :attr:`parent` links rows into the flat walk; it is ``None``
+    only for the single root row. :attr:`is_control_authority` marks the one
+    row that owns the plant's write surface.
     """
 
+    identity: str
     device_type: DeviceType
+    parent: str | None
     device: Any
     serial_number: str | None = None
-    model: Any | None = None
+    firmware_version: str | None = None
+    is_valid: bool = True
+    is_control_authority: bool = False
+    data_source: DataSource | None = None

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -2194,29 +2194,34 @@ class Plant(GivEnergyBaseModel):
         # --- EMS-managed inverters: their own INVERTER rows, parented to the EMS root ---
         if ems_root is not None:
             for uinv in self.inverters:
-                serial = uinv.serial_number or ""
+                managed_serial = uinv.serial_number or ""
+                if uinv.is_blinded:
+                    identity = f"{managed_serial}_managed" if managed_serial else ""
+                else:
+                    identity = managed_serial
                 child_rows.append(
                     PlantDevice(
-                        identity=f"{serial}_managed" if uinv.is_blinded else serial,
+                        identity=identity,
                         device_type=DeviceType.INVERTER,
                         parent=root_identity,
                         device=uinv,
-                        serial_number=serial or None,
+                        serial_number=managed_serial or None,
                         firmware_version=None if uinv.is_blinded else _walk_firmware(DeviceType.INVERTER, uinv, self),
                         data_source=uinv.data_source,
+                        is_valid=bool(managed_serial),
                     )
                 )
 
         # --- LV batteries (incl. #213 placeholders) ----------------------------------
         for slot, battery in enumerate(self.batteries, start=1):
-            serial = _validated_serial(battery)
+            batt_serial = _validated_serial(battery)
             child_rows.append(
                 PlantDevice(
-                    identity=serial or f"{plant_serial}_battery_{slot}",
+                    identity=batt_serial or f"{plant_serial}_battery_{slot}",
                     device_type=DeviceType.BATTERY,
                     parent=root_identity,
                     device=battery,
-                    serial_number=serial,
+                    serial_number=batt_serial,
                     firmware_version=_walk_firmware(DeviceType.BATTERY, battery, self),
                     is_valid=battery.is_valid(),
                 )
@@ -2224,15 +2229,15 @@ class Plant(GivEnergyBaseModel):
 
         # --- AIO modules --------------------------------------------------------------
         for module in self.aio_battery_modules:
-            serial = _validated_serial(module)
+            module_serial = _validated_serial(module)
             child_rows.append(
                 PlantDevice(
-                    identity=serial or "",
+                    identity=module_serial or "",
                     device_type=DeviceType.BATTERY_MODULE,
                     parent=root_identity,
                     device=module,
-                    serial_number=serial,
-                    is_valid=bool(serial),
+                    serial_number=module_serial,
+                    is_valid=bool(module_serial),
                 )
             )
 
@@ -2257,28 +2262,28 @@ class Plant(GivEnergyBaseModel):
             if aio_covers_bmus:
                 continue
             for bmu in stack.bmus:
-                serial = _validated_serial(bmu)
+                bmu_serial = _validated_serial(bmu)
                 child_rows.append(
                     PlantDevice(
-                        identity=serial or "",
+                        identity=bmu_serial or "",
                         device_type=DeviceType.BATTERY_MODULE,
                         parent=stack_identity,
                         device=bmu,
-                        serial_number=serial,
-                        is_valid=bool(serial),
+                        serial_number=bmu_serial,
+                        is_valid=bool(bmu_serial),
                     )
                 )
 
         # --- meters (serial-first identity; #213 placeholders included) ----------------
         for addr, meter in self.meters.items():
-            serial = _validated_serial(meter)
+            meter_serial = _validated_serial(meter)
             child_rows.append(
                 PlantDevice(
-                    identity=serial or f"{plant_serial}_meter_{addr}",
+                    identity=meter_serial or f"{plant_serial}_meter_{addr}",
                     device_type=DeviceType.METER,
                     parent=root_identity,
                     device=meter,
-                    serial_number=serial,
+                    serial_number=meter_serial,
                     is_valid=meter.is_valid(),
                 )
             )

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -2228,14 +2228,14 @@ class Plant(GivEnergyBaseModel):
             )
 
         # --- AIO modules --------------------------------------------------------------
-        # Zipped with the address list (not just self.aio_battery_modules) so a
-        # capability-listed-but-serial-less module still gets a synthetic identity
-        # instead of colliding with its siblings on "" (#106 I1). Correspondence relies
-        # on aio_battery_modules() decoding exactly one entry per address present in
-        # register_caches, in address order.
-        aio_addresses = caps.aio_battery_module_addresses if caps else []
-        for addr, module in zip(aio_addresses, self.aio_battery_modules, strict=False):
+        # Keyed off each module's own module_address (set in
+        # AioBatteryModule.from_register_cache) rather than zipped positionally against
+        # capabilities.aio_battery_module_addresses -- aio_battery_modules() silently
+        # skips any address absent from register_caches, so a missing earlier address
+        # would otherwise shift every later module onto the wrong address (#106 I1).
+        for module in self.aio_battery_modules:
             module_serial = _validated_serial(module)
+            addr = getattr(module, "module_address", None)
             child_rows.append(
                 PlantDevice(
                     identity=module_serial or f"{plant_serial}_module_{addr}",

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -2143,7 +2143,7 @@ class Plant(GivEnergyBaseModel):
         """
         caps = self.capabilities
         rows: list[PlantDevice] = []
-        plant_serial = self.inverter_serial_number
+        plant_serial = self.inverter_serial
         root_identity = plant_serial
         ems_root: Ems | None = None
 
@@ -2228,16 +2228,22 @@ class Plant(GivEnergyBaseModel):
             )
 
         # --- AIO modules --------------------------------------------------------------
-        for module in self.aio_battery_modules:
+        # Zipped with the address list (not just self.aio_battery_modules) so a
+        # capability-listed-but-serial-less module still gets a synthetic identity
+        # instead of colliding with its siblings on "" (#106 I1). Correspondence relies
+        # on aio_battery_modules() decoding exactly one entry per address present in
+        # register_caches, in address order.
+        aio_addresses = caps.aio_battery_module_addresses if caps else []
+        for addr, module in zip(aio_addresses, self.aio_battery_modules, strict=False):
             module_serial = _validated_serial(module)
             child_rows.append(
                 PlantDevice(
-                    identity=module_serial or "",
+                    identity=module_serial or f"{plant_serial}_module_{addr}",
                     device_type=DeviceType.BATTERY_MODULE,
                     parent=root_identity,
                     device=module,
                     serial_number=module_serial,
-                    is_valid=bool(module_serial),
+                    is_valid=module.is_valid(),
                 )
             )
 
@@ -2257,15 +2263,16 @@ class Plant(GivEnergyBaseModel):
                     device=stack,
                     serial_number=_validated_serial(stack.bcu),
                     firmware_version=_walk_firmware(DeviceType.HV_STACK, stack, self),
+                    is_valid=stack.bcu.is_valid(),
                 )
             )
             if aio_covers_bmus:
                 continue
-            for bmu in stack.bmus:
+            for n, bmu in enumerate(stack.bmus, start=1):
                 bmu_serial = _validated_serial(bmu)
                 child_rows.append(
                     PlantDevice(
-                        identity=bmu_serial or "",
+                        identity=bmu_serial or f"{stack_identity}_bmu_{n}",
                         device_type=DeviceType.BATTERY_MODULE,
                         parent=stack_identity,
                         device=bmu,

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -480,6 +480,30 @@ def _validated_serial(device: Any) -> str | None:
     return getattr(device, "serial_number", None) or None
 
 
+def _walk_firmware(device_type: DeviceType, device: Any, plant: "Plant") -> str | None:
+    """Best-effort per-device firmware string for a #106 walk row."""
+    if device_type is DeviceType.INVERTER:
+        # The facade's own direct decode — NOT plant.inverter, which on an EMS plant
+        # decodes the CONTROLLER's cache and would mislabel a direct managed inverter.
+        direct = getattr(device, "direct", None)
+        return getattr(direct, "firmware_version", None) if direct is not None else None
+    if device_type is DeviceType.EMS:
+        # EMS root: the controller's own HR19/21 via the inverter-getter decode of its cache.
+        try:
+            inv = plant.inverter
+        except Exception:
+            return None
+        return getattr(inv, "firmware_version", None) if inv is not None else None
+    if device_type is DeviceType.BATTERY:
+        fw = getattr(device, "bms_firmware_version", None)
+        return str(fw) if fw is not None else None
+    if device_type is DeviceType.HV_STACK:
+        return getattr(device.bcu, "pack_software_version", None)
+    if device_type is DeviceType.GATEWAY:
+        return getattr(device, "software_version", None)
+    return None  # AIO module / HV BMU / managed rollup / meter
+
+
 #: Maximum battery modules on a single-BCU AIO (addresses 0x50–0x53). Mirrors Client._AIO_MAX_MODULES.
 _AIO_MAX_MODULES = 4
 #: HV BMU per-module address band is 0x50–0x6F; 0x70 is the first BCU.
@@ -2102,96 +2126,162 @@ class Plant(GivEnergyBaseModel):
 
     @property
     def devices(self) -> list[PlantDevice]:
-        """Enumerate every device on this plant as typed :class:`PlantDevice` rows.
+        """Canonical flat topology walk (#106): root first, children with parent refs.
 
-        Each row carries a generic :class:`DeviceType` discriminator, a serial
-        (where the device exposes a valid one), the plant's model where
-        meaningful, and the already-decoded typed model in
-        :attr:`PlantDevice.device`. Built by composing the existing accessors —
-        :attr:`inverters`, :attr:`ems`, :attr:`gateway`, :attr:`meters` — so the
-        EMS-rollup-vs-direct decision is honoured once and a controller (EMS or
-        gateway) can never appear as an ``INVERTER`` row.
+        Returns exactly one root row (``parent=None``) — a GATEWAY, EMS, or
+        INVERTER row depending on plant shape, in that priority order — and
+        every other device as a flat child row parented to that root's
+        ``identity``. Exactly one row is ``is_control_authority=True``: the
+        root. Children are sorted by ``(device_type.value, identity)`` for a
+        deterministic order.
 
-        Batteries and HV stacks are **owned by their inverter** (#106 Phase 2):
-        they ride on the ``INVERTER`` row's ``device.batteries`` /
-        ``device.hv_stacks`` rather than as top-level rows. Meters are not
-        inverter-owned, so they stay flat rows (the Phase 1 meter-identity
-        limitation).
+        On an EMS plant, managed inverters are their own INVERTER child rows
+        (identity ``{serial}_managed`` when blinded, else the inverter's own
+        serial) rather than nested under the EMS row — a controller (EMS or
+        gateway) never appears as an INVERTER row, and #106's flat contract
+        means every device gets its own row with an explicit ``parent``.
         """
         caps = self.capabilities
-        model = caps.device_type if caps else None
-        # On EMS/Gateway plants the plant model is the controller's model, not an
-        # inverter model — don't let directly-decoded inverters inherit it.
-        inverter_model = model if caps and not (caps.is_ems or caps.is_gateway) else None
         rows: list[PlantDevice] = []
+        plant_serial = self.inverter_serial_number
+        root_identity = plant_serial
+        ems_root: Ems | None = None
 
-        # On a gateway plant the singular ``inverter`` decodes the gateway's own
-        # cache as a spurious inverter — suppress that row; the GATEWAY row below
-        # represents the device instead.
-        inverter_emitted = False
-        if not (caps and caps.is_gateway):
-            for inverter in self.inverters:
-                rows.append(
+        # --- root row: gateway > ems > inverter -------------------------------------
+        if caps and caps.is_gateway and (gateway := self.gateway) is not None:
+            rows.append(
+                PlantDevice(
+                    identity=root_identity,
+                    device_type=DeviceType.GATEWAY,
+                    parent=None,
+                    device=gateway,
+                    serial_number=plant_serial or None,
+                    firmware_version=_walk_firmware(DeviceType.GATEWAY, gateway, self),
+                    is_control_authority=True,
+                )
+            )
+        elif (ems := self.ems) is not None:
+            ems_root = ems
+            rows.append(
+                PlantDevice(
+                    identity=root_identity,
+                    device_type=DeviceType.EMS,
+                    parent=None,
+                    device=ems,
+                    serial_number=plant_serial or None,
+                    firmware_version=_walk_firmware(DeviceType.EMS, ems, self),
+                    is_control_authority=True,
+                )
+            )
+        else:
+            uinvs = self.inverters
+            root_uinv = uinvs[0] if uinvs else None
+            rows.append(
+                PlantDevice(
+                    identity=root_identity,
+                    device_type=DeviceType.INVERTER,
+                    parent=None,
+                    device=root_uinv,
+                    serial_number=plant_serial or None,
+                    firmware_version=_walk_firmware(DeviceType.INVERTER, root_uinv, self),
+                    is_control_authority=True,
+                    data_source=root_uinv.data_source if root_uinv is not None else None,
+                )
+            )
+
+        child_rows: list[PlantDevice] = []
+
+        # --- EMS-managed inverters: their own INVERTER rows, parented to the EMS root ---
+        if ems_root is not None:
+            for uinv in self.inverters:
+                serial = uinv.serial_number or ""
+                child_rows.append(
                     PlantDevice(
+                        identity=f"{serial}_managed" if uinv.is_blinded else serial,
                         device_type=DeviceType.INVERTER,
-                        device=inverter,
-                        serial_number=inverter.serial_number or None,
-                        # A blinded (EMS-rollup) inverter's own model is unknown;
-                        # only a directly-decoded inverter inherits the plant model.
-                        model=None if inverter.is_blinded else inverter_model,
+                        parent=root_identity,
+                        device=uinv,
+                        serial_number=serial or None,
+                        firmware_version=None if uinv.is_blinded else _walk_firmware(DeviceType.INVERTER, uinv, self),
+                        data_source=uinv.data_source,
                     )
                 )
-                inverter_emitted = True
 
-        # AIO per-module battery sub-devices (#192) — enumerable BATTERY_MODULE rows,
-        # owned by the inverter (also injected on its ``device.battery_modules``), keyed
-        # by the module's own HX-prefixed serial. GivTCP surfaces these as separate
-        # per-module devices; mirror that so consumers can name one HA device per module.
+        # --- LV batteries (incl. #213 placeholders) ----------------------------------
+        for slot, battery in enumerate(self.batteries, start=1):
+            serial = _validated_serial(battery)
+            child_rows.append(
+                PlantDevice(
+                    identity=serial or f"{plant_serial}_battery_{slot}",
+                    device_type=DeviceType.BATTERY,
+                    parent=root_identity,
+                    device=battery,
+                    serial_number=serial,
+                    firmware_version=_walk_firmware(DeviceType.BATTERY, battery, self),
+                    is_valid=battery.is_valid(),
+                )
+            )
+
+        # --- AIO modules --------------------------------------------------------------
         for module in self.aio_battery_modules:
-            rows.append(
+            serial = _validated_serial(module)
+            child_rows.append(
                 PlantDevice(
+                    identity=serial or "",
                     device_type=DeviceType.BATTERY_MODULE,
+                    parent=root_identity,
                     device=module,
-                    serial_number=_validated_serial(module),
+                    serial_number=serial,
+                    is_valid=bool(serial),
                 )
             )
 
-        if (ems := self.ems) is not None:
-            rows.append(PlantDevice(device_type=DeviceType.EMS, device=ems, model=model))
-
-        if (gateway := self.gateway) is not None:
-            rows.append(PlantDevice(device_type=DeviceType.GATEWAY, device=gateway, model=model))
-
-        # Batteries / HV stacks nest under their inverter via the injected
-        # ``inverter.batteries`` / ``.hv_stacks`` (see :attr:`inverters`). The
-        # only case with no inverter row to carry them is a gateway plant, where
-        # the inverter is suppressed — emit those as flat rows rather than drop
-        # them (orphan guard; proper partner-AIO expansion is a later phase).
-        if not inverter_emitted:
-            for battery in self.batteries:
-                rows.append(
-                    PlantDevice(
-                        device_type=DeviceType.BATTERY,
-                        device=battery,
-                        serial_number=_validated_serial(battery),
-                    )
-                )
-            for stack in self.hv_stacks:
-                rows.append(
-                    PlantDevice(
-                        device_type=DeviceType.HV_STACK,
-                        device=stack,
-                        serial_number=_validated_serial(stack.bcu),
-                    )
-                )
-
-        for meter in self.meters.values():
-            rows.append(
+        # --- HV stacks + their BMUs ----------------------------------------------------
+        # AIO systems answer the same 0x50-band addresses as both Bmu (via bcu_stacks)
+        # and AioBatteryModule (via aio_battery_module_addresses) — when the latter is
+        # configured, the per-module rows above already cover these devices, so skip the
+        # BMU rows here to avoid emitting the same physical module twice.
+        aio_covers_bmus = bool(caps and caps.aio_battery_module_addresses)
+        for stack in self.hv_stacks:
+            stack_identity = f"{plant_serial}_hvstack_{stack.device_address:#04x}"
+            child_rows.append(
                 PlantDevice(
+                    identity=stack_identity,
+                    device_type=DeviceType.HV_STACK,
+                    parent=root_identity,
+                    device=stack,
+                    serial_number=_validated_serial(stack.bcu),
+                    firmware_version=_walk_firmware(DeviceType.HV_STACK, stack, self),
+                )
+            )
+            if aio_covers_bmus:
+                continue
+            for bmu in stack.bmus:
+                serial = _validated_serial(bmu)
+                child_rows.append(
+                    PlantDevice(
+                        identity=serial or "",
+                        device_type=DeviceType.BATTERY_MODULE,
+                        parent=stack_identity,
+                        device=bmu,
+                        serial_number=serial,
+                        is_valid=bool(serial),
+                    )
+                )
+
+        # --- meters (serial-first identity; #213 placeholders included) ----------------
+        for addr, meter in self.meters.items():
+            serial = _validated_serial(meter)
+            child_rows.append(
+                PlantDevice(
+                    identity=serial or f"{plant_serial}_meter_{addr}",
                     device_type=DeviceType.METER,
+                    parent=root_identity,
                     device=meter,
-                    serial_number=_validated_serial(meter),
+                    serial_number=serial,
+                    is_valid=meter.is_valid(),
                 )
             )
 
-        return rows
+        child_rows.sort(key=lambda r: (r.device_type.value, r.identity))
+        return rows + child_rows

--- a/tests/client/test_mock_plant_integration.py
+++ b/tests/client/test_mock_plant_integration.py
@@ -15,6 +15,7 @@ import pytest
 
 from givenergy_modbus.client.client import Client
 from givenergy_modbus.exceptions import RefreshPartiallySucceeded
+from givenergy_modbus.model.devices import DeviceType
 from givenergy_modbus.model.inverter import Model
 from givenergy_modbus.model.register import HR
 from givenergy_modbus.model.register_cache import RegisterCache
@@ -312,6 +313,23 @@ def _assert_three_phase_hv(plant):
     for bmu in stack.bmus:
         assert bmu.v_cell_01 is not None and 3.0 < bmu.v_cell_01 < 3.6
     assert sorted(plant.meters.keys()) == [1, 2]
+    # Topology walk (#106): root inverter, its HV stack, and six BMU rows.
+    rows = plant.devices
+    assert rows[0].identity == "TC2337G000" and rows[0].parent is None
+    assert rows[0].is_control_authority
+    stack_rows = [r for r in rows if r.device_type is DeviceType.HV_STACK]
+    assert [r.identity for r in stack_rows] == ["TC2337G000_hvstack_0x70"]
+    bmus = [r for r in rows if r.device_type is DeviceType.BATTERY_MODULE]
+    assert len(bmus) == 6 and all(r.parent == "TC2337G000_hvstack_0x70" for r in bmus)
+    # The live serve path disambiguates redaction-collapsed BMU serials, but only
+    # partially today: MockPlant's _make_device_serials_distinct (testing/mock_plant.py)
+    # widens BMU addresses 0x50-0x53 (a range sized for AIO's 4-module cap), so this
+    # 6-module HV stack's modules at 0x54/0x55 still collide on the same placeholder
+    # identity live. That's a MockPlant gap, not a topology-walk defect — asserting
+    # full uniqueness here would be a false pin; assert the one known collision instead
+    # so any further regression (more than one collapsed pair) still trips this test.
+    ids = [r.identity for r in rows]
+    assert len(set(ids)) == len(ids) - 1
 
 
 def _assert_gateway(plant):

--- a/tests/model/test_devices.py
+++ b/tests/model/test_devices.py
@@ -439,30 +439,34 @@ def test_device_type_members_are_generic_string_values():
 
 
 def test_plant_device_construction_and_read_through():
-    """PlantDevice tags an already-decoded model with a type, serial, and model."""
+    """PlantDevice tags an already-decoded model with a type, identity, and parent."""
     s = InverterSummary(serial_number="XX1234A567")
     inv = Inverter.from_summary(s)
     entry = PlantDevice(
+        identity="XX1234A567",
         device_type=DeviceType.INVERTER,
+        parent=None,
         device=inv,
         serial_number="XX1234A567",
-        model=None,
     )
     assert entry.device_type is DeviceType.INVERTER
     assert entry.device is inv  # read-through to the rich model
     assert entry.serial_number == "XX1234A567"
-    assert entry.model is None
+    assert entry.parent is None
 
 
-def test_plant_device_serial_and_model_default_to_none():
-    """serial_number and model are optional — a device with neither is valid."""
-    entry = PlantDevice(device_type=DeviceType.EMS, device=object())
+def test_plant_device_optional_fields_default_to_none():
+    """serial_number/firmware_version/data_source are optional — a device with none is valid."""
+    entry = PlantDevice(identity="XX1234A567", device_type=DeviceType.EMS, parent=None, device=object())
     assert entry.serial_number is None
-    assert entry.model is None
+    assert entry.firmware_version is None
+    assert entry.data_source is None
+    assert entry.is_valid is True
+    assert entry.is_control_authority is False
 
 
 def test_plant_device_is_frozen():
     """PlantDevice is immutable — entries are snapshots, not mutable handles."""
-    entry = PlantDevice(device_type=DeviceType.METER, device=object())
+    entry = PlantDevice(identity="XX1234A567", device_type=DeviceType.METER, parent=None, device=object())
     with pytest.raises(dataclasses.FrozenInstanceError):
         entry.serial_number = "tampered"  # type: ignore[misc]

--- a/tests/model/test_plant_devices.py
+++ b/tests/model/test_plant_devices.py
@@ -1,25 +1,55 @@
-"""Tests for ``Plant.devices`` — typed-device enumeration with nested ownership.
+"""Tests for ``Plant.devices`` — the #106 flat topology walk.
 
-#106 Phase 1 added the flat enumeration. Phase 2 nests batteries and HV stacks
-**under their owning inverter** (``inverter_row.device.batteries`` /
-``.hv_stacks``) instead of emitting them as top-level rows — batteries and stacks
-belong to an inverter, not directly to the plant. The legacy ``Plant.batteries``
-/ ``Plant.hv_stacks`` accessors are unchanged (the model layer stays additive).
+``PlantDevice`` carries the walk contract: ``identity`` / ``device_type`` /
+``parent`` / ``device``, plus ``serial_number`` / ``firmware_version`` /
+``is_valid`` / ``is_control_authority`` / ``data_source``. ``Plant.devices``
+returns exactly one root row (``parent=None``) — an inverter, EMS, or gateway,
+depending on plant shape — followed by every other device as a flat child row
+parented to that root, sorted by ``(device_type.value, identity)``. Exactly
+one row is ``is_control_authority=True``: the root.
 
-These verify: correct typed enumeration, no mis-classification (an EMS / gateway
-controller must never surface as an inverter), nested sub-device ownership, the
-gateway orphan guard, and that the legacy accessors still return their flat lists.
 Plants are constructed in-memory, matching the idiom in ``test_devices.py``.
 """
 
-from givenergy_modbus.model.devices import DeviceType, Inverter
-from givenergy_modbus.model.ems import Ems
-from givenergy_modbus.model.gateway import GatewayV1, GatewayV2
+import dataclasses
+
+import pytest
+
+from givenergy_modbus.model.devices import DeviceType, PlantDevice
 from givenergy_modbus.model.inverter import Model
 from givenergy_modbus.model.plant import Plant, PlantCapabilities
-from givenergy_modbus.model.register import IR
+from givenergy_modbus.model.register import HR, IR
 from givenergy_modbus.model.register_cache import RegisterCache
 from tests.model.test_devices import _add_rollup_slot, _encode_serial
+
+
+def test_plant_device_row_contract():
+    """PlantDevice carries the #106 walk contract fields; `model` is gone."""
+    from givenergy_modbus.model.devices import DeviceType
+
+    row = PlantDevice(
+        identity="XX1234A567",
+        device_type=DeviceType.BATTERY,
+        parent="YY1234A567",
+        device=object(),
+        serial_number="XX1234A567",
+        firmware_version="3005",
+        is_valid=True,
+        is_control_authority=False,
+        data_source=None,
+    )
+    assert row.identity == "XX1234A567"
+    assert row.parent == "YY1234A567"
+    assert row.is_control_authority is False
+    assert not hasattr(row, "model")
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        row.identity = "nope"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Plant-priming helpers — same inline-construction idiom used throughout this
+# file and test_devices.py (Plant() + capabilities + register_caches).
+# ---------------------------------------------------------------------------
 
 
 def _battery_cache(serial: str) -> RegisterCache:
@@ -27,185 +57,148 @@ def _battery_cache(serial: str) -> RegisterCache:
     return RegisterCache({IR(110 + i): v for i, v in _encode_serial(serial).items()})
 
 
-def test_devices_ems_plant_enumerates_managed_inverters_and_ems_without_misclassification():
-    """EMS plant: managed inverters become INVERTER rows; the EMS is its own EMS row.
+def _hybrid_plant_two_packs(*, drop_cache_for: int | None = None) -> Plant:
+    """Hybrid inverter plant (root at 0x11) with two LV battery packs at 0x32/0x33.
 
-    The headline #106 fix — an EMS controller must NEVER appear as an INVERTER
-    row (hass#52). Two managed slots → two INVERTER rows + exactly one EMS row,
-    and no inverter row ever wraps the Ems. Blinded inverters carry no
-    sub-devices (the rollup can't see batteries).
-    """
-    values: dict = {IR(2040): 1, IR(2044): 2}
-    _add_rollup_slot(values, 1, serial="XX1234A567", power=1800, soc=65)
-    _add_rollup_slot(values, 2, serial="ZZ9876B543", power=2200, soc=78)
-    plant = Plant()
-    plant.capabilities = PlantCapabilities(device_type=Model.EMS, inverter_address=0x32)
-    plant.register_caches[0x32] = RegisterCache(values)
-
-    devices = plant.devices
-    by_type = [d.device_type for d in devices]
-
-    assert by_type.count(DeviceType.INVERTER) == 2
-    assert by_type.count(DeviceType.EMS) == 1
-    assert DeviceType.GATEWAY not in by_type
-
-    inverter_rows = [d for d in devices if d.device_type is DeviceType.INVERTER]
-    assert {d.serial_number for d in inverter_rows} == {"XX1234A567", "ZZ9876B543"}
-    assert all(isinstance(d.device, Inverter) for d in inverter_rows)
-    # No mis-classification: the EMS is never wrapped as an inverter.
-    assert not any(isinstance(d.device, Ems) for d in inverter_rows)
-    # Blinded managed inverters have an unknown own-model (the plant model is EMS).
-    assert all(d.model is None for d in inverter_rows)
-    # Blinded inverters honestly carry no sub-devices.
-    assert all(d.device.batteries == [] for d in inverter_rows)
-    assert all(d.device.hv_stacks == [] for d in inverter_rows)
-
-    ems_row = next(d for d in devices if d.device_type is DeviceType.EMS)
-    assert isinstance(ems_row.device, Ems)
-    assert ems_row.model is Model.EMS
-
-
-def test_devices_batteries_nest_under_their_inverter_and_back_compat_preserved():
-    """Non-EMS plant: LV batteries nest under the inverter, not as top-level rows.
-
-    No flat BATTERY rows are emitted; both packs ride on the single INVERTER
-    row's ``device.batteries`` with serials intact. The legacy ``Plant.batteries``
-    accessor stays untouched (same list, same serials) — the model layer is
-    additive.
+    ``drop_cache_for`` optionally omits one pack's register cache (0x32 or
+    0x33) to exercise the #213 placeholder path — the address stays listed in
+    capabilities but has no cache, so it decodes to an invalid, serial-less
+    battery instead of being dropped.
     """
     plant = Plant()
+    plant.inverter_serial_number = "SA1234G567"
     plant.capabilities = PlantCapabilities(
         device_type=Model.HYBRID_GEN3,
-        inverter_address=0x31,
+        inverter_address=0x11,
         lv_battery_addresses=[0x32, 0x33],
     )
-    plant.register_caches[0x31] = RegisterCache()
-    plant.register_caches[0x32] = _battery_cache("XX1234A567")
-    plant.register_caches[0x33] = _battery_cache("ZZ9876B543")
-
-    devices = plant.devices
-    by_type = [d.device_type for d in devices]
-
-    # Nested, not flat: exactly one INVERTER row, zero top-level BATTERY rows.
-    assert by_type.count(DeviceType.INVERTER) == 1
-    assert DeviceType.BATTERY not in by_type
-
-    inverter_row = next(d for d in devices if d.device_type is DeviceType.INVERTER)
-    nested = inverter_row.device.batteries
-    assert len(nested) == 2
-    assert {b.serial_number for b in nested} == {"XX1234A567", "ZZ9876B543"}
-
-    # Back-compat: legacy flat accessor unchanged.
-    assert len(plant.batteries) == 2
-    assert {b.serial_number for b in plant.batteries} == {"XX1234A567", "ZZ9876B543"}
-
-
-def test_devices_hv_stacks_nest_under_their_inverter():
-    """HV plant (AIO): HV stacks nest under the inverter, not as top-level rows.
-
-    Mirrors LV battery nesting for the HV (BCU/BMU) topology. The inverter row's
-    ``device.hv_stacks`` carries the stack; no flat HV_STACK row is emitted; the
-    legacy ``Plant.hv_stacks`` accessor is unchanged.
-    """
-    plant = Plant()
-    plant.capabilities = PlantCapabilities(
-        device_type=Model.ALL_IN_ONE,
-        inverter_address=0x11,
-        bcu_stacks=[(0, 2)],
-    )
     plant.register_caches[0x11] = RegisterCache()
-    plant.register_caches[0x70] = RegisterCache()
-
-    devices = plant.devices
-    by_type = [d.device_type for d in devices]
-
-    assert by_type.count(DeviceType.INVERTER) == 1
-    assert DeviceType.HV_STACK not in by_type
-
-    inverter_row = next(d for d in devices if d.device_type is DeviceType.INVERTER)
-    assert len(inverter_row.device.hv_stacks) == 1
-
-    # Back-compat: legacy flat accessor unchanged.
-    assert len(plant.hv_stacks) == 1
+    if drop_cache_for != 0x32:
+        plant.register_caches[0x32] = _battery_cache("XX1234A567")
+    if drop_cache_for != 0x33:
+        plant.register_caches[0x33] = _battery_cache("YY1234A567")
+    return plant
 
 
-def test_devices_gateway_plant_emits_single_gateway_row_and_no_spurious_inverter():
-    """Gateway plant: exactly one GATEWAY row and ZERO inverter rows.
+def test_walk_single_inverter_plant_root_and_batteries():
+    """Hybrid plant: inverter root (authority), packs as child rows keyed by own serial."""
+    plant = _hybrid_plant_two_packs()  # existing-style helper: caps + primed 0x11/0x32/0x33
+    rows = plant.devices
+    root = rows[0]
+    assert root.parent is None and root.device_type is DeviceType.INVERTER
+    assert root.identity == plant.inverter_serial_number
+    assert root.is_control_authority is True
+    packs = [r for r in rows if r.device_type is DeviceType.BATTERY]
+    assert [p.identity for p in packs] == [p.serial_number for p in packs]  # own serial, no prefix
+    assert all(p.parent == root.identity for p in packs)
+    assert sum(r.is_control_authority for r in rows) == 1
 
-    On a gateway plant the singular ``Plant.inverter`` decodes the gateway's
-    own cache as an inverter — a spurious row. ``Plant.devices`` suppresses it.
+
+def test_walk_placeholder_battery_slot_identity():
+    """#213 placeholder (listed address, empty cache): inert slot identity, is_valid False."""
+    plant = _hybrid_plant_two_packs(drop_cache_for=0x33)
+    rows = plant.devices
+    ph = [r for r in rows if r.device_type is DeviceType.BATTERY and not r.is_valid]
+    assert len(ph) == 1
+    assert ph[0].identity == f"{plant.inverter_serial_number}_battery_2"
+    assert ph[0].serial_number is None
+
+
+def test_walk_ems_plant_controller_authority_managed_children():
+    """EMS plant: EMS root has authority; managed inverters are INVERTER rows.
+
+    Identity {serial}_managed, parent=EMS root, data_source='ems_rollup', is_valid True.
     """
+    values: dict = {IR(2040): 1, IR(2044): 2}  # ems_status=1, inverter_count=2
+    _add_rollup_slot(values, 1, serial="XX1234A567", power=1800, soc=65)
+    _add_rollup_slot(values, 2, serial="YY1234A567", power=2200, soc=78)
+    # HR(19)/HR(21): dsp/arm firmware words, read via plant.inverter decoding the EMS's
+    # own cache (C.firmware_version -> "D0.{dsp}-A0.{arm}").
+    values[HR(19)] = 5
+    values[HR(21)] = 7
     plant = Plant()
-    plant.capabilities = PlantCapabilities(device_type=Model.GATEWAY, inverter_address=0x11)
-    plant.register_caches[0x11] = RegisterCache()
+    plant.inverter_serial_number = "EM1234A567"
+    plant.capabilities = PlantCapabilities(device_type=Model.EMS, inverter_address=0x11)
+    plant.register_caches[0x11] = RegisterCache(values)
 
-    devices = plant.devices
-    by_type = [d.device_type for d in devices]
+    rows = plant.devices
+    root = rows[0]
+    assert root.parent is None
+    assert root.device_type is DeviceType.EMS
+    assert root.identity == plant.inverter_serial_number
+    assert root.is_control_authority is True
+    assert root.firmware_version == "D0.5-A0.7"  # HR(19)=5, HR(21)=7
 
-    assert by_type.count(DeviceType.GATEWAY) == 1
-    assert DeviceType.INVERTER not in by_type
-    gw_row = next(d for d in devices if d.device_type is DeviceType.GATEWAY)
-    assert isinstance(gw_row.device, (GatewayV1, GatewayV2))
-    assert gw_row.model is Model.GATEWAY
+    managed = [r for r in rows if r.device_type is DeviceType.INVERTER]
+    assert len(managed) == 2
+    assert {r.identity for r in managed} == {"XX1234A567_managed", "YY1234A567_managed"}
+    assert all(r.parent == root.identity for r in managed)
+    assert all(r.data_source == "ems_rollup" for r in managed)
+    assert all(r.is_valid is True for r in managed)
+    # Blinded rollup entries carry no direct decode, so no per-inverter firmware.
+    assert all(r.firmware_version is None for r in managed)
+    assert sum(r.is_control_authority for r in rows) == 1
 
 
-def test_devices_gateway_orphan_stacks_kept_as_flat_rows():
-    """Gateway plant with a stray HV stack: keep it as a flat row, never drop it.
-
-    The gateway suppresses its (spurious) inverter row, so there's no inverter
-    to nest sub-devices under. Rather than silently lose a stack the plant did
-    decode, the orphan guard emits a flat HV_STACK row. (Proper gateway
-    partner-AIO expansion is deferred to a later phase.)
-    """
+def test_walk_gateway_plant():
+    """Gateway root (authority), no INVERTER row, meters parent to the gateway root."""
     plant = Plant()
+    plant.inverter_serial_number = "GW1234A567"
     plant.capabilities = PlantCapabilities(
         device_type=Model.GATEWAY,
-        inverter_address=0x11,
-        bcu_stacks=[(0, 2)],
-    )
-    plant.register_caches[0x11] = RegisterCache()
-    plant.register_caches[0x70] = RegisterCache()
-
-    by_type = [d.device_type for d in plant.devices]
-    assert by_type.count(DeviceType.GATEWAY) == 1
-    assert DeviceType.INVERTER not in by_type
-    # Not lost: the stray stack surfaces as a flat row.
-    assert by_type.count(DeviceType.HV_STACK) == 1
-
-
-def test_devices_gateway_orphan_batteries_kept_as_flat_rows():
-    """Gateway plant with stray LV batteries: keep them as flat rows, never drop them.
-
-    Mirrors the HV-stack orphan guard — the gateway suppresses its (spurious)
-    inverter row, so there's no inverter to nest batteries under. The orphan
-    guard emits flat BATTERY rows rather than silently losing them.
-    """
-    plant = Plant()
-    plant.capabilities = PlantCapabilities(
-        device_type=Model.GATEWAY,
-        inverter_address=0x11,
-        lv_battery_addresses=[0x32],
-    )
-    plant.register_caches[0x11] = RegisterCache()
-    plant.register_caches[0x32] = _battery_cache("XX1234A567")
-
-    by_type = [d.device_type for d in plant.devices]
-    assert by_type.count(DeviceType.GATEWAY) == 1
-    assert DeviceType.INVERTER not in by_type
-    assert by_type.count(DeviceType.BATTERY) == 1
-
-
-def test_devices_enumerates_meters_as_flat_rows():
-    """Meters surface as top-level rows — they aren't inverter-owned (Phase 1 limitation)."""
-    plant = Plant()
-    plant.capabilities = PlantCapabilities(
-        device_type=Model.HYBRID_GEN3,
         inverter_address=0x11,
         meter_addresses=[0x01],
     )
-    plant.register_caches[0x11] = RegisterCache()
-    plant.register_caches[0x01] = RegisterCache()
+    # IR(1600-1603): gateway_version block ('G'=0x47,'A'=0x41, then digit registers 0, 9) -> "GA0009".
+    plant.register_caches[0x11] = RegisterCache({IR(1600): 0x4741, IR(1601): 0, IR(1602): 0, IR(1603): 9})
+    plant.register_caches[0x01] = RegisterCache({IR(60): 2300})  # v_phase_1 deci -> 230.0V, meter.is_valid()
 
-    by_type = [d.device_type for d in plant.devices]
-    assert by_type.count(DeviceType.METER) == 1
-    assert by_type.count(DeviceType.INVERTER) == 1
+    rows = plant.devices
+    root = rows[0]
+    assert root.parent is None
+    assert root.device_type is DeviceType.GATEWAY
+    assert root.identity == plant.inverter_serial_number
+    assert root.is_control_authority is True
+    assert DeviceType.INVERTER not in [r.device_type for r in rows]
+    assert root.firmware_version == "GA0009"
+
+    meters = [r for r in rows if r.device_type is DeviceType.METER]
+    assert len(meters) == 1
+    assert meters[0].parent == root.identity
+    assert meters[0].is_valid is True
+    # Meter carries no own serial_number field (Phase-1 limitation) -> synthetic identity.
+    assert meters[0].identity == f"{plant.inverter_serial_number}_meter_1"
+    assert sum(r.is_control_authority for r in rows) == 1
+
+
+def test_walk_hv_stack_and_bmus():
+    """Stack identity {plant_serial}_hvstack_{addr:#04x}; BMUs parent to the stack.
+
+    BMU identity = own serial; stack firmware = bcu.pack_software_version.
+    """
+    plant = Plant()
+    plant.inverter_serial_number = "HV1234A567"
+    plant.capabilities = PlantCapabilities(
+        device_type=Model.ALL_IN_ONE,
+        inverter_address=0x11,
+        bcu_stacks=[(0, 1)],  # BCU at 0x70 + 0, one BMU at 0x50
+    )
+    plant.register_caches[0x11] = RegisterCache()
+    # IR(60-63): BCU pack_software_version ('H'=0x48,'Y'=0x59, then digit registers 0, 1) -> "HY0001".
+    plant.register_caches[0x70] = RegisterCache({IR(60): 0x4859, IR(61): 0, IR(62): 0, IR(63): 1})
+    # IR(114-118): BMU's own 5-register serial block.
+    plant.register_caches[0x50] = RegisterCache({IR(114 + i): v for i, v in _encode_serial("XX1234A567").items()})
+
+    rows = plant.devices
+    root = rows[0]
+    stack_identity = f"{plant.inverter_serial_number}_hvstack_0x70"  # device_address=0x70, {addr:#04x}
+    stack_row = next(r for r in rows if r.device_type is DeviceType.HV_STACK)
+    assert stack_row.parent == root.identity
+    assert stack_row.identity == stack_identity
+    assert stack_row.firmware_version == "HY0001"
+
+    bmu_rows = [r for r in rows if r.device_type is DeviceType.BATTERY_MODULE]
+    assert len(bmu_rows) == 1
+    assert bmu_rows[0].parent == stack_identity
+    assert bmu_rows[0].identity == "XX1234A567"  # own serial, no prefix
+    assert bmu_rows[0].serial_number == "XX1234A567"

--- a/tests/model/test_plant_devices.py
+++ b/tests/model/test_plant_devices.py
@@ -202,3 +202,116 @@ def test_walk_hv_stack_and_bmus():
     assert bmu_rows[0].parent == stack_identity
     assert bmu_rows[0].identity == "XX1234A567"  # own serial, no prefix
     assert bmu_rows[0].serial_number == "XX1234A567"
+
+
+def test_walk_root_identity_uses_inverter_serial_accessor():
+    """I2: root identity anchors on ``Plant.inverter_serial`` (register-first).
+
+    Not the envelope ``inverter_serial_number`` field. The documented
+    ``Plant.from_caches()`` recipe (no live client) doesn't pass an
+    envelope serial, so a bare ``Plant.from_caches()`` call must still resolve the real
+    serial from the register cache (HR13-17) rather than surfacing an empty identity.
+    """
+    values = {
+        HR(0): 0x2001,
+        HR(21): 449,  # HYBRID_GEN1
+        # HR(13-17) -> "XX1234A567"
+        HR(13): 0x5858,
+        HR(14): 0x3132,
+        HR(15): 0x3334,
+        HR(16): 0x4135,
+        HR(17): 0x3637,
+    }
+    plant = Plant.from_caches({0x11: RegisterCache(values)})
+    assert plant.devices[0].identity == "XX1234A567"
+
+
+def test_walk_aio_module_synthetic_identity_when_serial_less():
+    """I1: a capability-listed AIO module with no decodable serial gets a synthetic identity.
+
+    The address stays listed in capabilities but its register cache is present-and-empty
+    (no valid decode) rather than absent — analogous to the #213 battery/meter placeholder
+    path. Without the fallback this would collide with siblings on an empty identity.
+    """
+    plant = Plant()
+    plant.inverter_serial_number = "CH1234G567"
+    plant.capabilities = PlantCapabilities(
+        device_type=Model.ALL_IN_ONE,
+        inverter_address=0x11,
+        aio_battery_module_addresses=[0x50, 0x51],
+    )
+    plant.register_caches[0x11] = RegisterCache()
+    plant.register_caches[0x50] = RegisterCache({IR(114 + i): v for i, v in _encode_serial("XX1234A567").items()})
+    plant.register_caches[0x51] = RegisterCache()  # present, but serial-less — no valid decode
+
+    rows = plant.devices
+    module_rows = {r.identity: r for r in rows if r.device_type is DeviceType.BATTERY_MODULE}
+    assert set(module_rows) == {"XX1234A567", "CH1234G567_module_81"}  # 0x51 == 81
+    placeholder = module_rows["CH1234G567_module_81"]
+    assert placeholder.is_valid is False
+    assert placeholder.serial_number is None
+    assert module_rows["XX1234A567"].is_valid is True
+
+
+def test_walk_hv_bmu_synthetic_identity_when_serial_less():
+    """I1: an HV BMU with an absent module cache gets a synthetic identity.
+
+    Keyed off the stack identity and its 1-based index within the stack, instead of
+    colliding with its siblings on an empty identity.
+    """
+    plant = Plant()
+    plant.inverter_serial_number = "HV1234A567"
+    plant.capabilities = PlantCapabilities(
+        device_type=Model.ALL_IN_ONE,
+        inverter_address=0x11,
+        bcu_stacks=[(0, 2)],  # BCU at 0x70, two BMUs at 0x50/0x51
+    )
+    plant.register_caches[0x11] = RegisterCache()
+    # IR(60-63): BCU pack_software_version -> "HY0001".
+    plant.register_caches[0x70] = RegisterCache({IR(60): 0x4859, IR(61): 0, IR(62): 0, IR(63): 1})
+    plant.register_caches[0x50] = RegisterCache({IR(114 + i): v for i, v in _encode_serial("XX1234A567").items()})
+    # 0x51 (second BMU) has no cache at all; Plant.hv_stacks() decodes it from a default
+    # empty RegisterCache() rather than dropping it.
+
+    rows = plant.devices
+    stack_identity = f"{plant.inverter_serial_number}_hvstack_0x70"
+    bmu_rows = {r.identity: r for r in rows if r.device_type is DeviceType.BATTERY_MODULE}
+    assert set(bmu_rows) == {"XX1234A567", f"{stack_identity}_bmu_2"}
+    placeholder = bmu_rows[f"{stack_identity}_bmu_2"]
+    assert placeholder.is_valid is False
+    assert placeholder.serial_number is None
+
+
+def test_walk_hv_stack_row_is_valid_false_when_bcu_unreachable():
+    """M1: an HV_STACK row's is_valid reflects the BCU decode, not a bare default of True."""
+    plant = Plant()
+    plant.inverter_serial_number = "HV1234A567"
+    plant.capabilities = PlantCapabilities(
+        device_type=Model.ALL_IN_ONE,
+        inverter_address=0x11,
+        bcu_stacks=[(0, 0)],  # BCU at 0x70, no BMUs
+    )
+    plant.register_caches[0x11] = RegisterCache()
+    # No cache for 0x70 at all — the BCU hasn't answered.
+
+    rows = plant.devices
+    stack_row = next(r for r in rows if r.device_type is DeviceType.HV_STACK)
+    assert stack_row.is_valid is False
+
+
+def test_walk_pins_inverter_and_battery_firmware_versions():
+    """M4: root inverter firmware_version (HR19/HR21) and LV-battery firmware_version (IR98).
+
+    Matches ``SinglePhaseInverter.firmware_version``'s ``D0.{dsp}-A0.{arm}`` format for the
+    root row, and the battery row's raw ``bms_firmware_version`` stringified.
+    """
+    plant = _hybrid_plant_two_packs()
+    plant.register_caches[0x11].update({HR(19): 5, HR(21): 449})
+    plant.register_caches[0x32].update({IR(98): 3005})
+
+    rows = plant.devices
+    root = rows[0]
+    assert root.firmware_version == "D0.5-A0.449"
+
+    battery_row = next(r for r in rows if r.device_type is DeviceType.BATTERY and r.identity == "XX1234A567")
+    assert battery_row.firmware_version == "3005"

--- a/tests/model/test_plant_devices.py
+++ b/tests/model/test_plant_devices.py
@@ -89,7 +89,7 @@ def test_walk_single_inverter_plant_root_and_batteries():
     assert root.identity == plant.inverter_serial_number
     assert root.is_control_authority is True
     packs = [r for r in rows if r.device_type is DeviceType.BATTERY]
-    assert [p.identity for p in packs] == [p.serial_number for p in packs]  # own serial, no prefix
+    assert {p.identity for p in packs} == {"XX1234A567", "YY1234A567"}  # own serial, no prefix
     assert all(p.parent == root.identity for p in packs)
     assert sum(r.is_control_authority for r in rows) == 1
 

--- a/tests/model/test_plant_devices.py
+++ b/tests/model/test_plant_devices.py
@@ -253,6 +253,39 @@ def test_walk_aio_module_synthetic_identity_when_serial_less():
     assert module_rows["XX1234A567"].is_valid is True
 
 
+def test_walk_aio_module_identity_survives_sparse_earlier_address():
+    """I1 regression: a missing earlier address must not shift later modules' identities.
+
+    ``aio_battery_modules`` silently skips addresses absent from ``register_caches``
+    (0x50 here), so it only yields entries for 0x51 and 0x52. Zipping that shorter list
+    against the full address list ``[0x50, 0x51, 0x52]`` mislabels the 0x51 module as
+    0x50. Each module carries its own ``module_address`` (set in
+    ``AioBatteryModule.from_register_cache``), so the walk must key off that instead of
+    positional correspondence with the address list.
+    """
+    plant = Plant()
+    plant.inverter_serial_number = "CH1234G567"
+    plant.capabilities = PlantCapabilities(
+        device_type=Model.ALL_IN_ONE,
+        inverter_address=0x11,
+        aio_battery_module_addresses=[0x50, 0x51, 0x52],
+    )
+    plant.register_caches[0x11] = RegisterCache()
+    # 0x50 is absent entirely -> aio_battery_modules() skips it.
+    plant.register_caches[0x51] = RegisterCache()  # present, but serial-less
+    plant.register_caches[0x52] = RegisterCache({IR(114 + i): v for i, v in _encode_serial("XX1234A567").items()})
+
+    rows = plant.devices
+    module_rows = {r.identity: r for r in rows if r.device_type is DeviceType.BATTERY_MODULE}
+    # The serial-less module physically at 0x51 must be keyed on its own address (81),
+    # not shifted onto the absent 0x50 (80).
+    assert set(module_rows) == {"XX1234A567", "CH1234G567_module_81"}
+    placeholder = module_rows["CH1234G567_module_81"]
+    assert placeholder.is_valid is False
+    assert placeholder.serial_number is None
+    assert module_rows["XX1234A567"].is_valid is True
+
+
 def test_walk_hv_bmu_synthetic_identity_when_serial_less():
     """I1: an HV BMU with an absent module cache gets a synthetic identity.
 

--- a/tests/model/test_topology_walk.py
+++ b/tests/model/test_topology_walk.py
@@ -1,0 +1,123 @@
+"""Golden-fixture pins for the #106 flat topology walk (``Plant.devices``).
+
+Each test replays a committed wire capture offline (the same fixtures the golden
+master uses — see ``test_fixture_golden_master.py``), derives capabilities the way
+``Plant.from_caches()`` does (no live client), and pins the *exact* ordered
+``Plant.devices`` row list: one root row (``parent=None``,
+``is_control_authority=True``) followed by child rows sorted by
+``(device_type.value, identity)``. A drift in the walk's shape — a row dropped,
+reparented, or resorted — trips one of these pins.
+"""
+
+from givenergy_modbus.model.plant import Plant
+
+from .test_fixture_golden_master import _replay
+
+
+async def _walk(*relpaths: str) -> list[tuple[str, str, str | None, bool, bool]]:
+    """Replay a capture, derive capabilities offline, and flatten ``Plant.devices``.
+
+    Mirrors ``Plant.from_caches(plant_from_capture(path).register_caches)`` — the
+    documented recipe for building a fully-typed Plant from a register-cache dump
+    (see ``Plant.from_caches`` docstring) — applied to ``_replay``'s in-memory
+    caches instead of a fresh capture load, so every typed accessor (batteries,
+    meters, hv_stacks, ems, gateway) the walk reads from is populated exactly as
+    it would be for an offline capture export.
+    """
+    plant = await _replay(*relpaths)
+    walked = Plant.from_caches(
+        plant.register_caches,
+        inverter_serial_number=plant.inverter_serial_number,
+        data_adapter_serial_number=plant.data_adapter_serial_number,
+    )
+    return [(r.identity, r.device_type.value, r.parent, r.is_control_authority, r.is_valid) for r in walked.devices]
+
+
+async def test_ems_walk_pins_controller_plus_two_managed_inverters_and_meters():
+    """EMS controller + 2 managed inverters (blinded, rollup-sourced) + 2 CT meters.
+
+    No LV/HV batteries on this row list — the three physical packs live behind
+    the managed inverters' own dongles (separate captures), invisible to the EMS
+    controller's own register file. The two managed-inverter rows share an
+    identical identity (``CE2231G000_managed``): the fixture's real inverter
+    serials differ (`CE2231G000` vs `CE2242G000` per the fixture README), but the
+    committed capture's EMS-rollup slots decode byte-identical — a pre-existing
+    redaction artifact on this capture, not a walk defect (see test-3 report).
+    """
+    rows = await _walk("ems_2_inv_3_bat_a/ems_arm1036_30min.log")
+    assert rows == [
+        ("EMS2522000", "ems", None, True, True),
+        ("CE2231G000_managed", "inverter", "EMS2522000", False, True),
+        ("CE2231G000_managed", "inverter", "EMS2522000", False, True),
+        ("EMS2522000_meter_1", "meter", "EMS2522000", False, True),
+        ("EMS2522000_meter_3", "meter", "EMS2522000", False, True),
+    ]
+
+
+async def test_aio_walk_pins_inverter_plus_four_battery_modules_and_hv_stack():
+    """All-in-One: inverter root, 4 integrated HV battery modules, 1 HV stack (BCU).
+
+    The four module identities are all ``2414G000`` (no ``CH`` prefix): this BMU
+    firmware (BAAA0013) stores its serial split on the wire (prefix at IR110, tail
+    at IR115-118, #378) and this replay path applies no MockPlant-style
+    disambiguation, so the raw decode is prefixless and duplicated across modules
+    — documented as expected on this fixture in
+    ``test_mock_plant_integration.py::_assert_aio_redetect``.
+    """
+    rows = await _walk("aio_a/aio_arm620_redetect_7min.log")
+    assert rows == [
+        ("CH2414G000", "inverter", None, True, True),
+        ("2414G000", "battery_module", "CH2414G000", False, True),
+        ("2414G000", "battery_module", "CH2414G000", False, True),
+        ("2414G000", "battery_module", "CH2414G000", False, True),
+        ("2414G000", "battery_module", "CH2414G000", False, True),
+        ("CH2414G000_hvstack_0x70", "hv_stack", "CH2414G000", False, True),
+    ]
+
+
+async def test_hybrid_walk_pins_inverter_plus_two_lv_batteries():
+    """Single-phase HYBRID_GEN1, direct (no EMS): inverter root + 2 LV battery packs."""
+    rows = await _walk("hybrid_2_bat_a/hybrid_gen1_arm449_0x11_poll_10min.log")
+    assert rows == [
+        ("SA2114G000", "inverter", None, True, True),
+        ("BG2134G000", "battery", "SA2114G000", False, True),
+        ("DZ2228G000", "battery", "SA2114G000", False, True),
+    ]
+
+
+async def test_gateway_walk_pins_gateway_plus_two_meters():
+    """Gen1 Gateway fronting 2 parallel AIOs: gateway root + 2 CT meters.
+
+    The AIOs' batteries are register-embedded in the gateway rollup (IR1600-1859),
+    not separately-addressed devices, so they don't surface as their own rows here.
+    """
+    rows = await _walk("gateway_2aio_a/gateway_gaaa0014_10min_daylight.log")
+    assert rows == [
+        ("GW2412G000", "gateway", None, True, True),
+        ("GW2412G000_meter_1", "meter", "GW2412G000", False, True),
+        ("GW2412G000_meter_2", "meter", "GW2412G000", False, True),
+    ]
+
+
+async def test_three_phase_hv_walk_pins_inverter_plus_six_bmus_hv_stack_and_two_meters():
+    """Three-phase HV hybrid: inverter root, 1 HV stack with 6 BMU modules, 2 meters.
+
+    All six BMU identities pin to the same ``HY2336G000``: the fixture's redaction
+    scheme preserves family prefix + manufacture week but zeros only the trailing
+    per-unit digits (see ``captures/README.md``), so same-batch modules collapse
+    to an identical placeholder after redaction — a documented property of this
+    capture's redaction, not a decode defect.
+    """
+    rows = await _walk("three_phase_hv_a/giv3hy11_da011_detect_10min.log")
+    assert rows == [
+        ("TC2337G000", "inverter", None, True, True),
+        ("HY2336G000", "battery_module", "TC2337G000_hvstack_0x70", False, True),
+        ("HY2336G000", "battery_module", "TC2337G000_hvstack_0x70", False, True),
+        ("HY2336G000", "battery_module", "TC2337G000_hvstack_0x70", False, True),
+        ("HY2336G000", "battery_module", "TC2337G000_hvstack_0x70", False, True),
+        ("HY2336G000", "battery_module", "TC2337G000_hvstack_0x70", False, True),
+        ("HY2336G000", "battery_module", "TC2337G000_hvstack_0x70", False, True),
+        ("TC2337G000_hvstack_0x70", "hv_stack", "TC2337G000", False, True),
+        ("TC2337G000_meter_1", "meter", "TC2337G000", False, True),
+        ("TC2337G000_meter_2", "meter", "TC2337G000", False, True),
+    ]

--- a/tests/model/test_topology_walk.py
+++ b/tests/model/test_topology_walk.py
@@ -9,6 +9,8 @@ master uses — see ``test_fixture_golden_master.py``), derives capabilities the
 reparented, or resorted — trips one of these pins.
 """
 
+import pytest
+
 from givenergy_modbus.model.plant import Plant
 
 from .test_fixture_golden_master import _replay
@@ -31,6 +33,49 @@ async def _walk(*relpaths: str) -> list[tuple[str, str, str | None, bool, bool]]
         data_adapter_serial_number=plant.data_adapter_serial_number,
     )
     return [(r.identity, r.device_type.value, r.parent, r.is_control_authority, r.is_valid) for r in walked.devices]
+
+
+_FIXTURES = [
+    "ems_2_inv_3_bat_a/ems_arm1036_30min.log",
+    "aio_a/aio_arm620_redetect_7min.log",
+    "hybrid_2_bat_a/hybrid_gen1_arm449_0x11_poll_10min.log",
+    "gateway_2aio_a/gateway_gaaa0014_10min_daylight.log",
+    "three_phase_hv_a/giv3hy11_da011_detect_10min.log",
+]
+
+
+async def _walked_plant(*relpaths: str) -> Plant:
+    """Like ``_walk`` but returns the walked ``Plant`` itself, not flattened tuples."""
+    plant = await _replay(*relpaths)
+    return Plant.from_caches(
+        plant.register_caches,
+        inverter_serial_number=plant.inverter_serial_number,
+        data_adapter_serial_number=plant.data_adapter_serial_number,
+    )
+
+
+@pytest.mark.parametrize("relpath", _FIXTURES)
+async def test_walk_invariants(relpath):
+    """Structural invariants that hold regardless of redaction-collapsed identities.
+
+    Global identity uniqueness is deliberately NOT asserted here: these fixtures are
+    raw REDACTED wire captures where same-batch devices (EMS-managed inverters, AIO
+    modules, 3ph BMUs) legitimately decode byte-identical zeroed serials offline — see
+    the per-fixture pins above. Uniqueness is a property of the live MockPlant serve
+    path, which disambiguates those collisions, and is asserted there instead (see
+    ``tests/client/test_mock_plant_integration.py::_assert_three_phase_hv``).
+    """
+    walked = await _walked_plant(relpath)
+    rows = walked.devices
+    roots = [r for r in rows if r.parent is None]
+    assert len(roots) == 1 and rows[0] is roots[0]
+    assert sum(r.is_control_authority for r in rows) == 1
+    assert all(r.identity for r in rows)  # non-empty
+    known = {r.identity for r in rows}
+    assert all(r.parent in known for r in rows if r.parent is not None)
+    assert [(r.identity, r.parent, r.device_type.value) for r in walked.devices] == [
+        (r.identity, r.parent, r.device_type.value) for r in rows
+    ]  # deterministic across accesses
 
 
 async def test_ems_walk_pins_controller_plus_two_managed_inverters_and_meters():


### PR DESCRIPTION
Revives and completes #106 as a **consumer-driven backport**: the Home Assistant integration hand-built its device registry three times over, and this lifts that proven shape into the library as one canonical topology walk. Contract reviewed and **acked byte-for-byte by the hass consumer** before implementation (identity schemes verified against their live registry — zero HA device-registry migration).

## What changed

`Plant.devices` (a derived `@property`, nothing added to `model_dump`) is now a **flat topology walk**: a root row (`parent=None`, index 0, `is_control_authority=True`) followed by child rows sorted `(device_type.value, identity)`, each with a `parent` identity reference. `PlantDevice` gained `identity`, `parent`, `firmware_version`, `is_valid`, `is_control_authority`, `data_source`; dropped `model` (verified zero external consumers — hass and cli both).

**Identity contract** (plant-independent for any device with a serial, so a pack moved between inverters keeps its identity):
- root = plant serial; LV pack / AIO module / HV BMU = own serial; HV stack = `{plant_serial}_hvstack_{addr:#04x}`; blinded managed inverter = `{serial}_managed`; meter = own serial else `{plant_serial}_meter_{addr}`; serial-less placeholders = `{plant_serial}_battery_{slot}` / `_module_{addr}` / `_hvstack_..._bmu_{n}`.
- Exactly one root and one control authority (Gateway > EMS > inverter — the #201/#373 "controls live here" rule as data).

## Design notes

- **Derived-projection architecture kept** — no first-class persistent graph nodes, no Transport abstraction, no cache-ownership migration. Phases 3–4 of the original #106 are **deferred as YAGNI with explicit triggers** (second protocol → Transport; package extraction → cache ownership); recorded for the #106 close.
- **AIO double-count resolved**: `bcu_stacks` and `aio_battery_module_addresses` describe the same physical 0x50–0x53 modules, so the walk emits the HV_STACK row but not its nested BMU rows on AIO plants — matching the consumer's stack+modules device model.
- **Robust serial source**: identities anchor on the register-first `inverter_serial` (#227), so the offline `from_caches` path (no envelope serial) still yields real identities.

## Tests

`tests/model/test_topology_walk.py` — exact golden-fixture walk pins across all five topologies (hybrid, AIO, EMS, gateway, 3ph HV) + structural-invariant property tests (one root, one authority, parents resolve, non-empty identities, determinism). Live full-cycle fence (`test_mock_plant_integration.py`) asserts the walk + identity uniqueness on the 3ph case. Full suite 1623 green, tox green (py313/py314/format/lint/build).

## Follow-ups (not blocking; flagged for the review)

- **Meter identity** is now serial-first (`{plant_serial}_meter_{addr}` only as fallback) — a small refinement beyond the acked contract; hass surfaces no meter device today so it's net-new, but worth confirming.
- **AIO-module parent**: currently the root inverter; the physically-truer parent is the stack. Identity-neutral (own serial either way), so no migration impact — a parent-ref question for hass.
- **MockPlant `_make_device_serials_distinct`** only disambiguates 0x50–0x53, so a 6-module HV stack's last two BMUs collide even on the live serve path; the live uniqueness assertion is `len(set)==len-1` with a comment pending that testing-infra fix.
- Deferred Minors: the double-decode of sub-devices per `.devices` call (perf only); the all-or-nothing AIO/BMU skip guard (no real topology exercises it).

Closes #106 on merge (with the phases-3/4 deferral recorded there).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a flat, deterministic plant topology view with one controller root and linked child devices.
  * Device entries now include stable identities, parent relationships, firmware versions, validity status, control authority, and data-source metadata.
  * Added support for clearer topology reporting across inverters, batteries, HV stacks, meters, EMS systems, and gateways.
  * Unavailable devices are represented with synthetic identities and clearly marked invalid status.

* **Tests**
  * Expanded coverage for topology ordering, hierarchy, identity handling, firmware reporting, and unavailable devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->