### PR TITLE
docs: correct Gen2 fixture attribution to the actual reporter

### DIFF
--- a/tests/fixtures/captures/hybrid_gen2_1_bat_a/README.md
+++ b/tests/fixtures/captures/hybrid_gen2_1_bat_a/README.md
@@ -64,8 +64,9 @@ trailing unit digits zeroed):
 
 ## Origin
 
-A single 60-second poll cycle from the hass#293 reporter's system
-(`crg-n`), 2026-07-13, captured with `givenergy-cli capture` and already
+A single 60-second poll cycle posted publicly by reporter `josephd168` on
+[dewet22/givenergy-hass#293](https://github.com/dewet22/givenergy-hass/issues/293)
+(2026-07-13), captured with `givenergy-cli capture` and already
 redacted at source (unit digits zeroed; our `FrameRedactor` re-run is a
 no-op, verified zero unredacted serials).
 


### PR DESCRIPTION
The `hybrid_gen2_1_bat_a` fixture README credited `crg-n` as the hass#293 reporter. That's wrong: the issue was opened, and the capture posted, by **`josephd168`**. `crg-n` is a different contributor — Gateway + dual-AIO owner, who did the HR111/112 C-rate field work on hass#281.

I introduced the error when I wrote the fixture in #408; it came from conflating two contributors while working from memory rather than checking the issue. Verified now against the issue author.

Also switches the Origin line to the full issue link, matching the convention the other fixture READMEs use (and the `lamztib` precedent for naming a reporter who posted publicly).

Docs-only — no code or fixture bytes touched. Golden-master suite still green (15 passed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the capture fixture’s origin information to identify the public reporter.
  * Added a direct link to the related issue for easier reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->