### PR TITLE
test: property-based fuzzing for framer and codec

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dev = [
 ]
 test = [
     "bandit>=1.7.5,<2",
+    "hypothesis>=6.100,<7",
     "mypy>=2.0.0,<3",
     "pytest>=9.0.0,<10",
     "pytest-asyncio>=1.0.0,<2",

--- a/tests/test_framer_properties.py
+++ b/tests/test_framer_properties.py
@@ -1,0 +1,279 @@
+"""Property-based fuzzing of the framer's trust boundary.
+
+The framer is the library's network trust boundary: :meth:`Framer.decode`
+consumes raw, potentially-hostile bytes and must never raise, never grow its
+buffer without bound, and always yield the same messages regardless of how the
+byte stream is chunked (#88). Those are *properties* over all inputs, not a
+handful of examples, so we assert them with Hypothesis.
+
+Generation is biased towards structurally-valid frames — random bytes almost
+never contain the ``0x59590001`` start marker and so get discarded before
+reaching the interesting decode paths. We seed from the real capture corpus
+(``tests/fixtures/captures``) and mutate around it, which drives coverage into
+``decode_bytes`` and the PDU decoders.
+"""
+
+import asyncio
+import logging
+import os
+import string
+from pathlib import Path
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from givenergy_modbus.exceptions import ExceptionBase
+from givenergy_modbus.framer import HEADER_START_MARKER, ClientFramer
+from givenergy_modbus.pdu import (
+    BasePDU,
+    ReadHoldingRegistersResponse,
+    ReadInputRegistersResponse,
+    WriteHoldingRegisterResponse,
+)
+from givenergy_modbus.pdu.base import ClientIncomingMessage
+from tests.test_framer import EXCEPTION_RESPONSE_FRAME, VALID_REQUEST_FRAME, VALID_RESPONSE_FRAME
+
+# Property tests run many examples and legitimately exceed the suite-wide 1s
+# per-test timeout (pyproject ``timeout = 1``); give them their own headroom so
+# a deeper GE_FUZZ_EXAMPLES sweep isn't killed mid-run and mistaken for a fault.
+pytestmark = pytest.mark.timeout(120)
+
+_CAPTURES = Path(__file__).parent / "fixtures" / "captures"
+
+
+def _iter_rx_bytes(path: Path):
+    """Yield the raw rx byte chunks from a capture log, in file order."""
+    for line in path.read_text(encoding="utf-8").splitlines():
+        parts = line.split(" ", 2)
+        if len(parts) == 3 and parts[1] == "rx":
+            try:
+                yield bytes.fromhex(parts[2])
+            except ValueError:
+                continue
+
+
+def _load_corpus(limit: int = 400) -> list[bytes]:
+    """Extract complete, decodable frames from the real capture corpus.
+
+    Concatenating a file's rx chunks reconstructs the wire stream; feeding it
+    through a framer yields real complete frames (each PDU carries the exact
+    bytes it decoded from as ``raw_frame``). Deduplicated and capped so the
+    strategy stays fast and shrinking stays tractable.
+    """
+    seen: dict[bytes, None] = {}
+    for path in sorted(_CAPTURES.rglob("*.log")):
+        stream = b"".join(_iter_rx_bytes(path))
+
+        async def _drain(data: bytes):
+            framer = ClientFramer()
+            return [x async for x in framer.decode(data)]
+
+        for item in asyncio.run(_drain(stream)):
+            if isinstance(item, BasePDU):
+                seen.setdefault(item.raw_frame, None)
+                if len(seen) >= limit:
+                    return list(seen)
+    return list(seen)
+
+
+# Recorded constants plus real corpus frames. Falls back gracefully if the
+# corpus can't be mined so the garbage-only properties still run.
+_CORPUS: list[bytes] = [VALID_REQUEST_FRAME, VALID_RESPONSE_FRAME, EXCEPTION_RESPONSE_FRAME]
+_CORPUS += [f for f in _load_corpus() if f not in _CORPUS]
+
+
+@pytest.fixture(autouse=True)
+def _quiet_framer_logs():
+    """Silence the library's expected per-garbage discard/CRC/safety warnings.
+
+    Fuzzing emits them by the thousand; muting keeps a real failure visible.
+    """
+    logger = logging.getLogger("givenergy_modbus")
+    prior = logger.level
+    logger.setLevel(logging.CRITICAL)
+    yield
+    logger.setLevel(prior)
+
+
+def drain(framer: ClientFramer, data: bytes) -> list[object]:
+    """Run the async ``decode`` generator to completion (it never truly awaits)."""
+
+    async def _run():
+        return [x async for x in framer.decode(data)]
+
+    return asyncio.run(_run())
+
+
+# --- strategies ---------------------------------------------------------------
+
+valid_frame = st.sampled_from(_CORPUS)
+
+garbage = st.binary(max_size=512)
+
+
+@st.composite
+def mutated_frame(draw) -> bytes:
+    """A real frame with one byte flipped, truncated, or extended."""
+    frame = bytearray(draw(valid_frame))
+    kind = draw(st.sampled_from(("flip", "truncate", "extend")))
+    if kind == "flip" and frame:
+        i = draw(st.integers(0, len(frame) - 1))
+        frame[i] ^= draw(st.integers(1, 255))
+    elif kind == "truncate" and frame:
+        frame = frame[: draw(st.integers(0, len(frame) - 1))]
+    else:
+        frame += draw(st.binary(min_size=1, max_size=32))
+    return bytes(frame)
+
+
+chunk = st.one_of(garbage, valid_frame, mutated_frame())
+
+# Default is a fast PR-friendly pass; nightly CI can crank it via the env var
+# (e.g. GE_FUZZ_EXAMPLES=5000) for a deeper sweep without touching the code.
+_SETTINGS = settings(
+    deadline=None,  # asyncio.run-per-example trips the default 200ms deadline
+    suppress_health_check=[HealthCheck.too_slow],
+    max_examples=int(os.environ.get("GE_FUZZ_EXAMPLES", "300")),
+)
+
+
+def _split_at(data: bytes, cuts: list[int]) -> list[bytes]:
+    points = sorted({c % (len(data) + 1) for c in cuts}) if data else []
+    pieces, prev = [], 0
+    for p in points:
+        pieces.append(data[prev:p])
+        prev = p
+    pieces.append(data[prev:])
+    return pieces
+
+
+# --- properties ---------------------------------------------------------------
+
+
+@_SETTINGS
+@given(chunks=st.lists(chunk, max_size=20))
+def test_decode_never_raises_and_only_yields_pdu_or_exception(chunks):
+    """No input sequence escapes decode as an unhandled exception (#88).
+
+    Every yielded item is either a decoded PDU or a caught exception.
+    """
+    framer = ClientFramer()
+    for c in chunks:
+        for item in drain(framer, c):
+            assert isinstance(item, (BasePDU, ExceptionBase))
+
+
+@_SETTINGS
+@given(data=st.binary(min_size=0, max_size=4096))
+def test_headerless_garbage_never_grows_buffer(data):
+    """Marker-less garbage must be trimmed, not accumulated (anti-DoS, #88).
+
+    Worst case the framer retains a partial frame it still believes viable,
+    bounded by the maximum valid frame length (6 + max hdr_len of 300).
+    """
+    if HEADER_START_MARKER in data:
+        return  # only asserting the no-marker path here
+    framer = ClientFramer()
+    drain(framer, data)
+    assert len(framer._buffer) <= 6 + 300
+
+
+@_SETTINGS
+@given(
+    frames=st.lists(valid_frame, min_size=1, max_size=8),
+    cuts=st.lists(st.integers(min_value=0), max_size=12),
+)
+def test_chunking_is_invariant(frames, cuts):
+    """However the stream is fragmented across reads, the same messages decode.
+
+    This is the streaming property that fixed examples can't cover: it exercises
+    marker-straddling and mid-payload splits at arbitrary boundaries.
+    """
+    stream = b"".join(frames)
+
+    whole = ClientFramer()
+    reference = [type(x).__name__ for x in drain(whole, stream)]
+
+    pieces = ClientFramer()
+    got: list[str] = []
+    for piece in _split_at(stream, cuts):
+        got += [type(x).__name__ for x in drain(pieces, piece)]
+
+    assert got == reference
+
+
+@_SETTINGS
+@given(prefix=garbage, frame=valid_frame)
+def test_garbage_prefix_is_transparent(prefix, frame):
+    """Leading non-marker garbage is transparent to the following frame.
+
+    The frame decodes to exactly what it would on its own, whatever that is.
+    """
+    if HEADER_START_MARKER in prefix:
+        return  # a marker in the "garbage" would start a different frame
+
+    baseline = [type(x).__name__ for x in drain(ClientFramer(), frame)]
+    prefixed = [type(x).__name__ for x in drain(ClientFramer(), prefix + frame)]
+    assert prefixed == baseline
+
+
+# --- encode/decode round-trip (fuzzes the codec's register de/serialisation) --
+
+# Serials are 10-char alphanumeric on the wire; fuzzing them exercises the
+# string codec (decode_string / add_string) alongside the register path.
+serial = st.text(alphabet=string.ascii_uppercase + string.digits, min_size=10, max_size=10)
+register16 = st.integers(min_value=0, max_value=0xFFFF)
+
+
+@st.composite
+def read_register_response(draw) -> ReadHoldingRegistersResponse | ReadInputRegistersResponse:
+    cls = draw(st.sampled_from((ReadHoldingRegistersResponse, ReadInputRegistersResponse)))
+    values = draw(st.lists(register16, min_size=1, max_size=60))  # protocol caps at 60
+    return cls(
+        inverter_serial_number=draw(serial),
+        data_adapter_serial_number=draw(serial),
+        device_address=draw(st.integers(0x00, 0xFF)),
+        base_register=draw(register16),
+        register_count=len(values),
+        register_values=values,
+    )
+
+
+@st.composite
+def write_register_response(draw) -> WriteHoldingRegisterResponse:
+    return WriteHoldingRegisterResponse(
+        inverter_serial_number=draw(serial),
+        data_adapter_serial_number=draw(serial),
+        device_address=draw(st.integers(0x00, 0xFF)),
+        register=draw(register16),
+        value=draw(register16),
+    )
+
+
+@_SETTINGS
+@given(pdu=read_register_response())
+def test_read_response_encode_decode_round_trips(pdu):
+    """Any register response survives encode → decode intact (codec fidelity).
+
+    This drives ``decode_16bit_uint`` over arbitrary payloads — the layer where a
+    signedness or offset slip in the register decoders would surface.
+    """
+    decoded = ClientIncomingMessage.decode_bytes(pdu.encode())
+    assert type(decoded) is type(pdu)
+    assert decoded.register_values == pdu.register_values
+    assert decoded.base_register == pdu.base_register
+    assert decoded.register_count == pdu.register_count
+    assert not decoded.crc_failed  # the CRC we wrote must validate on the way back
+    assert decoded.encode() == pdu.encode()  # byte-level idempotence
+
+
+@_SETTINGS
+@given(pdu=write_register_response())
+def test_write_response_encode_decode_round_trips(pdu):
+    """A single-register write echo survives encode → decode intact."""
+    decoded = ClientIncomingMessage.decode_bytes(pdu.encode())
+    assert type(decoded) is type(pdu)
+    assert decoded.register == pdu.register
+    assert decoded.value == pdu.value
+    assert decoded.encode() == pdu.encode()

--- a/uv.lock
+++ b/uv.lock
@@ -520,6 +520,7 @@ docs = [
 ]
 test = [
     { name = "bandit" },
+    { name = "hypothesis" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -555,6 +556,7 @@ docs = [
 ]
 test = [
     { name = "bandit", specifier = ">=1.7.5,<2" },
+    { name = "hypothesis", specifier = ">=6.100,<7" },
     { name = "mypy", specifier = ">=2.0.0,<3" },
     { name = "pytest", specifier = ">=9.0.0,<10" },
     { name = "pytest-asyncio", specifier = ">=1.0.0,<2" },
@@ -572,6 +574,67 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
+]
+
+[[package]]
+name = "hypothesis"
+version = "6.156.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/20/83/8dbe89bdb8c6f25a7a52e7898af6d82fe35dfef08e5c702f6e33231ce6c6/hypothesis-6.156.6.tar.gz", hash = "sha256:96de02faefa3ce079873541da96f42595583bb001e8e4219294ed7d4501cc4cc", size = 476304, upload-time = "2026-07-10T20:56:49.96Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/dc/0c2a851f06c91d5ac9ef0f3b9615efc1ed650411d2eee23b6334f491c85e/hypothesis-6.156.6-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:caf6a93d011c10972da111c38ceb34ced20feaa8581e2b350c0655b022e27875", size = 747998, upload-time = "2026-07-10T20:56:16.311Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f8/59203ca978ab51595d12d6bc7e7a63300d7373431ab42ca3f1742e45db68/hypothesis-6.156.6-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:07f2bc9df1aeba80e12029c1618e2ee54abc440068c305d7075ffd6b85251843", size = 743073, upload-time = "2026-07-10T20:55:36.825Z" },
+    { url = "https://files.pythonhosted.org/packages/68/d8/86a0023740434098d1b187a62bd5f99b198f098fb43e7fc58342283a8270/hypothesis-6.156.6-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7baca17f4803ad4aa151732326f3990baf54c3127df44aa872ac5bdf8a98a9a6", size = 1070169, upload-time = "2026-07-10T20:55:49.47Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/82/673453915fd0c67673f35a4876ba88f48c621335f293f3537d77b27d4286/hypothesis-6.156.6-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8083806645f84243aade727f4978185caaa0b7190af4318673999ee15fdbf424", size = 1121760, upload-time = "2026-07-10T20:55:53.502Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/c3/3a5557f52912f2fecc6ed59642dcf80dd8e89d0d9664502b68e23d66bf3d/hypothesis-6.156.6-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a922eedcd8618f9c2e17b79fa7b3f3f0b2df34e201958611cc3f0f46cca33c10", size = 1111440, upload-time = "2026-07-10T20:55:43.054Z" },
+    { url = "https://files.pythonhosted.org/packages/38/a6/ae636d4ca7f996a1ccb4b3d5997d949f1718fba52b01559b3ab53b237b3f/hypothesis-6.156.6-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:5291bd33c4704d274d7c214d5c200e77f372a06644f5cbbe96dcbe53cb2fbf10", size = 1244944, upload-time = "2026-07-10T20:55:56.109Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/79/c425d22d734be0268ca60d120c6296299e4220a1783cb1a4cc76232807bb/hypothesis-6.156.6-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:55f3ec50161b4a95bae63bff2b5166e45935b493013d3be30ede279bf6192318", size = 1288808, upload-time = "2026-07-10T20:56:06.249Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/3a/cc9f479d22cbdd36ddfc55a978378eddadd183b09339ebdb81be33bb18e7/hypothesis-6.156.6-cp310-abi3-win32.whl", hash = "sha256:e96570ca5cdd9a5f2ff9e80a6fb2fd5420ebf33b833d7de5b09b6ebb26a3eb6c", size = 634868, upload-time = "2026-07-10T20:55:37.959Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/89/2008d287289841a936456cb13443ca89d88da6e4527d611d482e9544164d/hypothesis-6.156.6-cp310-abi3-win_amd64.whl", hash = "sha256:32710718c22fe8c5571464e898bb87d282837b02617d6ad68130abf7cb4843cb", size = 640382, upload-time = "2026-07-10T20:55:30.634Z" },
+    { url = "https://files.pythonhosted.org/packages/13/64/e4a0796190d8089e85f06731e21fdddd7e8edd3a4e562101527a048e21c4/hypothesis-6.156.6-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:5baec7943a14d106e982121dd4f74cfc5ef45e37c17f94fe49338d3d1377f38c", size = 748988, upload-time = "2026-07-10T20:56:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a2/4a789b286cd2cced31992e1f683036b51dd6909b934ea007ffb43aa3a32f/hypothesis-6.156.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:b5f519905ddeb10e23b8ba2c254541a5b1a8f146fe0551be94d972f4a77226f4", size = 743754, upload-time = "2026-07-10T20:56:09.113Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/f7/3dd36c1c03d24ae3ffc3c5b0eca8cc4ae90c07abc320f76509eceb37019a/hypothesis-6.156.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4c108655960b58ded3ca71b2dc5c69fb2ba7e9c723aeb6106facec3892d09087", size = 1070732, upload-time = "2026-07-10T20:56:28.738Z" },
+    { url = "https://files.pythonhosted.org/packages/57/51/befc4b816b471078034a875eb1ef69e0411ab84bcce582b4be173258785a/hypothesis-6.156.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7c8d37bebb6924729bc0bbf5852689df568842948abe4d93dd0ad3377adf76fa", size = 1121988, upload-time = "2026-07-10T20:56:07.676Z" },
+    { url = "https://files.pythonhosted.org/packages/05/b7/a796f5e3e4b7cb911ff346008d49720296d1f4073490b8bc1cce6b3fbb07/hypothesis-6.156.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:74137bef6d502305c3648b2ed1a9bb4bc05fb1025e96b30a2c092204c40fe097", size = 1245596, upload-time = "2026-07-10T20:55:50.662Z" },
+    { url = "https://files.pythonhosted.org/packages/37/65/849c4cba44a6f6cc888fd931124429b24180234ccc4883abab8cad5fcfcb/hypothesis-6.156.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5e0afdf79cceed20fcf0a9fb80d4064a9b2b53d4d4eecbac0e21208a13f5a31b", size = 1289172, upload-time = "2026-07-10T20:55:58.915Z" },
+    { url = "https://files.pythonhosted.org/packages/13/03/7106a110df29eb631d66776e8aa8128f82f04a9dd2b6b22b612e6025e3a2/hypothesis-6.156.6-cp311-cp311-win_amd64.whl", hash = "sha256:84dc89caaf741a02f904ca7bd02b1af99650c75552868162290208aeecb70858", size = 640222, upload-time = "2026-07-10T20:56:10.396Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/45/9f009005b9c796f4a40424484ac7e70847bc088456fd940a937f96bb4b6d/hypothesis-6.156.6-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a2a728b514fceb81e3f0464508911d5220fd74dadc3270f859427a686b60c4cf", size = 748844, upload-time = "2026-07-10T20:56:38.036Z" },
+    { url = "https://files.pythonhosted.org/packages/02/2f/4d852bb8a9c73a68b18eca9b5b085285282122166e158f4d2a477639bfee/hypothesis-6.156.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7489b9a8f9df8227edd6c7cd8b9ccfab2483bab24da6a474c175973ca2294f58", size = 741936, upload-time = "2026-07-10T20:55:27.539Z" },
+    { url = "https://files.pythonhosted.org/packages/74/89/b9968070ae042f9bf3149bb6ba6399d5f28f452e0fb7f638cafc69ff0b9a/hypothesis-6.156.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42760873d6db1069d6edbaa355a61b9078a9950259efcfc72fc695741d7db7cd", size = 1069749, upload-time = "2026-07-10T20:56:43.017Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a9/753806f5292b40aeab1d269e408e3a7e85be3c0d88828fb78ab4a34d6626/hypothesis-6.156.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b4e66aaa7385538a5d617174d47c198ee807f06de99e282a67c6cb724c69340d", size = 1120983, upload-time = "2026-07-10T20:56:25.424Z" },
+    { url = "https://files.pythonhosted.org/packages/85/88/8386d064d680be27e936eba94f1448bc93ef6fa05473ee5034139f1c4284/hypothesis-6.156.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:08796b674c0b31a5dd4119b2173823390055921588d13eb77324e861b00fd7f8", size = 1243911, upload-time = "2026-07-10T20:55:54.799Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/8c/7524c1e5279e7728eb47c99f2357cbc5f08ae92e9bce49bf50118b53f9c9/hypothesis-6.156.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4ca8cc26ea2d31d22cf7710e92951cfaa921f0f8aa1b6db33a5176335f583a4f", size = 1287806, upload-time = "2026-07-10T20:56:02.176Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/b3/c347ad913e1c5f2988956fe17826c0400b4ce470b973e6c248e97b6a0acf/hypothesis-6.156.6-cp312-cp312-win_amd64.whl", hash = "sha256:c3363d3fb8015594636689572510bb6090602d8e8e838a5693c2d52d3b5b09d8", size = 637679, upload-time = "2026-07-10T20:55:39.056Z" },
+    { url = "https://files.pythonhosted.org/packages/70/5d/9583fe153573523dac27226c89e041a86ad4aeeae08c868160cbb93d39d2/hypothesis-6.156.6-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:59a8def90d9a5a9b67e1ac529e903a2363ceb6cf873c209da6b4284c5daab671", size = 749264, upload-time = "2026-07-10T20:56:46.118Z" },
+    { url = "https://files.pythonhosted.org/packages/86/35/e4113d06769b544f0fb77ffea9195b598b4c56a298905c21fd47c4eed388/hypothesis-6.156.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c574c3224563d730848bc5d1ef1683c4f83993400c0167899fe328f4bfcd4725", size = 742095, upload-time = "2026-07-10T20:56:41.412Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/5c/a47666ede10384e8978722cade7ab96a42df71d2ab577317092d0fed7c8a/hypothesis-6.156.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:01bb8270c46b3ef53b0c2d23ff613ea506d609d06f936d823ea57c58b66b05f7", size = 1069917, upload-time = "2026-07-10T20:56:04.845Z" },
+    { url = "https://files.pythonhosted.org/packages/79/93/75f6057dadd9dc0134f37c08d5d14d04d3cd7374debbcb0cc4569c6712f1/hypothesis-6.156.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d4ea6559c13606e13b645927f2e0906e52b5ac5d99b40d3abaaeb2e8c7ceeb75", size = 1121204, upload-time = "2026-07-10T20:55:52.008Z" },
+    { url = "https://files.pythonhosted.org/packages/62/87/308efef08bc60d1e673d035e8ca8e9663f4b6b3ba519c3cdebf6583c2b76/hypothesis-6.156.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2d47054d0230f0dd9b6868fc030126c7a6c25527144272ff376cc4e9c39f7540", size = 1244168, upload-time = "2026-07-10T20:55:40.288Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/66/de8fff5bd9a40a4056dafbe7f904887ef12632282bbbac90f1977c30dd3b/hypothesis-6.156.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:050c8c0815f88d47dd0875a92698d20d61639b7b721ee043a6d687c7f14ff7d8", size = 1288127, upload-time = "2026-07-10T20:56:00.541Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8d/794fb26e1fd3ff004978f8f18b7aa7e1c2270ba72e1f977b987a812064f8/hypothesis-6.156.6-cp313-cp313-win_amd64.whl", hash = "sha256:f0d73edab7b8a0051b3634f2d04d62b7e7282f8f274963b11188ee4957d672ef", size = 637954, upload-time = "2026-07-10T20:56:33.35Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/be/5b4b27984cb43c60e95f570b069660335dad34cb67f7d226017c5d35d31e/hypothesis-6.156.6-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:34a70a7b8226e34d658072d8fb81d03f97f0a75ceb536329a321b94ce2232fd6", size = 749312, upload-time = "2026-07-10T20:55:46.902Z" },
+    { url = "https://files.pythonhosted.org/packages/31/11/709cceffc28666c9d4cb75ffc6df5ce30db8c7dd5cc2c8b38a2fd837427f/hypothesis-6.156.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:f1969646beead7d8cf6a2537d2765af89d73056e2cb218e7fae92b83802250a3", size = 742332, upload-time = "2026-07-10T20:56:30.254Z" },
+    { url = "https://files.pythonhosted.org/packages/84/52/cfc79b13d8dd3cd6de6b9df921c557efe8528a9c90a3a7cd93b37188d57e/hypothesis-6.156.6-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cbc2ec7b7d905e6b6ec1635f6340bfa52aaab718101c59f052bc012a6b486cd8", size = 1070109, upload-time = "2026-07-10T20:55:48.244Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/ac/1da4def1f006b5ad01187ff96379e24c37439d659ec10c3e944c03436c0f/hypothesis-6.156.6-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9367ae25dfa6dc1af37904785e43c4f8fe1c4118cafdc2f06514154fbdd90992", size = 1121528, upload-time = "2026-07-10T20:56:39.665Z" },
+    { url = "https://files.pythonhosted.org/packages/68/47/744e4f5e3d635dea20dbedf3fa486e2a6fa5210e0a52a0d5c4da56babd84/hypothesis-6.156.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:455f09107ec07c78f2a83cb8fc19e23879c9d51cdc831de6f9cb6ec4059cb9af", size = 1244690, upload-time = "2026-07-10T20:56:31.854Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8a/42252fcd5e521d140dac532f29c2a13ca8f22908cb545ffdd64b5e225680/hypothesis-6.156.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c76634c45a3ceee4c4fdfed39aebd08b8b822ec8b0c556877ef82846fd777730", size = 1288519, upload-time = "2026-07-10T20:56:03.429Z" },
+    { url = "https://files.pythonhosted.org/packages/44/e7/176df9e47cf583d2b8d234b78c0aac3a47075ad5d147e60b2c21a1338bb1/hypothesis-6.156.6-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:eb7e9f8343bc6b948937e6ec12e6879ed25a17b53ceccbd2b84adadd3d511698", size = 586452, upload-time = "2026-07-10T20:56:22.285Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/75/2c8a0411bbe76429f3ae738ef9a00107201bf6146d9534350014ce369d98/hypothesis-6.156.6-cp314-cp314-win_amd64.whl", hash = "sha256:f9631cd604ae6032c3edf99160dc1b9e33873f2e52762246b24f07fb758652ae", size = 637774, upload-time = "2026-07-10T20:56:34.97Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/22/8115005e9aa72c8d63d90e9db5e0b8425fd8950fbc5d6e332805d4d32c9e/hypothesis-6.156.6-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:1f81163d36d3763b09ffaef7c3a71e88174ca3e6816201fca9d1d159f448fdb5", size = 747428, upload-time = "2026-07-10T20:56:44.611Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/c2/66bfe9337f4a4b1f7754ee6d01d950280152a81d0d797e6c1d9eb0909750/hypothesis-6.156.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:556b905767e36147918634a64356aa05d8c956576f00aee01eb351678f193908", size = 740889, upload-time = "2026-07-10T20:55:57.656Z" },
+    { url = "https://files.pythonhosted.org/packages/95/3b/69f45af2d4f0950b7d1af3cdbdd800b88a6c2370331481eda79d6171fbe3/hypothesis-6.156.6-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c3f2604b28d16d696aaaf4954d20f907b27e54034df98e64746a20c74c319f03", size = 1069270, upload-time = "2026-07-10T20:56:12.024Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/43/6b2549885da08f5e50ba34fb8e0d0a60b2f190ffd516fac220f8db5b5869/hypothesis-6.156.6-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ffe012ad66dbe7b8e8ddef6f6992ab1b36719ea64430c2bf1ff7135521052a15", size = 1120409, upload-time = "2026-07-10T20:55:34.551Z" },
+    { url = "https://files.pythonhosted.org/packages/70/97/745c778c3eb29befa2367b1ded8437eecfbbe6932359d0f831275bc32170/hypothesis-6.156.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5bfa3c7b758f7278081c6bfec5f89b43c4eb075c0c9eb095323f7a9eb019b513", size = 1243111, upload-time = "2026-07-10T20:56:17.83Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/d7/c5ec6a442dc9b822f47064bda4b6d3e739dccdd1c5bf44c9a57fb6136830/hypothesis-6.156.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:d0db1f4573800c618773622f03cb6533bb3377430ef938c9476ba10c39d22591", size = 1287262, upload-time = "2026-07-10T20:56:23.749Z" },
+    { url = "https://files.pythonhosted.org/packages/11/0c/c134d61710e14b68b010215dcf6bd57d2ec05cd169dff8bfab8fefc2d410/hypothesis-6.156.6-cp314-cp314t-win_amd64.whl", hash = "sha256:38cd0c4a7b9f809f1e23a4d15adfa9c5d99869b9afc327350a5e563350b78e48", size = 637862, upload-time = "2026-07-10T20:56:13.347Z" },
+    { url = "https://files.pythonhosted.org/packages/59/9c/b94f3a31665527b6181616b72990fcf8d6d5fa82b4187aab104ab5f548f0/hypothesis-6.156.6-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:8893b4da90e06828846c1b100c3414a7729d047a020d854c0899ae9339df0e70", size = 749575, upload-time = "2026-07-10T20:55:29.371Z" },
+    { url = "https://files.pythonhosted.org/packages/21/74/dcf695f79f526543ae5d0f8c1325508e9fe990a996c0e0853129a9a5d81d/hypothesis-6.156.6-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:b7fc0b7df9b28d028e4cc295b2ac8fbbbc22e090a23382c92fff5e37696be74f", size = 744351, upload-time = "2026-07-10T20:56:36.46Z" },
+    { url = "https://files.pythonhosted.org/packages/11/d3/5bff4c55c6995a6c43f66ec8e5866b56e34f03837fd0be0e4922f3bab168/hypothesis-6.156.6-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:38ed3178526382d392d04ad699ad7a2e53845e521a09d40f1cbbc1e1ff63ba48", size = 1070916, upload-time = "2026-07-10T20:56:19.256Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/af/5ed42117a69221ea118caaff933d8212039a0ac0bc15afa915635f13984c/hypothesis-6.156.6-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5ad94e28aabf4db0d479297d43b8a2a01e7caaa9bdfccfdac7a4a3717e05b993", size = 1122625, upload-time = "2026-07-10T20:56:14.758Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/d3/02499badc6e3f3e980941021edf5fd780c895d8d08c9015e78516340ed83/hypothesis-6.156.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:983a5cfd955994bffc7eb02976241f7a1f3c2d94dbc3389430c45858fa5c1ae0", size = 640823, upload-time = "2026-07-10T20:55:45.461Z" },
 ]
 
 [[package]]
@@ -1728,6 +1791,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds a hypothesis-based property-test module over the framer and codec — the library's network trust boundary. This came out of a look at where the test suite's weight actually sits: the framer/`decode_bytes`/codec path is directly network-exposed and already carries the #88 DoS-hardening, but was covered only by fixed examples. Property tests express its invariants over all inputs instead.

## What it covers

**Framer (bytes → messages)**
- `decode` never escapes as an unhandled exception — the #88 trust-boundary invariant
- marker-less garbage never grows the buffer without bound (anti-DoS)
- chunking invariance: however a stream is fragmented across reads, the same messages decode
- leading non-marker garbage is transparent to the following frame

**Codec (messages ↔ bytes)**
- read- and write-register response encode→decode round-trip fidelity, exercising the 16-bit register and string de/serialisers over arbitrary payloads

## Approach

Frame generation is seeded from the real capture corpus (403 frames mined from `tests/fixtures/captures`) and mutated around it. Random bytes almost never contain the `0x59590001` start marker, so pure-random generation gets discarded before reaching the interesting decode paths; seeding from real frames biases the generator toward structurally-valid input so mutation actually reaches `decode_bytes` and the PDU decoders.

All six properties hold at 5,000 examples each (~20k framer inputs plus ~10k round-trip PDUs). No defects surfaced — the expected-good outcome for a fuzz pass over well-exercised code; the lasting value is the regression net for future changes to the framer/codec.

## Notes

- Example count is env-driven (`GE_FUZZ_EXAMPLES`, default 300 for a fast PR pass) so a deeper sweep needs no code change.
- The module carries its own `pytest.mark.timeout(120)` because the suite-wide 1s per-test limit is aimed at unit tests — a deeper sweep would otherwise trip it mid-example and surface as a confusing `FlakyFailure` rather than an honest timeout.
- `hypothesis` added to the `test` dependency group.
- I haven't wired a nightly deeper-sweep CI job in this PR — can add it here or leave it as a follow-up.

One thing I deliberately kept out of scope: the round-trip tests exercise the wire codec, not the model-layer register *interpretation* (scale/signedness conversions). That seam is already guarded by `test_register_conventions`, so I didn't duplicate it here.