### PR TITLE
fix: observe exception responses the client never routes

### DIFF
--- a/tests/debug/probe_bms_register_map.py
+++ b/tests/debug/probe_bms_register_map.py
@@ -314,7 +314,13 @@ async def selftest(client: Client, watcher: _ErrorResponseWatcher, addr: int) ->
         )
 
 
-async def main(host: str, addrs: list[int], do_sweep: bool = False, do_selftest: bool = False) -> None:
+async def main(
+    host: str,
+    addrs: list[int],
+    do_sweep: bool = False,
+    do_selftest: bool = False,
+    use_ir: bool = False,
+) -> None:
     # Expected error responses would otherwise print over the results table. A
     # NullHandler is needed as well as propagate=False: with neither, logging falls
     # back to lastResort and writes to stderr anyway.

--- a/tests/debug/probe_bms_register_map.py
+++ b/tests/debug/probe_bms_register_map.py
@@ -76,46 +76,74 @@ ANCHOR_UNMAPPED = 0x8000  # far above anything plausible
 OK, ERR, DEAD = "data", "exception", "no-reply"
 
 
-class _ErrorResponseWatcher(logging.Handler):
-    """Detect a Modbus exception response, which the client will not hand back.
+class _ErrorResponseWatcher:
+    """Observe exception responses, which never reach the caller of the client API.
 
-    ``Client.send_request_and_await_response`` never returns a response with
-    ``error`` set: on receiving one it logs, consumes a retry, and ultimately raises
-    ``TimeoutError``. So at that API an exception response and dead silence are
-    indistinguishable - inspecting the returned PDU can never see an exception,
-    because an erroring request never returns a PDU at all.
+    Two layers hide them, and both have to be bypassed:
 
-    The distinction does survive in the ERROR log the client emits before retrying,
-    so watch for that instead. Getting this wrong silently reclassifies every
-    exception as a no-reply, which inverts the whole point of the script.
+    1. ``send_request_and_await_response`` never returns a response with ``error``
+       set - it logs, consumes a retry, and raises ``TimeoutError``. So inspecting
+       the returned PDU can never see an exception.
+
+    2. More importantly, an error response usually does not *match* the request it
+       answers. A response is routed to its waiting future by shape hash, which is
+       ``(device_address, base_register, register_count)`` - and observed error
+       responses carry ``register_count=0`` rather than echoing the count asked for
+       (see the ``hybrid_2_bat_a`` and ``aio_a`` captures). The hashes differ, the
+       future is never resolved, and even the client's own error log never fires.
+
+    ``Plant.update()`` is called for *every* decoded message before any shape
+    matching, so wrapping it sees exception responses whichever way they arrive.
+
+    Responses are recorded by ``(device_address, base_register)`` rather than as a
+    bare flag: the dongle fans every response out to all connected clients, so an
+    exception provoked by GivTCP or the phone app would otherwise be misread as an
+    answer to our own probe.
     """
 
-    def __init__(self) -> None:
-        super().__init__(logging.ERROR)
-        self.saw_error_response = False
+    def __init__(self, plant: object) -> None:
+        self.errors: set[tuple[int, int]] = set()
+        # Patch the class, not the instance: Plant is a pydantic model, and assigning
+        # an attribute on the instance raises "object has no field".
+        self._cls = type(plant)
+        self._original = self._cls.update
 
-    def emit(self, record: logging.LogRecord) -> None:
-        if "error response" in record.getMessage().lower():
-            self.saw_error_response = True
+    def install(self) -> None:
+        original, errors = self._original, self.errors
 
+        def wrapped(plant_self: object, pdu: object, **kwargs: object) -> object:
+            if getattr(pdu, "error", False):
+                addr = getattr(pdu, "device_address", None)
+                base = getattr(pdu, "base_register", None)
+                if addr is not None and base is not None:
+                    errors.add((addr, base))
+            return original(plant_self, pdu, **kwargs)
 
-_WATCHER = _ErrorResponseWatcher()
+        self._cls.update = wrapped
+
+    def remove(self) -> None:
+        self._cls.update = self._original
 
 
 async def probe(
-    client: Client, addr: int, base: int, count: int, attempts: int = ATTEMPTS, timeout: float = TIMEOUT
+    client: Client,
+    watcher: _ErrorResponseWatcher,
+    addr: int,
+    base: int,
+    count: int,
+    attempts: int = ATTEMPTS,
+    timeout: float = TIMEOUT,
 ) -> str:
     """Classify one read as OK (data), ERR (Modbus exception) or DEAD (no reply).
 
     Retries only the no-reply case: contention from GivTCP or the phone app shows up
