### PR TITLE
feat: Plant.last_updated_at freshness signal + coalesce reader-EOF churn

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -172,6 +172,8 @@ The polling path mirrors `detect()`'s split — pure policy decides *what* to re
 
 Unlike `detect()`, there is no validate stage. `refresh()` decides only what to *ask* for; whether to *believe* a response is the cache layer's call — the keep-last-good guards (CRC #255, sub-bus splice #256, bank holds) validate each frame as it commits. The skip-if-fresh gate also makes `refresh()` cooperative with the dongle fan-out: GivEnergy dongles echo responses to every connected client, so a bank another poller just refreshed can be left alone (#196).
 
+A caveat on that fan-out, though: echoing to every connected client is not the same as *tolerating* several of them. How well a dongle copes with concurrent connections and polling load appears to vary by hardware generation, and we can't characterise it from inside the library. One newer-chipset All-In-One dongle (hass#95) idle-reaps the TCP connection roughly every ~10s even with only two clients polling at a fairly mild ~30s cadence — the client reconnects transparently each time and the fan-out resumes, so it stays functional, but "multiple clients at frequent poll rates just work" is not a guarantee the hardware makes uniformly. Treat the fan-out as an opportunistic optimisation, not a contract that concurrent access is free.
+
 ## Plant data model
 
 `Plant` is passive — it stores data, drives no I/O. Its two responsibilities are:

