### PR TITLE
feat(client): probe_alive() — cheap reconnect liveness gate

### DIFF
--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -855,6 +855,49 @@ class Client:
                 _logger.exception("detect: error during connection teardown after failure")
             raise
 
+    async def probe_alive(self, timeout: float = 2.0, retries: int = 0) -> bool:
+        """Cheap reconnect liveness gate: read HR(0) once and report whether the inverter answered.
+
+        Distinct from :meth:`detect` by design. Its ONLY job is "is the inverter responding at
+        all?", so on a hung dongle it fails fast (default ``retries=0``, no peripheral sweep) and
+        its failure is free — the caller just probes again next tick. On the first success the
+        caller runs a full, robust ``detect(retries=3)`` to re-establish topology; that detect
+        stays robust because it no longer carries the probe's fail-fast constraint (which is the
+        whole reason this is a separate method rather than ``detect(retries=0)`` — one call cannot
+        be both the cheap gate and the robust recovery, since the identity read shares a single
+        ``retries``).
+
+        Mirrors :meth:`detect`'s connection discipline, returning a bool instead of raising:
+
+        - **Alive** (HR(0) came back): the socket is left **open**, so the caller's follow-up
+          ``detect`` reuses the same live connection.
+        - **Not alive** (timeout / :class:`CommunicationError`, or a response that left no usable
+          HR(0)): the socket is **closed** (mirroring detect's #274 teardown), releasing it for the
+          dongle's quiet window so the coordinator uniformly reconnects next tick. Never raises.
+
+        Reuses the exact HR(0,60)@0x11 read :meth:`detect` uses (the read proven against real
+        hardware). Reconnect cadence/backoff stays the caller's concern (#356): this owns only the
+        single check.
+        """
+        try:
+            await self.send_request_and_await_response(
+                ReadHoldingRegistersRequest(base_register=0, register_count=60, device_address=0x11),
+                timeout=timeout,
+                retries=retries,
+            )
+            alive = self.plant.register_caches.get(0x11, RegisterCache()).get(HR(0)) is not None
+        except (TimeoutError, CommunicationError):
+            alive = False
+        if not alive:
+            # Release the socket on any not-alive outcome, mirroring detect()'s teardown so a
+            # failed liveness check leaves no half-open connection. Guard close() so a teardown
+            # error can't turn a clean False into an exception.
+            try:
+                await self.close()
+            except Exception:
+                _logger.exception("probe_alive: error during connection teardown after failed liveness probe")
+        return alive
+
     async def _detect_lv_batteries(
         self,
         prior: PlantCapabilities | None,

--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -879,13 +879,23 @@ class Client:
         hardware). Reconnect cadence/backoff stays the caller's concern (#356): this owns only the
         single check.
         """
+        # Liveness must come from THIS probe's fresh response, not any cached HR(0): a
+        # stale HR(0) from an earlier healthy connection would otherwise make a fresh
+        # non-committing probe look alive (e.g. the dongle returns an all-zero bank that
+        # _commit_bank rejects while the read still returns — Codex review). The block's
+        # ingestion timestamp is stamped ONLY on a successful commit (which applies every
+        # guard: Modbus error, CRC, all-zero rejection), so "did this probe re-stamp the
+        # HR(0,60) block" is the honest, guard-delegating liveness signal.
+        block = (0x11, "HR", 0, 60)
+        stamped_before = self.plant.register_block_updated_at.get(block)
         try:
             await self.send_request_and_await_response(
                 ReadHoldingRegistersRequest(base_register=0, register_count=60, device_address=0x11),
                 timeout=timeout,
                 retries=retries,
             )
-            alive = self.plant.register_caches.get(0x11, RegisterCache()).get(HR(0)) is not None
+            stamped_after = self.plant.register_block_updated_at.get(block)
+            alive = stamped_after is not None and stamped_after != stamped_before
         except (TimeoutError, CommunicationError):
             alive = False
         if not alive:

--- a/tests/client/test_detect.py
+++ b/tests/client/test_detect.py
@@ -1,5 +1,6 @@
 """Tests for Client.detect() and PlantCapabilities."""
 
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -1785,26 +1786,56 @@ async def test_detect_skips_lv_preamble_when_prior_has_no_0x32():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
-async def test_probe_alive_true_when_hr0_answers_leaves_socket_open():
-    """A successful HR(0) read returns True and leaves the connection OPEN.
+def _stamp_hr0(client, when):
+    """Simulate what a successful HR(0,60) commit does: stamp the block's ingestion time."""
+    client.plant.register_block_updated_at[(0x11, "HR", 0, 60)] = when
 