-    as a timeout and would otherwise masquerade as a meaningful negative. An exception
-    is definitive and returns at once.
+    as a timeout and would otherwise masquerade as a meaningful negative.
 
-    ``retries=0`` matters: with retries left, the client would retry an error response
-    before giving up, muddying which attempt produced what.
+    ``retries=0`` matters: with retries left the client would re-send after an error
+    response, muddying which attempt produced what.
     """
     for _ in range(attempts):
-        _WATCHER.saw_error_response = False
+        watcher.errors.discard((addr, base))
         try:
             await client.send_request_and_await_response(
                 ReadHoldingRegistersRequest(base_register=base, register_count=count, device_address=addr),
@@ -124,7 +152,7 @@ async def probe(
                 warn_timeout=False,
             )
         except TimeoutError:
-            if _WATCHER.saw_error_response:
+            if (addr, base) in watcher.errors:
                 return ERR
             await asyncio.sleep(0.4)
             continue
@@ -153,7 +181,9 @@ def verdict(baseline: str, single: str, mapped: str, unmapped: str) -> str:
     return "INCONCLUSIVE- mixed result, see columns"
 
 
-async def sweep(client: Client, addr: int, limit: int = 0x900, step: int = 0x20) -> None:
+async def sweep(
+    client: Client, watcher: _ErrorResponseWatcher, addr: int, limit: int = 0x900, step: int = 0x20
+) -> None:
     """Map which single registers answer at ``addr``, to locate the served extent.
 
     Run when the anchors both come back silent. A clean cutoff at a round boundary
@@ -172,7 +202,7 @@ async def sweep(client: Client, addr: int, limit: int = 0x900, step: int = 0x20)
     )
     results: dict[int, str] = {}
     for base in bases:
-        results[base] = await probe(client, addr, base, 1, attempts=1, timeout=1.5)
+        results[base] = await probe(client, watcher, addr, base, 1, attempts=1, timeout=1.5)
         await asyncio.sleep(0.1)
 
     edges = [i for i in range(1, len(bases)) if results[bases[i]] != results[bases[i - 1]]]
@@ -180,7 +210,7 @@ async def sweep(client: Client, addr: int, limit: int = 0x900, step: int = 0x20)
         print(f"  confirming {len(edges) * 2} addresses either side of {len(edges)} transition(s)...")
     for i in edges:
         for b in (bases[i - 1], bases[i]):
-            results[b] = await probe(client, addr, b, 1, attempts=3, timeout=3.0)
+            results[b] = await probe(client, watcher, addr, b, 1, attempts=3, timeout=3.0)
     # Recompute: a confirmation can dissolve an edge (or expose a new one), and
     # bisecting a boundary that no longer exists would print a meaningless result.
     edges = [i for i in range(1, len(bases)) if results[bases[i]] != results[bases[i - 1]]]
@@ -204,7 +234,7 @@ async def sweep(client: Client, addr: int, limit: int = 0x900, step: int = 0x20)
         lo_state, hi_state = results[lo], results[hi]
         while hi - lo > 1:
             mid = (lo + hi) // 2
-            if await probe(client, addr, mid, 1, attempts=2, timeout=3.0) == lo_state:
+            if await probe(client, watcher, addr, mid, 1, attempts=2, timeout=3.0) == lo_state:
                 lo = mid
             else:
                 hi = mid
@@ -222,27 +252,25 @@ async def sweep(client: Client, addr: int, limit: int = 0x900, step: int = 0x20)
 
 
 async def main(host: str, addrs: list[int], do_sweep: bool = False) -> None:
-    # Route the client's logging into the watcher only. Without propagate=False the
-    # "Received error response" lines - which are expected here, not faults - would
-    # print over the results table.
-    client_log = logging.getLogger("givenergy_modbus")
-    client_log.addHandler(_WATCHER)
-    client_log.propagate = False
+    # Expected error responses would otherwise print over the results table.
+    logging.getLogger("givenergy_modbus").propagate = False
 
     client = Client(host, 8899)
     await client.connect()
+    watcher = _ErrorResponseWatcher(client.plant)
+    watcher.install()
     sweepable: list[int] = []
     try:
         print(f"probing {host}:8899 - READ ONLY, {ATTEMPTS} attempts per probe, {TIMEOUT}s timeout\n")
         print(f"{'addr':>5}  {'HR(0,60)':>9}  {'HR(0,1)':>9}  {'HR(0x486,1)':>12}  {'HR(0x8000,1)':>13}  verdict")
         for addr in addrs:
-            baseline = await probe(client, addr, 0, 60)
+            baseline = await probe(client, watcher, addr, 0, 60)
             if baseline == DEAD:
                 print(f"  0x{addr:02x}  {baseline:>9}  {'-':>9}  {'-':>12}  {'-':>13}  {verdict(baseline, '', '', '')}")
                 continue
-            single = await probe(client, addr, 0, 1)
-            mapped = await probe(client, addr, ANCHOR_MAPPED, 1)
-            unmapped = await probe(client, addr, ANCHOR_UNMAPPED, 1)
+            single = await probe(client, watcher, addr, 0, 1)
+            mapped = await probe(client, watcher, addr, ANCHOR_MAPPED, 1)
+            unmapped = await probe(client, watcher, addr, ANCHOR_UNMAPPED, 1)
             # Only worth sweeping where single-register reads actually work; a sweep
             # built on HR(n,1) is meaningless if the device rejects that count.
             if single == OK:
@@ -261,12 +289,12 @@ async def main(host: str, addrs: list[int], do_sweep: bool = False) -> None:
         )
         if do_sweep:
             if sweepable:
-                await sweep(client, sweepable[0])
+                await sweep(client, watcher, sweepable[0])
             else:
                 print("\nnothing to sweep: no address accepted a single-register read.")
     finally:
+        watcher.remove()
         await client.close()
-        client_log.removeHandler(_WATCHER)
 
 
 if __name__ == "__main__":