--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -7,7 +7,7 @@ import warnings
 from asyncio import Future, Queue, StreamReader, StreamWriter, Task
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Literal
 
 from givenergy_modbus.exceptions import (
@@ -79,6 +79,13 @@ _FRAME_SENT_MIN_TIMEOUT = 5.0
 # means the peer stopped ACKing — a half-open connection — so it's treated as
 # connection loss rather than left to wedge the producer until close() (hass#233).
 _DRAIN_TIMEOUT = 10.0
+
+# Re-warn cadence for the coalesced reader-EOF reconnect churn. A marginal dongle that
+# idle-reaps the TCP connection every ~10s (hass#95) would otherwise emit thousands of
+# 'connection lost (reader at EOF)' WARNING lines/day on a setup that is working fine —
+# each drop transparently recovers. The first drop warns; subsequent drops within this
+# window are demoted to DEBUG; one re-warn per window carries the running tally.
+_EOF_REWARN_SECONDS = 300.0
 
 
 class FrameRedactor:
@@ -497,6 +504,11 @@ class Client:
         self.expected_responses = {}
         self._shutting_down = False
         self._connection_lost = False
+        # Reader-EOF reconnect-churn coalescing state (#355-style, see _note_eof_drop). Persists
+        # across reconnects — a marginal dongle drops repeatedly, so the burst must be tracked on
+        # the long-lived Client, not per-connection.
+        self._eof_drop_count = 0
+        self._eof_last_warn_at: datetime | None = None
         self.network_producer_task: Task | None = None
         self.network_consumer_task: Task | None = None
         # self.debug_frames = {
@@ -1528,6 +1540,24 @@ class Client:
             self._capture_redactor_rx = None
             self._capture_redactor_tx = None
 
+    def _note_eof_drop(self, now: datetime) -> tuple[bool, int]:
+        """Coalesce a burst of reader-EOF reconnect churn; decide WARNING vs DEBUG (#355-style).
+
+        Returns ``(warn_now, count_since_last_warn)``. The first drop, and the first drop past
+        each ``_EOF_REWARN_SECONDS`` window, warn and carry the running tally of drops since the
+        previous warning; drops in between return ``(False, 0)`` for DEBUG. A drop after a long
+        quiet spell re-warns because ``now - last_warn`` has aged past the window — so a genuinely
+        fresh problem is never silently swallowed, only sustained churn is throttled.
+        """
+        self._eof_drop_count += 1
+        last = self._eof_last_warn_at
+        if last is None or (now - last).total_seconds() >= _EOF_REWARN_SECONDS:
+            count = self._eof_drop_count
+            self._eof_last_warn_at = now
+            self._eof_drop_count = 0
+            return True, count
+        return False, 0
+
     async def _task_network_consumer(self):
         """Task for orchestrating incoming data."""
         while hasattr(self, "reader") and self.reader and not self.reader.at_eof():
@@ -1570,7 +1600,18 @@ class Client:
             _logger.debug("network_consumer exiting on intentional shutdown")
         else:
             self.connected = False
-            _logger.warning("network_consumer: connection lost (reader at EOF)")
+            warn_now, count = self._note_eof_drop(datetime.now(UTC))
+            if warn_now and count > 1:
+                _logger.warning(
+                    "network_consumer: connection lost (reader at EOF) — %d drops in the last ~%ds, "
+                    "recovering transparently each time",
+                    count,
+                    int(_EOF_REWARN_SECONDS),
+                )
+            elif warn_now:
+                _logger.warning("network_consumer: connection lost (reader at EOF)")
+            else:
+                _logger.debug("network_consumer: connection lost (reader at EOF) — coalesced, recovering transparently")
             self._abort_connection(ConnectionLost("reader at EOF — connection lost"))
 
     async def _task_network_producer(self):

--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -1271,6 +1271,9 @@ class Client:
         is not re-solicited this cycle. Defaults to ``None`` — always solicit, the
         historic behaviour. Note the fan-out only exists while something else is polling
         the unit; on a cloud-disconnected dongle the blocks age out and we solicit them.
+        The fan-out is opportunistic, not a promise that concurrent access is free —
+        some dongles idle-reap the connection under multiple clients (hass#95) and
+        reconnect transparently; the skip degrades safely (blocks age out, we solicit).
 
         ``ir0_max_age`` is deprecated — use ``max_age`` instead. It applied the same
         logic to IR(0,60) only; ``max_age`` extends it to every bank. Will be removed

--- a/givenergy_modbus/client/client.py
+++ b/givenergy_modbus/client/client.py
@@ -509,6 +509,7 @@ class Client:
         # the long-lived Client, not per-connection.
         self._eof_drop_count = 0
         self._eof_last_warn_at: datetime | None = None
+        self._eof_last_drop_at: datetime | None = None
         self.network_producer_task: Task | None = None
         self.network_consumer_task: Task | None = None
         # self.debug_frames = {
@@ -1546,15 +1547,27 @@ class Client:
     def _note_eof_drop(self, now: datetime) -> tuple[bool, int]:
         """Coalesce a burst of reader-EOF reconnect churn; decide WARNING vs DEBUG (#355-style).
 
-        Returns ``(warn_now, count_since_last_warn)``. The first drop, and the first drop past
-        each ``_EOF_REWARN_SECONDS`` window, warn and carry the running tally of drops since the
-        previous warning; drops in between return ``(False, 0)`` for DEBUG. A drop after a long
-        quiet spell re-warns because ``now - last_warn`` has aged past the window — so a genuinely
-        fresh problem is never silently swallowed, only sustained churn is throttled.
+        Returns ``(warn_now, count_since_last_warn)``. The first drop of a burst, and the first
+        drop past each ``_EOF_REWARN_SECONDS`` window within a *sustained* burst, warn and carry
+        the running tally of drops since the previous warning; drops in between return
+        ``(False, 0)`` for DEBUG.
+
+        A burst is a run of drops each within ``_EOF_REWARN_SECONDS`` of the previous one. When
+        the gap since the *last drop* exceeds the window the churn has clearly stopped, so the
+        burst is closed and the next drop starts fresh (count 1) rather than escalating with a
+        stale tally accumulated an hour ago — keeping the reported count honest (Codex note on
+        #401). A genuinely fresh problem is therefore never swallowed; only sustained churn is
+        throttled.
         """
+        last_drop = self._eof_last_drop_at
+        if last_drop is not None and (now - last_drop).total_seconds() >= _EOF_REWARN_SECONDS:
+            # Preceding burst is over — reset so this drop is treated as a fresh onset.
+            self._eof_drop_count = 0
+            self._eof_last_warn_at = None
+        self._eof_last_drop_at = now
         self._eof_drop_count += 1
-        last = self._eof_last_warn_at
-        if last is None or (now - last).total_seconds() >= _EOF_REWARN_SECONDS:
+        last_warn = self._eof_last_warn_at
+        if last_warn is None or (now - last_warn).total_seconds() >= _EOF_REWARN_SECONDS:
             count = self._eof_drop_count
             self._eof_last_warn_at = now
             self._eof_drop_count = 0
@@ -1606,10 +1619,9 @@ class Client:
             warn_now, count = self._note_eof_drop(datetime.now(UTC))
             if warn_now and count > 1:
                 _logger.warning(
-                    "network_consumer: connection lost (reader at EOF) — %d drops in the last ~%ds, "
-                    "recovering transparently each time",
+                    "network_consumer: connection lost (reader at EOF) — %d drops since the previous "
+                    "warning, recovering transparently each time",
                     count,
-                    int(_EOF_REWARN_SECONDS),
                 )
             elif warn_now:
                 _logger.warning("network_consumer: connection lost (reader at EOF)")

--- a/givenergy_modbus/model/plant.py
+++ b/givenergy_modbus/model/plant.py
@@ -1647,6 +1647,21 @@ class Plant(GivEnergyBaseModel):
             ts = ts.replace(tzinfo=UTC)
         self.register_block_updated_at[(device_address, reg_type, base_register, register_count)] = ts
 
+    @property
+    def last_updated_at(self) -> datetime | None:
+        """Newest register-block ingestion time across the whole plant, or None if never seen.
+
+        The honest "is the cache being kept fresh" signal for a passive consumer (#65): it
+        advances whenever ANY bank commits — solicited or fanned-out from a peer client —
+        regardless of content, so a stale bus is visible as a signal that stops moving.
+        Because it keys off commit rather than value, it is meaningful even on a Gateway
+        (where the synthetic all-zeros inverter makes ``system_time`` spurious) and is
+        topology-agnostic. ``None`` before the first commit (cold). Consumers derive age as
+        ``now - last_updated_at``.
+        """
+        stamps = self.register_block_updated_at
+        return max(stamps.values()) if stamps else None
+
     def block_age(
         self,
         device_address: int,

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -250,6 +250,24 @@ async def test_consumer_coalesces_repeat_eof_to_debug(caplog):
     )
 
 
+async def test_consumer_escalation_warning_carries_tally(caplog):
+    """After the re-warn window elapses, a repeat drop warns at WARNING with the coalesced tally."""
+    client = Client(host="foo", port=4321)
+    # Simulate an in-progress burst whose last warning is well outside the 300s window: the next
+    # drop must escalate (warn_now True, count > 1) and emit the running tally.
+    client._eof_drop_count = 4
+    client._eof_last_warn_at = datetime.datetime(2000, 1, 1, tzinfo=datetime.UTC)
+    client.reader = StreamReader()
+    client.reader.feed_eof()  # _shutting_down stays False
+
+    with caplog.at_level(logging.DEBUG, logger="givenergy_modbus.client.client"):
+        await client._task_network_consumer()
+
+    warn = [r for r in caplog.records if "reader at EOF" in r.getMessage() and r.levelno == logging.WARNING]
+    assert warn, f"expected an escalation WARNING: {[(r.levelname, r.getMessage()) for r in caplog.records]}"
+    assert "5 drops" in warn[0].getMessage()  # 4 coalesced + this escalation drop
+
+
 async def test_producer_logs_debug_not_critical_on_intentional_shutdown(caplog):
     """Regression for #50: when close() set _shutting_down, the producer must exit at DEBUG, not CRITICAL."""
     client = Client(host="foo", port=4321)

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -251,12 +251,16 @@ async def test_consumer_coalesces_repeat_eof_to_debug(caplog):
 
 
 async def test_consumer_escalation_warning_carries_tally(caplog):
-    """After the re-warn window elapses, a repeat drop warns at WARNING with the coalesced tally."""
+    """A sustained burst crossing the re-warn window escalates at WARNING with the running tally."""
+    from givenergy_modbus.client.client import _EOF_REWARN_SECONDS
+
     client = Client(host="foo", port=4321)
-    # Simulate an in-progress burst whose last warning is well outside the 300s window: the next
-    # drop must escalate (warn_now True, count > 1) and emit the running tally.
+    now = datetime.datetime.now(datetime.UTC)
+    # A live burst: last warned just over the window ago, last drop very recent (churn ongoing),
+    # four drops coalesced since the warning. The next drop must escalate (count > 1).
     client._eof_drop_count = 4
-    client._eof_last_warn_at = datetime.datetime(2000, 1, 1, tzinfo=datetime.UTC)
+    client._eof_last_warn_at = now - datetime.timedelta(seconds=_EOF_REWARN_SECONDS + 1)
+    client._eof_last_drop_at = now - datetime.timedelta(seconds=10)
     client.reader = StreamReader()
     client.reader.feed_eof()  # _shutting_down stays False
 
@@ -266,6 +270,20 @@ async def test_consumer_escalation_warning_carries_tally(caplog):
     warn = [r for r in caplog.records if "reader at EOF" in r.getMessage() and r.levelno == logging.WARNING]
     assert warn, f"expected an escalation WARNING: {[(r.levelname, r.getMessage()) for r in caplog.records]}"
     assert "5 drops" in warn[0].getMessage()  # 4 coalesced + this escalation drop
+    assert "~" not in warn[0].getMessage()  # no misleading fixed-window claim
+
+
+def test_note_eof_drop_reset_keeps_tally_honest_after_quiet_gap():
+    """A lone drop after a long quiet gap warns fresh (count 1), not with a stale coalesced tally."""
+    client = Client(host="foo", port=4321)
+    t0 = datetime.datetime(2026, 7, 12, 12, 0, 0, tzinfo=datetime.UTC)
+    client._note_eof_drop(t0)  # burst onset — warns
+    client._note_eof_drop(t0 + datetime.timedelta(seconds=10))  # coalesced (DEBUG)
+    client._note_eof_drop(t0 + datetime.timedelta(seconds=20))  # coalesced (DEBUG)
+    # An hour of silence, then a single drop: the prior burst is closed, so this is a fresh onset —
+    # it must NOT report the 2 stale drops from an hour ago (Codex #401 honesty note).
+    warn_now, count = client._note_eof_drop(t0 + datetime.timedelta(hours=1))
+    assert (warn_now, count) == (True, 1)
 
 
 async def test_producer_logs_debug_not_critical_on_intentional_shutdown(caplog):

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -185,6 +185,71 @@ async def test_consumer_logs_warning_on_unexpected_eof(caplog):
     assert not any(r.levelno >= logging.ERROR for r in caplog.records)  # a routine drop must not alarm
 
 
+def test_note_eof_drop_first_drop_warns():
+    """The first reader-EOF drop always warns, carrying a tally of 1."""
+    from givenergy_modbus.client.client import _EOF_REWARN_SECONDS  # noqa: F401 — presence check
+
+    client = Client(host="foo", port=4321)
+    t0 = datetime.datetime(2026, 7, 12, 12, 0, 0, tzinfo=datetime.UTC)
+    assert client._note_eof_drop(t0) == (True, 1)
+
+
+def test_note_eof_drop_coalesces_within_interval():
+    """Rapid repeat drops within the re-warn interval are demoted (warn_now False)."""
+    from givenergy_modbus.client.client import _EOF_REWARN_SECONDS
+
+    client = Client(host="foo", port=4321)
+    t0 = datetime.datetime(2026, 7, 12, 12, 0, 0, tzinfo=datetime.UTC)
+    client._note_eof_drop(t0)  # first — warns
+    # Drops every 10s for just under the re-warn interval are all coalesced.
+    for s in range(10, int(_EOF_REWARN_SECONDS), 10):
+        assert client._note_eof_drop(t0 + datetime.timedelta(seconds=s)) == (False, 0)
+
+
+def test_note_eof_drop_rewarns_after_interval_with_tally():
+    """After the re-warn interval elapses, the next drop warns and reports the coalesced count."""
+    from givenergy_modbus.client.client import _EOF_REWARN_SECONDS
+
+    client = Client(host="foo", port=4321)
+    t0 = datetime.datetime(2026, 7, 12, 12, 0, 0, tzinfo=datetime.UTC)
+    client._note_eof_drop(t0)  # first — warns, resets tally
+    # Two coalesced drops, then one past the interval.
+    client._note_eof_drop(t0 + datetime.timedelta(seconds=10))
+    client._note_eof_drop(t0 + datetime.timedelta(seconds=20))
+    warn_now, count = client._note_eof_drop(t0 + datetime.timedelta(seconds=_EOF_REWARN_SECONDS))
+    assert warn_now is True
+    assert count == 3  # the two coalesced + this escalation drop, since the last warning
+
+
+def test_note_eof_drop_rewarns_after_long_quiet_spell():
+    """A single drop after a long stable period warns afresh (last-warn has aged out)."""
+    from givenergy_modbus.client.client import _EOF_REWARN_SECONDS
+
+    client = Client(host="foo", port=4321)
+    t0 = datetime.datetime(2026, 7, 12, 12, 0, 0, tzinfo=datetime.UTC)
+    client._note_eof_drop(t0)  # first — warns
+    later = t0 + datetime.timedelta(seconds=_EOF_REWARN_SECONDS + 3600)
+    assert client._note_eof_drop(later) == (True, 1)
+
+
+async def test_consumer_coalesces_repeat_eof_to_debug(caplog):
+    """A second EOF drop within the interval lands at DEBUG, not WARNING (hass#95 log spam)."""
+    client = Client(host="foo", port=4321)
+    # Simulate a prior recent drop so this one is within the coalescing window.
+    client._note_eof_drop(datetime.datetime.now(datetime.UTC))
+    client.reader = StreamReader()
+    client.reader.feed_eof()  # _shutting_down stays False
+
+    with caplog.at_level(logging.DEBUG, logger="givenergy_modbus.client.client"):
+        await client._task_network_consumer()
+
+    eof_records = [r for r in caplog.records if "reader at EOF" in r.message]
+    assert eof_records, "expected an EOF log line"
+    assert all(r.levelno == logging.DEBUG for r in eof_records), (
+        f"coalesced repeat drop should be DEBUG: {[(r.levelname, r.message) for r in eof_records]}"
+    )
+
+
 async def test_producer_logs_debug_not_critical_on_intentional_shutdown(caplog):
     """Regression for #50: when close() set _shutting_down, the producer must exit at DEBUG, not CRITICAL."""
     client = Client(host="foo", port=4321)

--- a/tests/model/test_plant.py
+++ b/tests/model/test_plant.py
@@ -1928,6 +1928,38 @@ def test_block_age_normalises_naive_now(plant: Plant):
     assert age == 7.0
 
 
+def test_last_updated_at_none_before_first_commit(plant: Plant):
+    """No committed bank yet → the whole-cache freshness signal is None (cold), never raises."""
+    assert plant.last_updated_at is None
+
+
+def test_last_updated_at_returns_newest_across_banks(plant: Plant):
+    """last_updated_at is the newest ingestion time across every committed bank, regardless of type."""
+    t0 = datetime(2026, 6, 6, 12, 0, 0, tzinfo=UTC)
+    plant.update(_make_ir_pdu({5: 2367}, device_address=0x11, base_register=0), received_at=t0)
+    plant.update(_make_hr_pdu({20: 1}, device_address=0x11, base_register=0), received_at=t0 + timedelta(seconds=5))
+    # An older bank ingested afterwards must not pull the signal backwards.
+    plant.update(_make_ir_pdu({180: 1}, device_address=0x11, base_register=180), received_at=t0 + timedelta(seconds=2))
+    assert plant.last_updated_at == t0 + timedelta(seconds=5)
+
+
+def test_last_updated_at_advances_with_new_commit(plant: Plant):
+    """A fresh fan-out/solicited commit advances the signal — that is 'the bus is still alive'."""
+    t0 = datetime(2026, 6, 6, 12, 0, 0, tzinfo=UTC)
+    plant.update(_make_ir_pdu({5: 2367}, device_address=0x11, base_register=0), received_at=t0)
+    assert plant.last_updated_at == t0
+    plant.update(_make_ir_pdu({5: 2400}, device_address=0x11, base_register=0), received_at=t0 + timedelta(seconds=30))
+    assert plant.last_updated_at == t0 + timedelta(seconds=30)
+
+
+def test_last_updated_at_ignores_discarded_bank(plant: Plant):
+    """A discarded (never-landed) bank must not register as freshness."""
+    t = datetime(2026, 6, 6, 12, 0, 0, tzinfo=UTC)
+    pdu = _make_ir_pdu({110: 0, 111: 0, 112: 0, 113: 0, 114: 0, 60: 3221}, device_address=0x33, base_register=60)
+    plant.update(pdu, received_at=t)
+    assert plant.last_updated_at is None
+
+
 def test_hr_bank_rejected_by_commit_is_not_stamped(plant: Plant):
     """An incoherent HR bank must not record an ingestion timestamp."""
     # Seed non-zero HR data, then push all-zero (Pattern B) to trigger rejection.


### PR DESCRIPTION
Two small, independent additions that both come out of the passive-mode /
marginal-dongle work with givenergy-hass. Neither changes existing behaviour on
a healthy setup.

## `Plant.last_updated_at` (freshness signal)

`Plant.last_updated_at` returns the newest `register_block_updated_at` across
all committed banks, or `None` before the first commit. It's the honest "is the
cache being kept fresh" signal for a passive consumer: it advances whenever any
bank commits — solicited or fanned-out from a peer client — regardless of
content, so a quiet bus shows up as a signal that stops moving.

Because it keys off commit rather than value, it stays meaningful on a Gateway
(where the synthetic all-zeros inverter makes `system_time` spurious) and is
topology-agnostic. Age is consumer-derived (`now - last_updated_at`), so there's
no baked-in threshold.

hass asked for this to gate passive-mode freshness — without it, a passive tick
marks success on a stale cache and their energy integrals keep accumulating from
a frozen power value.

## Coalesce reader-EOF reconnect churn (hass#95)

A newer-chipset AIO dongle idle-reaps the TCP connection roughly every ~10s when
no client→dongle frame goes out in that window. The client reconnects instantly
and the fan-out resumes, so it's functionally harmless — but it emits thousands
of `connection lost (reader at EOF)` WARNING lines/day on a working setup
(~7000/day in the capture we looked at).

`_note_eof_drop()` throttles that log #355-style: the first drop warns, repeats
within a 5-minute window drop to DEBUG, and one re-warn per window carries the
running tally. A drop after a long quiet spell re-warns (the last-warn timestamp
has aged out), so a genuinely fresh disconnect is never swallowed — only
sustained churn is throttled. The counter lives on the `Client` so it survives
the reaped-and-reconnected sockets.

I've treated the ~10s reap itself as dongle-side and benign rather than something
to fight with keepalives — the data pointed at a rolling idle timer, and loading
a fragile dongle with continuous traffic to keep it quiet felt like the wrong
trade. This PR just stops the noise; the passive freshness signal above is what
makes the reap harmless to consumers regardless.

Both changes are test-covered (4 + 5 new tests); full suite and tox green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a plant freshness indicator showing when register data was last updated.
* **Bug Fixes**
  * Improved handling of repeated connection drops by reducing duplicate warning messages while retaining useful diagnostics.
  * Connection loss caused by an unexpected end-of-file is now reported more clearly.
* **Tests**
  * Added coverage for plant freshness tracking and connection-drop logging behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->