### PR TITLE
fix: route HYBRID_GEN2 daily battery energy to alt1 (hass#293)

### DIFF
--- a/givenergy_modbus/model/manifest.py
+++ b/givenergy_modbus/model/manifest.py
@@ -31,9 +31,14 @@ from givenergy_modbus.model.inverter import Model
 #
 # Evidence (tests/fixtures/captures/): GEN1 populates the alt2 daily registers as
 # authoritative and IR alt1 totals; AC/AIO populate alt1 daily, totals unknown → None.
+# GEN2 populates the alt1 daily registers (IR36/37) like AC/AIO — NOT GEN1's alt2 (hass#293
+# capture: alt1 daily 4.7/5.5 kWh, corroborated by e_ac_charge_today ~= 4.8; alt2 daily read 0).
+# GEN2 total is deferred: alt1 total (IR180/181) read an implausible 0 on that capture and the
+# likely register (HR4111/4112) wasn't polled — undeclared → honest None until a fuller capture.
 VALUE_SOURCES: dict[str, dict[Model, str]] = {
     "battery_energy_today": {
         Model.HYBRID_GEN1: "alt2",
+        Model.HYBRID_GEN2: "alt1",
         Model.AC: "alt1",
         Model.ALL_IN_ONE: "alt1",
     },

--- a/tests/model/test_inverter.py
+++ b/tests/model/test_inverter.py
@@ -22,6 +22,23 @@ from givenergy_modbus.model.register import HR, IR
 from givenergy_modbus.model.register_cache import RegisterCache
 
 
+def test_hybrid_gen2_daily_battery_energy_routes_to_alt1():
+    """HYBRID_GEN2 reports daily battery energy at alt1 (IR36/37), like AC/AIO — not GEN1's alt2.
+
+    Regression for hass#293: on a Gen2 3.6 hybrid (dtc 0x2003, arm 920) the canonical daily
+    charge/discharge energy sensors read blank because GEN2 was undeclared in VALUE_SOURCES, so
+    they routed to None while the real data sat in alt1. Field capture: IR(36)=47 -> 4.7 kWh,
+    corroborated by e_ac_charge_today ~= 4.8 on that unit. Total stays deferred (None) — the Gen2
+    total register isn't confirmed (alt1 total read an implausible 0 on the capture).
+    """
+    inv = SinglePhaseInverter.from_register_cache(RegisterCache({HR(0): 0x2003, HR(21): 920, IR(36): 47, IR(37): 55}))
+    assert resolve_model(0x2003, 920) is Model.HYBRID_GEN2
+    assert inv.e_battery_charge_today == 4.7
+    assert inv.e_battery_discharge_today == 5.5
+    assert inv.e_battery_charge_total is None  # deferred: Gen2 total register unconfirmed
+    assert inv.e_battery_discharge_total is None
+
+
 def test_first_battery_serial_number_removed():
     """first_battery_serial_number is gone from the model (#191).
 

--- a/tests/model/test_manifest.py
+++ b/tests/model/test_manifest.py
@@ -24,6 +24,16 @@ def test_battery_energy_source_migrated_rows():
     assert battery_energy_source(Model.ALL_IN_ONE, "today") == "alt1"
 
 
+def test_battery_energy_source_hybrid_gen2_daily_is_alt1():
+    """HYBRID_GEN2 daily energy is at alt1 (IR36/37) like AC/AIO, not GEN1's alt2 (hass#293).
+
+    Total stays undeclared — the Gen2 total register isn't confirmed (alt1 total read 0 on the
+    capture; the likely HR4111/4112 wasn't polled), so it routes to an honest None.
+    """
+    assert battery_energy_source(Model.HYBRID_GEN2, "today") == "alt1"
+    assert battery_energy_source(Model.HYBRID_GEN2, "total") is None
+
+
 def test_battery_energy_source_absent_is_none():
     """Absent model or metric routes to None — the honest no-evidence posture."""
     assert battery_energy_source(Model.AC, "total") is None


### PR DESCRIPTION
Gen2 3.6 hybrids resolve to `Model.HYBRID_GEN2`, which was never declared in `VALUE_SOURCES`. The canonical daily battery-energy routers (`e_battery_charge_today` / `e_battery_discharge_today`) therefore fell through to `None`, which is what surfaced downstream as the missing charge/discharge sensors reported on [hass#293](https://github.com/dewet22/givenergy-home-assistant/issues/293).

## Fix

Declare `HYBRID_GEN2` daily energy at **alt1** (IR36/37), the same source AC and AIO already use:

```python
"battery_energy_today": {
    Model.HYBRID_GEN1: "alt2",
    Model.HYBRID_GEN2: "alt1",   # <- added
    Model.AC: "alt1",
    Model.ALL_IN_ONE: "alt1",
},
```

## Evidence

From the reporter's capture:

- `e_battery_charge_today_alt1` = 4.7, corroborated by `e_ac_charge_today` = 4.8
- `e_battery_discharge_today_alt1` = 5.5
- alt2 daily (GEN1's source) reads 0.0 for this unit

End-to-end through the framer + `Plant.update()`, the canonical fields now resolve to 4.7 / 5.5 rather than `None`.

## Total deferred (honest `None`)

Battery-energy **total** stays `None` for GEN2, and deliberately so. The alt1 total register (IR180/181) reads an implausible 0 for a unit with ~7397 kWh lifetime throughput, and the alt2/alt3 total candidates live in the HR(4100+) bank — which the library polls on **no** model. That bank isn't in the base refresh, in `LOAD_CONFIG_RANGES`, or in any gated range, so a passive capture (like this one, or anything HA collects) can never contain it; the dongle is simply never asked.

Pinning the Gen2 total source therefore needs a **directed probe** — a one-off `ReadHoldingRegisters(base=4100, count~16)` against a Gen2 — not a fuller passive capture, to see whether the bank answers at all and whether HR4111/4112 hold a plausible lifetime value. Until that lands I'd rather report an honest `None` than route to a register I can't stand behind. Something I'll return to once a Gen2 owner can run that probe.

## Tests

- `test_hybrid_gen2_daily_battery_energy_routes_to_alt1` — routing + `resolve_model(0x2003, 920) is HYBRID_GEN2`, total asserted `None`
- `test_battery_energy_source_hybrid_gen2_daily_is_alt1` — table-level

Full suite + tox green.