--- a/tests/debug/probe_bms_register_map.py
+++ b/tests/debug/probe_bms_register_map.py
@@ -189,7 +189,12 @@ def verdict(baseline: str, single: str, mapped: str, unmapped: str) -> str:
 
 
 async def sweep(
-    client: Client, watcher: _ErrorResponseWatcher, addr: int, limit: int = 0x900, step: int = 0x20
+    client: Client,
+    watcher: _ErrorResponseWatcher,
+    addr: int,
+    limit: int = 0x900,
+    step: int = 0x20,
+    input_regs: bool = False,
 ) -> None:
     """Map which single registers answer at ``addr``, to locate the served extent.
 
@@ -203,13 +208,14 @@ async def sweep(
     # The second re-probes only the addresses either side of a transition, at full
     # patience, so a stray timeout under contention cannot invent a false edge.
     bases = list(range(0, limit + 1, step))
+    kind = "IR" if input_regs else "HR"
     print(
-        f"\nsweep 0x{addr:02x}: HR(n,1) for n in 0..0x{limit:X} step 0x{step:X} "
+        f"\nsweep 0x{addr:02x}: {kind}(n,1) for n in 0..0x{limit:X} step 0x{step:X} "
         f"({len(bases)} probes, ~{len(bases) * 2}s)"
     )
     results: dict[int, str] = {}
     for base in bases:
-        results[base] = await probe(client, watcher, addr, base, 1, attempts=1, timeout=1.5)
+        results[base] = await probe(client, watcher, addr, base, 1, attempts=1, timeout=1.5, input_regs=input_regs)
         await asyncio.sleep(0.1)
 
     edges = [i for i in range(1, len(bases)) if results[bases[i]] != results[bases[i - 1]]]
@@ -217,7 +223,7 @@ async def sweep(
         print(f"  confirming {len(edges) * 2} addresses either side of {len(edges)} transition(s)...")
     for i in edges:
         for b in (bases[i - 1], bases[i]):
-            results[b] = await probe(client, watcher, addr, b, 1, attempts=3, timeout=3.0)
+            results[b] = await probe(client, watcher, addr, b, 1, attempts=3, timeout=3.0, input_regs=input_regs)
     # Recompute: a confirmation can dissolve an edge (or expose a new one), and
     # bisecting a boundary that no longer exists would print a meaningless result.
     edges = [i for i in range(1, len(bases)) if results[bases[i]] != results[bases[i - 1]]]
@@ -241,7 +247,7 @@ async def sweep(
         lo_state, hi_state = results[lo], results[hi]
         while hi - lo > 1:
             mid = (lo + hi) // 2
-            if await probe(client, watcher, addr, mid, 1, attempts=2, timeout=3.0) == lo_state:
+            if await probe(client, watcher, addr, mid, 1, attempts=2, timeout=3.0, input_regs=input_regs) == lo_state:
                 lo = mid
             else:
                 hi = mid
@@ -309,8 +315,12 @@ async def selftest(client: Client, watcher: _ErrorResponseWatcher, addr: int) ->
 
 
 async def main(host: str, addrs: list[int], do_sweep: bool = False, do_selftest: bool = False) -> None:
-    # Expected error responses would otherwise print over the results table.
-    logging.getLogger("givenergy_modbus").propagate = False
+    # Expected error responses would otherwise print over the results table. A
+    # NullHandler is needed as well as propagate=False: with neither, logging falls
+    # back to lastResort and writes to stderr anyway.
+    client_log = logging.getLogger("givenergy_modbus")
+    client_log.propagate = False
+    client_log.addHandler(logging.NullHandler())
 
     client = Client(host, 8899)
     await client.connect()
@@ -348,7 +358,7 @@ async def main(host: str, addrs: list[int], do_sweep: bool = False, do_selftest:
             await selftest(client, watcher, sweepable[0] if sweepable else addrs[0])
         if do_sweep:
             if sweepable:
-                await sweep(client, watcher, sweepable[0])
+                await sweep(client, watcher, sweepable[0], input_regs=use_ir)
             else:
                 print("\nnothing to sweep: no address accepted a single-register read.")
     finally:
@@ -360,7 +370,7 @@ if __name__ == "__main__":
     if len(sys.argv) < 2:
         print(__doc__.rstrip().rsplit("\n\n", 1)[-1], file=sys.stderr)
         raise SystemExit(2)
-    flags = {"--sweep", "--selftest"}
+    flags = {"--sweep", "--selftest", "--ir"}
     args = [a for a in sys.argv[2:] if a not in flags]
     given = [int(a, 16) for a in args] or DEFAULT_ADDRS
     asyncio.run(
@@ -369,5 +379,6 @@ if __name__ == "__main__":
             given,
             do_sweep="--sweep" in sys.argv,
             do_selftest="--selftest" in sys.argv,
+            use_ir="--ir" in sys.argv,
         )
     )

--- a/tests/debug/probe_bms_register_map.py
+++ b/tests/debug/probe_bms_register_map.py
@@ -62,9 +62,16 @@ from __future__ import annotations
 import asyncio
 import logging
 import sys
+from datetime import datetime
+from typing import Any
 
 from givenergy_modbus.client.client import Client
-from givenergy_modbus.pdu import ReadHoldingRegistersRequest, ReadInputRegistersRequest
+from givenergy_modbus.model.plant import Plant
+from givenergy_modbus.pdu import (
+    ClientIncomingMessage,
+    ReadHoldingRegistersRequest,
+    ReadInputRegistersRequest,
+)
 
 # LV packs 0x32-0x37, LV BCU 0x31, HV BMU 0x50+, HV BCU 0x70+ (see model/plant.py,
 # model/hv_bcu.py). Kept short so an unattended run stays quick.
@@ -105,29 +112,30 @@ class _ErrorResponseWatcher:
     answer to our own probe.
     """
 
-    def __init__(self, plant: object) -> None:
+    def __init__(self, plant: Plant) -> None:
         self.errors: set[tuple[int, int, bool]] = set()
         # Patch the class, not the instance: Plant is a pydantic model, and assigning
         # an attribute on the instance raises "object has no field".
-        self._cls = type(plant)
+        self._cls: type[Plant] = type(plant)
         self._original = self._cls.update
 
     def install(self) -> None:
         original, errors = self._original, self.errors
 
-        def wrapped(plant_self: object, pdu: object, **kwargs: object) -> object:
+        # Signature must mirror Plant.update exactly, or mypy rejects the assignment.
+        def wrapped(plant_self: Plant, pdu: ClientIncomingMessage, *, received_at: datetime | None = None) -> Any:
             if getattr(pdu, "error", False):
                 addr = getattr(pdu, "device_address", None)
                 base = getattr(pdu, "base_register", None)
                 if addr is not None and base is not None:
                     is_input = "Input" in type(pdu).__name__
                     errors.add((addr, base, is_input))
-            return original(plant_self, pdu, **kwargs)
+            return original(plant_self, pdu, received_at=received_at)
 
-        self._cls.update = wrapped
+        self._cls.update = wrapped  # type: ignore[assignment]
 
     def remove(self) -> None:
