### PR TITLE
test: assert the HV Gen3 fixture's decoded-frame count and CRC cleanliness

### DIFF
--- a/tests/fixtures/captures/hybrid_hv_gen3_a/README.md
+++ b/tests/fixtures/captures/hybrid_hv_gen3_a/README.md
@@ -7,7 +7,7 @@ in [`../README.md`](../README.md).
 
 | File | Vantage |
 |---|---|
-| `givhy80g3hv_hass295_120s.log` | HYBRID_HV_GEN3 passive HA capture, 120 s (34 frames) |
+| `givhy80g3hv_hass295_120s.log` | HYBRID_HV_GEN3 passive HA capture, 120 s (34 frames: 17 requests + 17 responses) |
 
 ## Topology
 
@@ -116,4 +116,7 @@ A 120-second passive capture from `KevC1978` on
 
 ## Clean
 
-34 frames, no error responses and no decoder gaps.
+34 frames (17 requests + 17 responses), no error responses, no CRC failures
+and no decoder gaps. Pinned by `test_every_response_frame_decodes`, which
+asserts the decoded-response count and CRC cleanliness rather than inferring
+them from the resulting topology.

--- a/tests/model/test_hybrid_hv_gen3_from_capture.py
+++ b/tests/model/test_hybrid_hv_gen3_from_capture.py
@@ -18,11 +18,13 @@ from pathlib import Path
 
 import pytest
 
+from givenergy_modbus.framer import ClientFramer
 from givenergy_modbus.model.inverter import Model, SinglePhaseInverter, resolve_model
 from givenergy_modbus.model.inverter_threephase import ThreePhaseInverter, select_inverter
 from givenergy_modbus.model.manifest import has_capability
 from givenergy_modbus.model.plant import Plant
 from givenergy_modbus.model.register import IR
+from givenergy_modbus.pdu import TransparentResponse
 from givenergy_modbus.testing.mock_plant import plant_from_capture
 
 _CAPTURE = Path(__file__).parents[1] / "fixtures" / "captures" / "hybrid_hv_gen3_a" / "givhy80g3hv_hass295_120s.log"
@@ -107,12 +109,38 @@ def test_three_phase_bank_answers_but_is_all_zero(replayed_plant: Plant):
 
 
 @pytest.mark.timeout(15)
-def test_every_response_frame_decodes(replayed_plant: Plant):
-    """All 17 rx frames decode cleanly — `plant_from_capture` skips undecodable ones silently.
+async def test_every_response_frame_decodes(replayed_plant: Plant):
+    """All 17 response frames decode — `plant_from_capture` skips undecodable ones silently.
 
-    Without this, a corrupted fixture (a botched CRC regen, a hand-edit) would degrade to a
-    thinner plant rather than an error, and the assertions above would quietly test less.
+    Counts the decoded frames rather than inferring from the resulting topology. A frame
+    dropped for an already-populated device leaves the device set and the populated count
+    untouched, so a topology-only check stays green while the fixture quietly tests less —
+    the same shape of hole as the #371 load_config fence.
+
+    CRC is asserted separately because a bad CRC does NOT reduce the decoded count: the
+    PDU still decodes and is flagged `crc_failed`, with the guard refusing the commit
+    downstream. Counting alone would therefore miss a botched CRC regen, which is exactly
+    the failure the README's "clean" claim rules out.
     """
+    raw_frames = [
+        bytes.fromhex(line.split(":", 1)[1].strip())
+        for line in _CAPTURE.read_text(encoding="utf-8").splitlines()
+        if line.startswith("rx:")
+    ]
+    assert len(raw_frames) == 17, "the capture's 34 frames are 17 requests + 17 responses"
+
+    framer = ClientFramer()
+    decoded = errors = crc_failures = 0
+    for raw in raw_frames:
+        async for pdu in framer.decode(raw):
+            if isinstance(pdu, TransparentResponse):
+                errors += bool(pdu.error)
+                decoded += not pdu.error
+                crc_failures += bool(getattr(pdu, "crc_failed", False))
+    assert (decoded, errors) == (17, 0), "every response decodes and none is an error response"
+    assert crc_failures == 0, "fixture is CRC-clean — a bad regen would surface here, not in the count"
+
+    # Topology is still worth pinning: it is what the assertions above actually read from.
     devices = set(replayed_plant.register_caches)
     assert devices == {0x01, 0x11, 0x32, 0x50, 0x51, 0x52, 0x70}
     populated = sum(1 for a in devices if len(replayed_plant.register_caches[a]))


### PR DESCRIPTION
Post-merge review catch on #412 (CodeRabbit reviewed after the merge landed).

`test_every_response_frame_decodes` claimed all 17 response frames decode, but only asserted the device topology. A frame dropped for an already-populated device leaves both the device set and the populated count untouched — so the fence would have stayed green while the fixture quietly tested less. That's the same hole as the #371 `load_config` fence, and a fence that doesn't bite is worse than no fence because it reads as reassurance.

It now counts decoded responses directly.

## One correction to the review's framing, worth recording

CodeRabbit suggested folding this into a single verified count. That isn't sufficient on its own: **a bad CRC does not reduce the decoded count.** The PDU still decodes and is flagged `crc_failed`, with the guard refusing the commit downstream. I checked rather than assumed:

| capture state | (decoded, errors, crc_failed) | caught by |
|---|---|---|
| pristine | (17, 0, 0) | — |
| one frame removed | (16, 0, 0) | count |
| one CRC byte flipped | (17, 0, **1**) | CRC assertion only |

So counting alone would have missed a botched CRC regen — precisely what the fixture README's "clean" claim rules out. CRC is asserted separately for that reason, with the reasoning in the docstring so the next person doesn't collapse the two.

The README frame count is disambiguated to 17 requests + 17 responses; it read 34 while the test said 17, which is the inconsistency that surfaced this.

## Verification

tox green (py314, format, lint); 1660 tests pass. Both failure modes confirmed to trip the fence by hand before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)