### PR TITLE
ci: nightly deep fuzz sweep for framer/codec properties

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,39 @@
+name: Nightly Fuzz
+
+on:
+  schedule:
+    # Nightly deep property-based fuzz sweep of the framer + codec (04:30 UTC,
+    # offset from dev.yml's weekly 06:30 Monday run). Per-PR/weekly CI runs these
+    # property tests at a shallow example count for speed; this runs them deep
+    # against the latest main so a regression in the wire trust boundary surfaces
+    # within a day of landing rather than a week.
+    - cron: '30 4 * * *'
+
+  # Allows a manual run (optionally with a custom example count) from the Actions tab.
+  workflow_dispatch:
+    inputs:
+      examples:
+        description: 'Hypothesis examples per property'
+        required: false
+        default: '5000'
+
+# Least privilege: read-only, like dev.yml. No coverage upload here.
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Set up uv
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
+        with:
+          enable-cache: true
+          python-version: '3.14'
+      - name: Deep fuzz sweep
+        env:
+          GE_FUZZ_EXAMPLES: ${{ github.event.inputs.examples || '5000' }}
+        run: uv run --group test tox -e fuzz

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,6 +168,20 @@ setenv =
 commands =
     pytest --cov=givenergy_modbus --cov-branch --cov-report=xml --cov-report=term-missing tests
 
+[testenv:fuzz]
+# Deep property-based fuzz sweep of the framer + codec (tests/test_framer_properties.py).
+# The per-PR/weekly suite runs these at a shallow example count for speed; this env
+# cranks GE_FUZZ_EXAMPLES so a nightly run explores far more inputs. Override the count
+# with `GE_FUZZ_EXAMPLES=N tox -e fuzz`. No coverage — this is depth, not line-hitting.
+runner = uv-venv-lock-runner
+dependency_groups =
+    test
+setenv =
+    {[testenv]setenv}
+    GE_FUZZ_EXAMPLES = {env:GE_FUZZ_EXAMPLES:5000}
+commands =
+    pytest tests/test_framer_properties.py -p no:cacheprovider
+
 [testenv:format]
 runner = uv-venv-lock-runner
 dependency_groups =


### PR DESCRIPTION
Follow-up to #404. That PR added the property tests but they only run at a shallow example count (`GE_FUZZ_EXAMPLES` default 300) so per-PR CI stays fast — which meant the deeper sweep only ever ran when someone bumped the count by hand locally. This wires it into CI so it actually runs somewhere.

## What it adds

- **`tox -e fuzz` env** — runs just `tests/test_framer_properties.py`, cranks `GE_FUZZ_EXAMPLES` (default 5,000, overridable), no coverage. Usable locally too: `GE_FUZZ_EXAMPLES=20000 tox -e fuzz`.
- **`Nightly Fuzz` workflow** — 04:30 UTC daily (offset from `dev.yml`'s weekly 06:30 Monday run) plus manual dispatch with a custom example count.

A nightly run explores fresh random inputs against whatever landed on `main` that day, so a regression in the framer/codec trust boundary surfaces within a day rather than a week (or whenever someone next fuzzes locally).

## Notes

- **Kept separate from `dev.yml` on purpose.** Its cadence differs — nightly here vs the weekly cross-OS/newer-Python safety net there. Folding it in would mean gating every job on which cron fired, which reads worse than a small dedicated file.
- **No injection surface.** The `workflow_dispatch` examples input is bound through `env:` (not interpolated into `run:`) and consumed only as an `int()`-parsed value, so a malformed input fails closed with `ValueError`.
- Read-only permissions, pinned action SHAs — matches `dev.yml`.
- Verified locally: `tox -e fuzz` at the default 5,000 runs all six properties green in ~28s.

The nightly cron won't fire until this is on `main`; the `workflow_dispatch` trigger lets it be run on demand from the Actions tab once merged.