-        self._cls.update = self._original
+        self._cls.update = self._original  # type: ignore[assignment]
 
 
 async def probe(

--- a/tests/debug/probe_bms_register_map.py
+++ b/tests/debug/probe_bms_register_map.py
@@ -42,7 +42,11 @@ Verdict:
 NO WRITES WHATSOEVER - every request is a read, and reading an unserved address is a
 no-op: the device either declines it or ignores it, and nothing changes either way.
 
-    uv run python tests/debug/probe_bms_register_map.py <inverter-host> [addr ...] [--sweep]
+    uv run python tests/debug/probe_bms_register_map.py <inverter-host> [addr ...] [--sweep] [--selftest]
+
+``--selftest`` first establishes whether an exception response can reach this
+script at all, using a read this project's captures record as error-responding.
+Run it before trusting any no-reply result.
 
 With no addresses given it tries a sample of the LV battery range (0x32-0x34, 0x31)
 plus the HV BCU/BMU bases; pass addresses explicitly to cover 0x35-0x37 as well.
@@ -60,7 +64,7 @@ import logging
 import sys
 
 from givenergy_modbus.client.client import Client
-from givenergy_modbus.pdu import ReadHoldingRegistersRequest
+from givenergy_modbus.pdu import ReadHoldingRegistersRequest, ReadInputRegistersRequest
 
 # LV packs 0x32-0x37, LV BCU 0x31, HV BMU 0x50+, HV BCU 0x70+ (see model/plant.py,
 # model/hv_bcu.py). Kept short so an unattended run stays quick.
@@ -102,7 +106,7 @@ class _ErrorResponseWatcher:
     """
 
     def __init__(self, plant: object) -> None:
-        self.errors: set[tuple[int, int]] = set()
+        self.errors: set[tuple[int, int, bool]] = set()
         # Patch the class, not the instance: Plant is a pydantic model, and assigning
         # an attribute on the instance raises "object has no field".
         self._cls = type(plant)
@@ -116,7 +120,8 @@ class _ErrorResponseWatcher:
                 addr = getattr(pdu, "device_address", None)
                 base = getattr(pdu, "base_register", None)
                 if addr is not None and base is not None:
-                    errors.add((addr, base))
+                    is_input = "Input" in type(pdu).__name__
+                    errors.add((addr, base, is_input))
             return original(plant_self, pdu, **kwargs)
 
         self._cls.update = wrapped
@@ -133,6 +138,7 @@ async def probe(
     count: int,
     attempts: int = ATTEMPTS,
     timeout: float = TIMEOUT,
+    input_regs: bool = False,
 ) -> str:
     """Classify one read as OK (data), ERR (Modbus exception) or DEAD (no reply).
 
@@ -142,17 +148,18 @@ async def probe(
     ``retries=0`` matters: with retries left the client would re-send after an error
     response, muddying which attempt produced what.
     """
+    request_cls = ReadInputRegistersRequest if input_regs else ReadHoldingRegistersRequest
     for _ in range(attempts):
-        watcher.errors.discard((addr, base))
+        watcher.errors.discard((addr, base, input_regs))
         try:
             await client.send_request_and_await_response(
-                ReadHoldingRegistersRequest(base_register=base, register_count=count, device_address=addr),
+                request_cls(base_register=base, register_count=count, device_address=addr),
                 timeout=timeout,
                 retries=0,
                 warn_timeout=False,
             )
         except TimeoutError:
-            if (addr, base) in watcher.errors:
+            if (addr, base, input_regs) in watcher.errors:
                 return ERR
             await asyncio.sleep(0.4)
             continue
@@ -251,7 +258,57 @@ async def sweep(
         )
 
 
-async def main(host: str, addrs: list[int], do_sweep: bool = False) -> None:
+async def selftest(client: Client, watcher: _ErrorResponseWatcher, addr: int) -> None:
+    """Prove whether an exception response can reach this script at all.
+
+    Every negative result so far has been a no-reply, which is ambiguous: it could
+    mean the device stays silent, or that the exception is real but something between
+    here and the device swallows it. Two fixes aimed at that ambiguity changed
+    nothing, so before trusting any further negative, establish the positive case.
+
+    The control comes from this project's own capture corpus rather than a guess. In
+    ``hybrid_2_bat_a`` a Gen1 system with two packs answered ``IR(236, 60)`` at 0x32
+    with an error response, while ``IR(60, 60)`` at the same address answered
+    normally 346 times. If the control errors here, the instrumentation works and a
+    no-reply elsewhere is a real silence. If it does not, the negatives mean nothing.
+    """
+    print(f"\nself-test on 0x{addr:02x}: can an exception response reach this script?")
+    checks = [
+        ("IR(60,60)   normally answers", 60, 60, True, OK),
+        ("IR(236,60)  recorded as error-responding", 236, 60, True, ERR),
+        ("IR(0x8000,1) far out of range", 0x8000, 1, True, None),
+        ("HR(0x486,1) the anchor under test", ANCHOR_MAPPED, 1, False, None),
+    ]
+    got: dict[str, str] = {}
+    for label, base, count, ir, expect in checks:
+        r = await probe(client, watcher, addr, base, count, input_regs=ir)
+        got[label] = r
+        flag = "" if expect is None else ("  as expected" if r == expect else f"  EXPECTED {expect}")
+        print(f"  {label:<42} {r}{flag}")
+
+    control = got["IR(236,60)  recorded as error-responding"]
+    print()
+    if control == ERR:
+        print(
+            "  Instrumentation CONFIRMED: an exception response is visible here.\n"
+            "  Every no-reply elsewhere is therefore a genuine silence, not a masked\n"
+            "  exception, and reply-vs-silence is the only oracle this stack offers."
+        )
+    elif control == OK:
+        print(
+            "  Control answered with DATA rather than erroring. The recorded error was\n"
+            "  probably transient, so this control cannot settle the question - it needs\n"
+            "  an address that reliably errors on this hardware."
+        )
+    else:
+        print(
+            "  Control was ALSO silent. Either exceptions never reach this script, or\n"
+            "  that recorded error was a one-off. Until a control does error here, no\n"
+            "  no-reply result should be read as evidence of anything."
+        )
+
+
+async def main(host: str, addrs: list[int], do_sweep: bool = False, do_selftest: bool = False) -> None:
     # Expected error responses would otherwise print over the results table.
     logging.getLogger("givenergy_modbus").propagate = False
 
@@ -287,6 +344,8 @@ async def main(host: str, addrs: list[int], do_sweep: bool = False) -> None:
             "  ABSENT       -> try other device addresses, or the battery is not on this bus.\n"
             "  INAPPLICABLE -> anchors silent; re-run with --sweep <addr> to map the served range."
         )
+        if do_selftest:
+            await selftest(client, watcher, sweepable[0] if sweepable else addrs[0])
         if do_sweep:
             if sweepable:
                 await sweep(client, watcher, sweepable[0])
@@ -301,6 +360,14 @@ if __name__ == "__main__":
     if len(sys.argv) < 2:
         print(__doc__.rstrip().rsplit("\n\n", 1)[-1], file=sys.stderr)
         raise SystemExit(2)
-    args = [a for a in sys.argv[2:] if a != "--sweep"]
+    flags = {"--sweep", "--selftest"}
+    args = [a for a in sys.argv[2:] if a not in flags]
     given = [int(a, 16) for a in args] or DEFAULT_ADDRS
-    asyncio.run(main(sys.argv[1], given, do_sweep="--sweep" in sys.argv))
+    asyncio.run(
+        main(
+            sys.argv[1],
+            given,
+            do_sweep="--sweep" in sys.argv,
+            do_selftest="--selftest" in sys.argv,
+        )
+    )


### PR DESCRIPTION
Follow-up to #417. The probe still reported `no-reply` where an exception was plausible, and the reason turned out to be a layer deeper than the previous fix addressed.

`send_request_and_await_response` logs `Received error response` only when an error response is *matched* to its waiting future. Matching is by shape hash — `(device_address, base_register, register_count)` — and observed error responses carry `register_count=0` rather than echoing the requested count. Both the `hybrid_2_bat_a` and `aio_a` captures show this. So the hashes differ, the future is never resolved, nothing is logged, and the request just times out.

Wraps `Plant.update` instead, which the network consumer calls for every decoded message before any shape matching. Errors are recorded by `(device_address, base_register)` rather than as a bare flag, because the dongle fans responses out to all connected clients and an exception provoked by GivTCP or the phone app would otherwise be misattributed to our probe.

Verified against a genuine error PDU pulled from the capture corpus (`addr=0x31 base=180 count=0`): recorded under the right key, normal responses ignored, class restored on teardown.

Refs #416

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved register probing so device errors are identified reliably and separately from request timeouts.
  * Error results are now recorded by device and register, providing clearer diagnostic output.

* **Refactor**
  * Updated probing and sweep operations to use consistent exception tracking.
  * Removed reliance on logging handlers for detecting device errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->