### PR TITLE
fix: suppress v_pv*/i_pv* where PV is metered AC-side (hass#281)

### DIFF
--- a/givenergy_modbus/model/inverter.py
+++ b/givenergy_modbus/model/inverter.py
@@ -1065,7 +1065,7 @@ class SinglePhaseInverter(  # type: ignore[valid-type,misc]
         source field actually carries one, and re-validating a dumped model (where
         e_pv_generation_* is already None) passes the moved values through untouched.
         """
-        from givenergy_modbus.model.manifest import ir44_is_inverter_output
+        from givenergy_modbus.model.manifest import ir44_is_inverter_output, pv_string_vi_is_ac_derived
 
         if not isinstance(values, dict):
             return values
@@ -1085,6 +1085,13 @@ class SinglePhaseInverter(  # type: ignore[valid-type,misc]
                 if values.get(src) is not None:
                     values[dst] = values.pop(src)
                     values[src] = None
+        if pv_string_vi_is_ac_derived(model, arm_fw=int(arm_fw)):
+            # Suppressed rather than relocated: v_ac1 already carries the voltage these
+            # registers echo, so there is no destination field worth adding. The power
+            # and energy members of the PV family are left alone — they are the only
+            # generation figure an AC-metered install has (hass#281).
+            for field in ("v_pv1", "v_pv2", "i_pv1", "i_pv2"):
+                values[field] = None
         return values
 
     def _battery_energy(self, direction: str, metric: str) -> float | None:

--- a/givenergy_modbus/model/manifest.py
+++ b/givenergy_modbus/model/manifest.py
@@ -67,12 +67,39 @@ def battery_energy_source(model: Model, metric: str, arm_fw: int | None = None) 
 # are ThreePhase-decoded and never reach the SinglePhaseInverter validator.
 FIELD_IDENTITY: dict[str, frozenset[Model]] = {
     "ir44_inverter_out": frozenset({Model.AC, Model.ALL_IN_ONE}),
+    # Models where PV is metered on the AC side, so IR(1)/IR(2) and IR(8)/IR(9) do not
+    # describe a DC string even though the power/energy members of the family do carry
+    # real generation figures (hass#281).
+    #
+    # Evidence, strongest first. On the AIO (`aio_a` fw612 capture) `v_pv1` is
+    # bit-identical to `v_ac1` in all 49 states, tracking it across nine distinct
+    # voltages, while `i_pv1` takes only two values against 24 distinct `p_pv1` values —
+    # so neither reading is a coherent string measurement, and `p_pv1 != v_pv1 * i_pv1`.
+    # On DC hybrids the same product reconciles with `p_pv1` (GEN1, GEN2, HYBRID_HV_GEN3)
+    # and `v_pv1` sits 43-142 V clear of mains, so those keep the fields.
+    #
+    # Model.AC is listed on the structural argument rather than corpus evidence: an
+    # AC-coupled unit has no DC string for these registers to describe. Every AC capture
+    # we hold reads `p_pv1 == 0`, so none of them can corroborate it directly; the one
+    # live sample (a GIV-AC3.0 on hass#281) has v_pv1 within ~1.6 V of mains rather than
+    # exactly equal, which is weaker than the AIO signature.
+    #
+    # AC_3PH is deliberately absent despite being is_ac_coupled. This row is applied by
+    # SinglePhaseInverter._apply_field_identity, and ThreePhaseInverter carries no model
+    # validators at all, so listing AC_3PH would read as handled while doing nothing.
+    # Extending the routing to three-phase is its own piece of work.
+    "pv_string_vi_ac_derived": frozenset({Model.AC, Model.ALL_IN_ONE}),
 }
 
 
 def ir44_is_inverter_output(model: Model, arm_fw: int | None = None) -> bool:
     """True when IR44/IR45-46 carry inverter output (not PV) on this model (#293)."""
     return model in FIELD_IDENTITY["ir44_inverter_out"]
+
+
+def pv_string_vi_is_ac_derived(model: Model, arm_fw: int | None = None) -> bool:
+    """True when v_pv*/i_pv* are AC-side artefacts rather than string readings (hass#281)."""
+    return model in FIELD_IDENTITY["pv_string_vi_ac_derived"]
 
 
 # Consumption-family evidence gate (#293): a candidate corrected-AIO consumption

--- a/tests/model/test_fixture_golden_master.py
+++ b/tests/model/test_fixture_golden_master.py
@@ -27,7 +27,7 @@ import pytest
 from givenergy_modbus.framer import ClientFramer
 from givenergy_modbus.model.inverter import Model, inverter_address_for, resolve_model
 from givenergy_modbus.model.plant import Plant, PlantCapabilities
-from givenergy_modbus.model.register import HR
+from givenergy_modbus.model.register import HR, IR
 from givenergy_modbus.model.register_cache import RegisterCache
 from givenergy_modbus.pdu import TransparentResponse
 
@@ -146,6 +146,22 @@ async def test_aio_classifies_as_hv_all_in_one():
     inv = plant.inverter
     assert inv.e_pv_generation_today is None  # mislabel retired on AIO (#293)
     assert inv.e_inverter_out_today == 1.8  # raw IR(44) == 18; 18 / 10 == 1.8
+
+    # v_pv*/i_pv* are AC-side artefacts on the AIO, so they decode to None (hass#281).
+    # The power members stay — they carry the install's only real generation figure.
+    assert inv.v_pv1 is None
+    assert inv.v_pv2 is None
+    assert inv.i_pv1 is None
+    assert inv.i_pv2 is None
+    assert inv.p_pv1 == 862
+
+    # The evidence for that suppression, pinned raw so a later capture can contradict
+    # it: IR(1) (v_pv1's source) is bit-identical to IR(5) (v_ac1's), and IR(8) (i_pv1)
+    # is a flat 3.0 A that cannot reconcile 862 W against a 245.7 V "string".
+    cache = plant.register_caches[0x11]
+    assert cache.get(IR(1)) == cache.get(IR(5)) == 2457
+    assert cache.get(IR(8)) == 30
+    assert inv.v_ac1 == pytest.approx(245.7)
 
 
 @pytest.mark.timeout(20)

--- a/tests/model/test_manifest.py
+++ b/tests/model/test_manifest.py
@@ -12,6 +12,7 @@ from givenergy_modbus.model.manifest import (
     has_capability,
     has_extended_slots,
     ir44_is_inverter_output,
+    pv_string_vi_is_ac_derived,
     write_safe_registers,
 )
 
@@ -52,6 +53,96 @@ def test_ir44_identity_overrides():
     assert ir44_is_inverter_output(Model.HYBRID_GEN1) is False
     assert ir44_is_inverter_output(Model.HYBRID_GEN3) is False
     assert ir44_is_inverter_output(Model.GATEWAY) is False  # unlisted → status quo
+
+
+def test_pv_string_vi_is_ac_derived_overrides():
+    """v_pv*/i_pv* are not string measurements where PV is metered AC-side (hass#281).
+
+    Evidence is strongest on the AIO: across all 49 states of the `aio_a` fw612 capture
+    `v_pv1` is bit-identical to `v_ac1` (tracking together over nine distinct voltages)
+    while `i_pv1` takes just two values against 24 distinct `p_pv1` values — neither is
+    a coherent string reading. On DC hybrids the V*I product reconciles with `p_pv1`
+    and `v_pv1` sits 43-142 V clear of mains, so they keep the fields.
+
+    Model.AC is included on the structural argument rather than corpus evidence: an
+    AC-coupled unit has no DC string for those registers to describe. No fixture has a
+    generating AC sample (every AC capture reads p_pv1 == 0).
+
+    AC_3PH is deliberately ABSENT despite being is_ac_coupled: ThreePhaseInverter
+    carries no model validators, so the routing below never fires there and listing it
+    would be a silent no-op rather than a fix.
+    """
+    assert pv_string_vi_is_ac_derived(Model.ALL_IN_ONE) is True
+    assert pv_string_vi_is_ac_derived(Model.AC) is True
+    assert pv_string_vi_is_ac_derived(Model.HYBRID_GEN1) is False
+    assert pv_string_vi_is_ac_derived(Model.HYBRID_GEN2) is False
+    assert pv_string_vi_is_ac_derived(Model.HYBRID_HV_GEN3) is False
+    assert pv_string_vi_is_ac_derived(Model.AC_3PH) is False  # see docstring
+    assert pv_string_vi_is_ac_derived(Model.GATEWAY) is False  # unlisted → status quo
+
+
+def _pv_inverter(dtc_hex: str, arm_fw: int):
+    """Build a SinglePhaseInverter with the PV string registers primed."""
+    from givenergy_modbus.model.inverter import SinglePhaseInverter
+    from givenergy_modbus.model.register import HR, IR
+    from givenergy_modbus.model.register_cache import RegisterCache
+
+    cache = RegisterCache(
+        {
+            HR(0): int(dtc_hex, 16),
+            HR(21): arm_fw,
+            IR(1): 2457,  # v_pv1 245.7
+            IR(2): 3808,  # v_pv2 380.8
+            IR(8): 30,  # i_pv1 3.0
+            IR(9): 52,  # i_pv2 5.2
+            IR(18): 862,  # p_pv1
+            IR(20): 674,  # p_pv2
+        }
+    )
+    return SinglePhaseInverter.from_register_cache(cache)
+
+
+def test_pv_string_vi_suppressed_on_aio_power_retained():
+    """On the AIO the V/I pair goes None while the power figures stay.
+
+    The power members carry the only real generation reading such an install has.
+    """
+    inv = _pv_inverter("8001", 612)  # ALL_IN_ONE
+    assert inv.v_pv1 is None
+    assert inv.v_pv2 is None
+    assert inv.i_pv1 is None
+    assert inv.i_pv2 is None
+    assert inv.p_pv1 == 862
+    assert inv.p_pv2 == 674
+
+
+def test_pv_string_vi_suppressed_on_ac_coupled():
+    """Model.AC has no DC string, so the same suppression applies."""
+    inv = _pv_inverter("3001", 282)  # Model.AC
+    assert inv.v_pv1 is None
+    assert inv.i_pv1 is None
+    assert inv.p_pv1 == 862
+
+
+def test_pv_string_vi_retained_on_dc_hybrids():
+    """DC hybrids keep the full triplet — the fields are genuine there."""
+    for dtc, fw in (("2001", 449), ("2003", 920), ("8102", 500)):
+        inv = _pv_inverter(dtc, fw)
+        assert inv.v_pv1 == pytest.approx(245.7), dtc
+        assert inv.v_pv2 == pytest.approx(380.8), dtc
+        assert inv.i_pv1 == pytest.approx(3.0), dtc
+        assert inv.i_pv2 == pytest.approx(5.2), dtc
+
+
+def test_pv_string_vi_suppression_is_idempotent_on_roundtrip():
+    """model_validate(model_dump()) must not resurrect the suppressed fields."""
+    from givenergy_modbus.model.inverter import SinglePhaseInverter
+
+    inv = _pv_inverter("8001", 612)
+    again = SinglePhaseInverter.model_validate(inv.model_dump())
+    assert again.v_pv1 is None
+    assert again.i_pv1 is None
+    assert again.p_pv1 == 862
 
 
 def _inverter(dtc_hex: str, arm_fw: int, ir44: int = 77, ir45: int = 1, ir46: int = 17083):


### PR DESCRIPTION
Raised from [givenergy-hass#281](https://github.com/dewet22/givenergy-hass/issues/281): an AC-coupled unit has no DC string, yet reports a live, climbing `p_pv1`. The power figure is real — but the accompanying *voltage* is mains, not a string voltage. Same class of quiet mislabelling as IR44 before #267: plausible-looking and wrong.

`v_pv1`/`v_pv2`/`i_pv1`/`i_pv2` now decode to `None` on `Model.AC` and `Model.ALL_IN_ONE`, via a new `FIELD_IDENTITY` row reusing the mechanism `ir44_inverter_out` already established.

The **power and energy** members are deliberately untouched. They carry real generation and are the only such figure an AC-metered install has.

## Evidence

The AIO case is conclusive. Across all 49 states of the `aio_a` fw612 capture:

- `v_pv1` is **bit-identical** to `v_ac1` — not "within about a volt", the same value — tracking together across nine distinct voltages (245.5 → 246.2).
- `i_pv1` takes just **two** distinct values (3.0, 4.0) against **24** distinct `p_pv1` values (860–971 W). So `p_pv1 ≠ v_pv1 × i_pv1`; 245.7 × 3.0 = 737 W against a reported 862 W.

Neither is a coherent string measurement. The DC controls behave completely differently — V×I reconciles with `p_pv1` on GEN1, GEN2 and HYBRID_HV_GEN3, and `v_pv1` sits 43–142 V clear of mains:

| model | v_pv1 | v_ac1 | delta | p/(V×I) |
|---|---|---|---|---|
| GEN1 hybrid | 372.2 | 243.5 | 128.7 | ~1.0 |
| HYBRID_HV_GEN3 | 127.6 | 244.8 | −117.2 | 1.02 |
| **ALL_IN_ONE** | **245.7** | **245.7** | **0.00** | **1.17** |

Both directions are pinned, plus the raw `IR(1) == IR(5)` equality on the fixture so a later capture can contradict the reading rather than having to argue with a derived field.

## Two scope calls worth flagging

**`Model.AC` is included on a structural argument, not corpus evidence.** An AC-coupled unit has no DC string for these registers to describe, which I find convincing on its own. But every AC capture we hold reads `p_pv1 == 0` — across 690 and 825 samples at both `0x11` and `0x31`, there is not a single generating AC sample. So our fixtures cannot corroborate it directly. The one live sample (a GIV-AC3.0 on hass#281) has `v_pv1` ~1.6 V from mains rather than exactly equal, which is a weaker signature than the AIO's exact match. Flagging in case that gap matters more to a reviewer than it does to me.

**`AC_3PH` is deliberately absent despite being `is_ac_coupled`.** The row is applied by `SinglePhaseInverter._apply_field_identity`, and `ThreePhaseInverter` carries no model validators at all — so listing `AC_3PH` would read as handled while doing nothing. Extending the routing to three-phase is its own piece of work; I'd rather leave the gap visible than paper it over.

## Behaviour change

Consumers reading `v_pv1`/`v_pv2`/`i_pv1`/`i_pv2` on AC or AIO models will now get `None` where they previously got a mains-derived number. Worth an upgrade note on the release.

## Not established

The metering path — whether the figure comes from a generation CT on a separate solar inverter's output or from something internal — is still unknown, and I haven't guessed at it. It matters because it determines whether a zero reading means "no generation right now" or "no CT fitted". The pinned `i_pv1`-at-3.0 A is a clue but not an answer.

## Verification

tox green (py311, py314, format, lint); 1665 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)