### PR TITLE
chore: let codespell ignore verbatim doc register-name typos

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -219,7 +219,9 @@ commands =
 """
 
 [tool.codespell]
-ignore-words-list = "astroid"
 # The register inventory carries verbatim doc register names, typos and all
-# ("Freqency", "ModelL") — they're facts about the doc, not our prose.
+# ("Freqency", "ModelL") — they're facts about the doc, not our prose. They recur
+# in this file's own explanatory comment too, so ignore them by word (not only via
+# the register-JSON skip below, which can't cover pyproject.toml itself).
+ignore-words-list = "astroid,freqency,modell"
 skip = "./.*,./uv.lock,*/reference/registers/*.json,./docs/reference/registers/*.json"


### PR DESCRIPTION
Small config tidy-up spotted while landing #404/#405. Both PRs touched `pyproject.toml`, and each time the local `codespell` pre-commit hook flagged the two words in the `[tool.codespell]` block's own comment — `"Freqency"` and `"ModelL"`, the verbatim doc register names it exists to explain.

The `skip` list already exempts the register-inventory JSON, but it can't exempt `pyproject.toml` itself without stopping codespell checking the rest of the file. So the fix is to move the two words into `ignore-words-list`, letting the config lint its own explanatory comment. The register-JSON skip stays as a second layer.

Config-only — codespell isn't part of the tox CI gate (it's a local pre-commit hook), so this just stops the recurring local-commit friction on `pyproject.toml` edits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated spelling-checker configuration to recognise approved technical and inventory-specific terms.
  * Clarified guidance for handling factual strings in documentation and project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->