### PR TITLE
fix(mock): disambiguate HV BMU serials across the full 0x50-0x6F band

### DIFF
--- a/givenergy_modbus/testing/mock_plant.py
+++ b/givenergy_modbus/testing/mock_plant.py
@@ -43,7 +43,7 @@ from givenergy_modbus.framer import ServerFramer
 from givenergy_modbus.model.aio_battery import AioBatteryModuleRegisterGetter
 from givenergy_modbus.model.battery import BatteryRegisterGetter
 from givenergy_modbus.model.ems import EmsRegisterGetter
-from givenergy_modbus.model.plant import Plant
+from givenergy_modbus.model.plant import _HV_BMU_BAND_END, Plant
 from givenergy_modbus.model.register import HR, IR, MR, Register
 from givenergy_modbus.model.register_cache import RegisterCache
 from givenergy_modbus.pdu import (
@@ -192,10 +192,12 @@ def _make_device_serials_distinct(plant: Plant) -> None:
     synthetic. A fully-distinct group is left untouched; only the in-memory mock caches change,
     never the fixture bytes.
 
-    Handles the IR/``C.serial`` 5-register devices: LV battery packs and AIO modules (re-tailed by
-    bus address), and EMS managed-inverter slots within the 0x11 cache (re-tailed by slot index,
-    since they share an address). Meters (MR/``C.string``) and HV BMUs (stride within a single 0x70
-    cache) use other layouts and are out of scope.
+    Handles the IR/``C.serial`` 5-register devices: LV battery packs (IR 110-114, re-tailed by bus
+    address), AIO modules and HV BMU modules (both IR 114-118, same separate-per-address layout, so a
+    single band walk over 0x50-0x6F re-tails either by bus address), and EMS managed-inverter slots
+    within the 0x11 cache (re-tailed by slot index, since they share an address). Only addresses
+    actually present in the caches are touched, so an AIO's ≤4 modules and a 6-module HV stack alike
+    disambiguate off the same walk. Meters (MR/``C.string``) use another layout and are out of scope.
     """
     caches = plant.register_caches
     # Unified addressing (inverter at 0x11/0x31) puts LV battery pack #1 at 0x32; legacy bare-plant
@@ -205,7 +207,11 @@ def _make_device_serials_distinct(plant: Plant) -> None:
     lv_start = 0x32 if (0x11 in caches or 0x31 in caches) else 0x33
     for addr_range, getter in (
         (range(lv_start, 0x38), BatteryRegisterGetter),  # LV battery packs
-        (range(0x50, 0x54), AioBatteryModuleRegisterGetter),  # AIO battery modules
+        # AIO modules (≤4, 0x50-0x53) and HV BMU modules (≤32, 0x50-0x6F) share the IR(114-118)
+        # serial layout, so one walk over the whole 0x50-band disambiguates either. Filtering on
+        # `a in caches` below means only real, populated module addresses are re-tailed — an AIO
+        # touches 4, a 6-module HV stack touches 6, without a per-topology constant here.
+        (range(0x50, _HV_BMU_BAND_END), AioBatteryModuleRegisterGetter),  # AIO + HV BMU modules
     ):
         # registers_of returns () for getters without a serial_number; _disambiguate_serials then
         # decodes every member to None and no-ops, so we can iterate unconditionally (#247 contract).

--- a/tests/client/test_mock_plant_integration.py
+++ b/tests/client/test_mock_plant_integration.py
@@ -321,15 +321,12 @@ def _assert_three_phase_hv(plant):
     assert [r.identity for r in stack_rows] == ["TC2337G000_hvstack_0x70"]
     bmus = [r for r in rows if r.device_type is DeviceType.BATTERY_MODULE]
     assert len(bmus) == 6 and all(r.parent == "TC2337G000_hvstack_0x70" for r in bmus)
-    # The live serve path disambiguates redaction-collapsed BMU serials, but only
-    # partially today: MockPlant's _make_device_serials_distinct (testing/mock_plant.py)
-    # widens BMU addresses 0x50-0x53 (a range sized for AIO's 4-module cap), so this
-    # 6-module HV stack's modules at 0x54/0x55 still collide on the same placeholder
-    # identity live. That's a MockPlant gap, not a topology-walk defect — asserting
-    # full uniqueness here would be a false pin; assert the one known collision instead
-    # so any further regression (more than one collapsed pair) still trips this test.
+    # The live serve path disambiguates redaction-collapsed BMU serials across the full
+    # 0x50-0x6F band, so all six modules of this HV stack carry distinct identities — no
+    # collision survives to the topology walk. Pin full uniqueness so any regression that
+    # re-collapses a module serial (e.g. narrowing the disambiguation range again) trips here.
     ids = [r.identity for r in rows]
-    assert len(set(ids)) == len(ids) - 1
+    assert len(set(ids)) == len(ids)
 
 
 def _assert_gateway(plant):


### PR DESCRIPTION
## What

`MockPlant._make_device_serials_distinct` re-tails redaction-collapsed serials so replayed multi-instance devices serve distinct identities. For the AIO/HV-module family it walked only `range(0x50, 0x54)` — a range sized for AIO's 4-module cap (`_AIO_MAX_MODULES`). HV BMU stacks share the exact same per-address IR(114-118) serial layout as AIO modules but can span up to 6 modules, so on the `three_phase_hv_a` 6-module fixture the BMUs at 0x54/0x55 kept the collapsed placeholder (`HY2336G000`) even through the live serve path.

This widens the walk to the existing `_HV_BMU_BAND_END` (0x70) constant from `plant.py`, so it covers the full HV BMU per-module band. The existing `a in caches` filter already scopes it to real, populated addresses, so an AIO still touches only its 4 and a 6-module HV stack touches its 6 — no second hardcoded per-topology constant.

## Why not derive from `capabilities`

The topology-walk gap comment suggested deriving the range from `plant.capabilities.hv_bmu_addresses` / `bcu_stacks`. That turns out not to be viable here: `_make_device_serials_distinct` runs on the mock-*server* plant built by `plant_from_capture`, whose `capabilities` is always `None` — it's only ever populated by `Client.detect()` on the client side, never during capture replay. The `a in caches` band filter is actually more precise than a capabilities-derived candidate list would be: it keys off exactly the addresses the capture proved present.

## Test

Tightens `_assert_three_phase_hv` in `test_mock_plant_integration.py` back to full identity uniqueness (`len(set(ids)) == len(ids)`) — it had been weakened on the topology-walk branch to `len(ids) - 1` to tolerate the one known collapsed pair, with a comment flagging the gap. Verified failing before the fix, passing after; full suite 1623 passed, ruff/mypy clean.

## Notes

The old docstring claimed HV BMUs "stride within a single 0x70 cache" and were out of scope — that described an earlier layout and is now stale; the real fixtures show BMUs at separate per-address IR caches, same shape as AIO modules. I've updated it to match. The 6-module stride was wire-confirmed on lamztib's HV capture, but I haven't verified stacks larger than 6 against live data — the band tolerates up to 32 addresses, which is speculative headroom rather than tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device identification for high-voltage battery systems.
  * Prevented duplicate identities among battery management modules in three-phase high-voltage setups.
  * Ensured all detected modules are reported as distinct through the live serving path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->