-    The coordinator's follow-up detect(retries=3) reuses the same live socket — so
-    probe_alive must NOT tear down on success (mirrors detect leaving the socket up
-    for refresh()).
+
+@pytest.mark.asyncio
+async def test_probe_alive_true_when_fresh_hr0_commits_leaves_socket_open():
+    """A probe that COMMITS a fresh HR(0) bank returns True and leaves the connection OPEN.
+
+    Liveness is derived from this probe re-stamping the HR(0,60) block (a successful
+    commit), not from any cached HR(0) value. The follow-up detect(retries=3) reuses the
+    same live socket, so probe_alive must NOT tear down on success (mirrors detect
+    leaving the socket up for refresh()).
     """
     client = _make_client()
     client.connected = True
-    _prime_cache(client, 0x11, {HR(0): 0x2001})  # what a real successful read would commit
 
-    async def _ok(request, *, timeout, retries):
+    async def _ok_commits(request, *, timeout, retries):
+        _stamp_hr0(client, datetime.now(UTC))  # fresh read survives the commit guards
         return MagicMock()
 
-    with patch.object(client, "send_request_and_await_response", side_effect=_ok):
+    with patch.object(client, "send_request_and_await_response", side_effect=_ok_commits):
         alive = await client.probe_alive()
 
     assert alive is True
     assert client.connected is True  # socket left open for the follow-up detect
+
+
+@pytest.mark.asyncio
+async def test_probe_alive_false_on_stale_hr0_when_fresh_read_does_not_commit():
+    """A stale HR(0) from an earlier healthy connection must NOT read as alive (Codex review).
+
+    Scenario: a prior detect committed a good HR(0); on reconnect the dongle returns an
+    all-zero bank that _commit_bank rejects (so the cache keeps the stale-good HR(0)) while
+    the read still returns. Deriving liveness from the cached value would false-positive;
+    deriving it from 'did this probe re-stamp the block' correctly returns False + closes.
+    """
+    client = _make_client()
+    client.connected = True
+    _prime_cache(client, 0x11, {HR(0): 0x2001})  # stale-but-good HR(0) from a prior connection
+    _stamp_hr0(client, datetime(2020, 1, 1, tzinfo=UTC))  # its ingestion time, before this probe
+
+    async def _ok_no_commit(request, *, timeout, retries):
+        return MagicMock()  # responds, but the rejected bank leaves the stamp unchanged
+
+    with patch.object(client, "send_request_and_await_response", side_effect=_ok_no_commit):
+        alive = await client.probe_alive()
+
+    assert alive is False  # stale HR(0) is not a live signal
+    assert client.connected is False
 
 
 @pytest.mark.asyncio
@@ -1840,17 +1871,17 @@ async def test_probe_alive_false_on_timeout_closes_socket_no_raise():
 
 
 @pytest.mark.asyncio
-async def test_probe_alive_false_when_answered_but_hr0_absent_closes():
-    """A response with no usable HR(0) is not a viable liveness pass.
+async def test_probe_alive_false_when_answered_but_nothing_commits_closes():
+    """A response that commits no HR(0) (never-populated cache, no prior stamp) is not alive.
 
-    E.g. a CRC-dropped identity frame: return False and close, so the coordinator keeps
-    probing rather than detecting off a corrupt identity.
+    E.g. a CRC-dropped or error identity frame: the block is never stamped, so return False
+    and close — the coordinator keeps probing rather than detecting off a corrupt identity.
     """
     client = _make_client()
     client.connected = True
 
     async def _ok_no_commit(request, *, timeout, retries):
-        return MagicMock()  # "responded" but nothing lands in the 0x11 cache
+        return MagicMock()  # "responded" but nothing stamps the HR(0,60) block
 
     with patch.object(client, "send_request_and_await_response", side_effect=_ok_no_commit):
         alive = await client.probe_alive()

--- a/tests/client/test_detect.py
+++ b/tests/client/test_detect.py
@@ -1778,3 +1778,105 @@ async def test_detect_skips_lv_preamble_when_prior_has_no_0x32():
 
     assert 0x32 not in sent_addresses
     assert caps.lv_battery_addresses == []
+
+
+# ---------------------------------------------------------------------------
+# probe_alive() — cheap reconnect liveness gate (mirrors detect teardown, returns bool)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_probe_alive_true_when_hr0_answers_leaves_socket_open():
+    """A successful HR(0) read returns True and leaves the connection OPEN.
+
+    The coordinator's follow-up detect(retries=3) reuses the same live socket — so
+    probe_alive must NOT tear down on success (mirrors detect leaving the socket up
+    for refresh()).
+    """
+    client = _make_client()
+    client.connected = True
+    _prime_cache(client, 0x11, {HR(0): 0x2001})  # what a real successful read would commit
+
+    async def _ok(request, *, timeout, retries):
+        return MagicMock()
+
+    with patch.object(client, "send_request_and_await_response", side_effect=_ok):
+        alive = await client.probe_alive()
+
+    assert alive is True
+    assert client.connected is True  # socket left open for the follow-up detect
+
+
+@pytest.mark.asyncio
+async def test_probe_alive_false_on_timeout_closes_socket_no_raise():
+    """A hung dongle (timeout) returns False (never raises) and CLOSES the socket.
+
+    Mirrors detect's #274 teardown-on-failure, so a failed liveness probe releases the
+    socket for the dongle's quiet window and the coordinator uniformly reconnects next
+    tick — no reprobe-same-socket branch.
+    """
+    client = _make_client()
+    client.connected = True
+
+    async def _timeout(request, *, timeout, retries):
+        raise TimeoutError
+
+    close_calls = []
+    orig_close = client.close
+
+    async def _spy_close():
+        close_calls.append(True)
+        await orig_close()
+
+    with (
+        patch.object(client, "send_request_and_await_response", side_effect=_timeout),
+        patch.object(client, "close", side_effect=_spy_close),
+    ):
+        alive = await client.probe_alive(timeout=0.1, retries=0)
+
+    assert alive is False  # returned, not raised
+    assert close_calls  # teardown happened
+    assert client.connected is False
+
+
+@pytest.mark.asyncio
+async def test_probe_alive_false_when_answered_but_hr0_absent_closes():
+    """A response with no usable HR(0) is not a viable liveness pass.
+
+    E.g. a CRC-dropped identity frame: return False and close, so the coordinator keeps
+    probing rather than detecting off a corrupt identity.
+    """
+    client = _make_client()
+    client.connected = True
+
+    async def _ok_no_commit(request, *, timeout, retries):
+        return MagicMock()  # "responded" but nothing lands in the 0x11 cache
+
+    with patch.object(client, "send_request_and_await_response", side_effect=_ok_no_commit):
+        alive = await client.probe_alive()
+
+    assert alive is False
+    assert client.connected is False
+
+
+@pytest.mark.asyncio
+async def test_probe_alive_reads_hr0_at_0x11_with_given_retries():
+    """The probe issues a single HR(0,60) read at 0x11 with the caller's retries.
+
+    The same proven read detect uses, so retries=0 fails fast on a hung dongle.
+    """
+    client = _make_client()
+    client.connected = True
+    _prime_cache(client, 0x11, {HR(0): 0x2001})
+    seen = {}
+
+    async def _capture(request, *, timeout, retries):
+        seen["device_address"] = request.device_address
+        seen["base_register"] = request.base_register
+        seen["retries"] = retries
+        return MagicMock()
+
+    with patch.object(client, "send_request_and_await_response", side_effect=_capture):
+        await client.probe_alive(retries=2)
+
+    assert seen == {"device_address": 0x11, "base_register": 0, "retries": 2}


### PR DESCRIPTION
Adds `Client.probe_alive(timeout=2.0, retries=0) -> bool` — a named liveness primitive for coordinators managing reconnects to a marginal/hung dongle (hass field diagnosis on AberDino's Gen-1 Gateway).

## Why a separate method, not `detect(retries=0)`

The two-phase reconnect pattern is: while hung, cheap repeated probe; on first sign of life, a full robust detect to re-establish topology. `detect(retries=0)` *looks* like it covers this (its HR0 identity read is the gating first step and aborts fast on a hung dongle), but it conflates the two phases: the identity read shares a single `retries`, so `retries=0` makes the **recovery** detect fragile — a single dropped HR0/HR21 frame on a just-recovered, still-flaky link aborts the whole detect and loses that recovery tick. You can't have one call be both the cheap fail-fast gate and the robust recovery. (The peripheral *sweep* is separately robustifiable via `probe_retries`; the identity read is the irreducible conflict.) So the clean shape is a dedicated cheap probe → then a normal `detect(retries=3)` that no longer carries the fail-fast constraint.

## Contract

Reads the exact `HR(0,60)@0x11` read `detect` uses (proven against real hardware — not a leaner untested `HR(0,1)`). Mirrors detect's connection discipline, returning a bool instead of raising:

- **Alive** (HR0 answered) → socket **left open**, `True` — the coordinator's follow-up `detect(retries=3)` reuses the live connection (as detect-success leaves the socket for `refresh`).
- **Not alive** (timeout / `CommunicationError` / a response that left no usable HR0) → socket **closed** (detect's #274 teardown), `False` — releasing it for the dongle's quiet window, so the coordinator uniformly `connect()` → `probe_alive()` each tick with no reprobe-same-socket branch. Never raises.

Reconnect cadence/backoff stays coordinator-side (#356); the library owns only the single check. No new reconnect loop.

## Tests

`tests/client/test_detect.py` — alive→True + socket stays open; hung→False (not raised) + socket closed; answered-but-no-HR0→False + closed; the read is `HR(0,60)@0x11` with the caller's retries. Full suite 1627 green, tox green.

Rides the pending 2.12.0. hass will be notified of the exact signature to wire their reconnect loop.